### PR TITLE
Allow user to specify PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 
+ifeq ($(PREFIX),)
 PREFIX = /usr/local
+endif
 
 BINS = $(wildcard bin/git-*)
 


### PR DESCRIPTION
Howdy!

git-extras is awesome! When I first installed it, it failed because /usr/local was not writable, so I tweaked the Makefile to look for PREFIX, so I could run it with PREFIX=$HOME make .

Thanks for git-extras! It rocks.

Duke
