### PR TITLE
New delete branch

### DIFF
--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 test -z $1 && echo "branch required." && exit 1
-git branch -d $1 && git branch -d -r origin/$1 && git push origin :$1
+git branch -d $1
+git branch -d -r origin/$1 && git push origin :$1


### PR DESCRIPTION
I've changed the `git-delete-branch` so it no longer fails if you don't have a local copy of the branch. And it will fail if the remote branch is not fully integrate (using `git branch -r -d`)
