### PR TITLE
A very little fix for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ MAN_PAGES = $(MANS:.md=.1)
 
 install:
 	@mkdir -p $(MANPREFIX)
+	@mkdir -p $(PREFIX)/bin
 	@echo "... installing bins to $(PREFIX)/bin"
 	@echo "... installing man pages to $(MANPREFIX)"
 	@$(foreach BIN, $(BINS), \


### PR DESCRIPTION
Tried installing git-extras via
$ PREFIX=/path/to/prefix make install
This failed because there was no directory bin/ in that folder. I made the install target create one.
