### PR TITLE
Fixed a bug in git-changelog where it wouldn't pull back the last tag

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -6,7 +6,7 @@ DATE=`date +'%Y-%m-%d'`
 HEAD="\nn.n.n / $DATE \n==================\n"
 
 if test "$1" = "--list"; then
-  version=`git tag | tail -n 1`
+  version=`git describe --tags --abbrev=0`
   if test -z "$version"; then
     git log --pretty="format:  * %s"
   else


### PR DESCRIPTION
Loving your git-extras library, BTW!

My version numbers for my project were of the format v1.0.14 (double digits for last number).

git tag (which is used in git-changelog) would return:

```
v1.0.10
v1.0.11
v1.0.12
v1.0.13
v1.0.14
v1.0.6
v1.0.7
v1.0.8
v1.0.9
```

which when you grab the top item is wrong using tail.

A more reliable way of getting the last tag is 'git describe --tags --abbrev=0'
