### PR TITLE
Fixed git-changelog tag retrieval

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -6,7 +6,8 @@ DATE=`date +'%Y-%m-%d'`
 HEAD="\nn.n.n / $DATE \n==================\n"
 
 if test "$1" = "--list"; then
-  version=`git tag | tail -n 1`
+  version=`git for-each-ref refs/tags --sort=-authordate --format='%(refname)' \
+    --count=1 | sed 's/^refs\/tags\///'`
   if test -z "$version"; then
     git log --pretty="format:  * %s"
   else


### PR DESCRIPTION
Now supports versions like `X.Y.ZZ`. Actually supports any sort of naming convention, whether they can be sorted or not.
