### PR TITLE
[HOTFIX][git-changelog] Sort by authordate ASC instead of authordate DESC to retrieve the latest 

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -6,7 +6,7 @@ DATE=`date +'%Y-%m-%d'`
 HEAD="\nn.n.n / $DATE \n==================\n"
 
 if test "$1" = "--list"; then
-  version=`git for-each-ref refs/tags --sort=-authordate --format='%(refname)' \
+  version=`git for-each-ref refs/tags --sort=authordate --format='%(refname)' \
     --count=1 | sed 's/^refs\/tags\///'`
   if test -z "$version"; then
     git log --pretty="format:  * %s"


### PR DESCRIPTION
Hi,

First, let me say that we love this project here at my company. We use it everyday.
One of the command we like is **git-changelog** that is very useful to track changes between one tag and another.

But since the last time I have upgraded my **git-extras** through Homebrew, **git-changelog** seems to retrieve my first tag instead of my last one. So my changelog contains all the commit since my first tag to my current HEAD.

I made a little fix that change the tag list order. It seems to work well.

BTW, Do you have a sample git project to test changes before releasing a new version of **git-extras** ?

Thank you.

Have a nice day.
Mathieu