### PR TITLE
Fix git-count parsing of shortlog output when --all used

### DIFF
--- a/bin/git-count
+++ b/bin/git-count
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if test "$1" = "--all"; then
+  shift 1
   git shortlog -n -s $@ | awk '{print substr($0,index($0,$2)) " (" $1 ")"}'
   echo
 fi


### PR DESCRIPTION
**Commit msg:**

Fixed parsing of shortlog output to get the counts correct and not include any extra logs lines in the output.

**Description:**
- I found that if log messages contained the sequence of characters `):` then they were included in the output of `git-count`.
- Also, I didn't dig into why, but the counts were wrong in some cases.  For example, in the git-extras repo, adding up the counts provided by `git count` came to a larger number (by 2) than the total.  When I run `git shortlog -n -s` I get the right counts.  So, I changed the command to use `-n -s` which made the counts more accurate.
- I also shifted the positional parameters so that we aren't passing `--all` to `git shortlog`.
