### PR TITLE
fixed: "git extra update" errors when pwd includes whitespace

### DIFF
--- a/bin/git-extras
+++ b/bin/git-extras
@@ -9,7 +9,7 @@ update() {
     && git clone --depth 1 http://github.com/visionmedia/git-extras.git \
     && cd git-extras \
     && make install \
-    && cd $orig \
+    && cd "$orig" \
     && echo "... updated git-extras $VERSION -> $(git extras --version)"
 }
 


### PR DESCRIPTION
```
ma:Aptana Studio 3 Workspace nulltask$ pwd
/Users/nulltask/Documents/Aptana Studio 3 Workspace
ma:Aptana Studio 3 Workspace nulltask$ git extras update
Cloning into git-extras...
remote: Counting objects: 316, done.
remote: Compressing objects: 100% (209/209), done.
remote: Total 316 (delta 175), reused 217 (delta 96)
Receiving objects: 100% (316/316), 62.67 KiB | 56 KiB/s, done.
Resolving deltas: 100% (175/175), done.
... installing bins to /usr/local/bin
... installing man pages to /usr/local/share/man/man1
... installing git-alias
... installing git-apply-branch
... installing git-back
... installing git-bug
... installing git-changelog
... installing git-commits-since
... installing git-contrib
... installing git-count
... installing git-create-branch
... installing git-delete-branch
... installing git-delete-submodule
... installing git-delete-tag
... installing git-extras
... installing git-feature
... installing git-fresh-branch
... installing git-gh-pages
... installing git-graft
... installing git-ignore
... installing git-pull-request
... installing git-refactor
... installing git-release
... installing git-repl
... installing git-setup
... installing git-summary
... installing git-touch
... installing git-undo
cp -f man/git-*.1 "/usr/local/share/man/man1"
/usr/local/bin/git-extras: line 12: cd: /Users/nulltask/Documents/Aptana: No such file or directory
ma:Aptana Studio 3 Workspace nulltask$ 
```

a little bit patch!
