### PR TITLE
add get-submodules command

### DIFF
--- a/bin/git-get-submodules
+++ b/bin/git-get-submodules
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+git submodule update --init
+git submodule foreach --recursive git submodule update --init


### PR DESCRIPTION
`get-submodules` is a simple command for cloning all the submodules, along with any submodules of their own etc.

This is something needed for almost every repo and you can't even set it up as an alias. Should be a core git command, IMHO.

As you can guess, I love the `delete-submodule` command in git-extras. :)
