### PR TITLE
Added git-promote

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,7 @@ $ brew install git-extras
  - `git feature`
  - `git refactor`
  - `git bug`
+ - `git promote`
 
 ## extras
 
@@ -418,3 +419,7 @@ Set up a git repository (if one doesn't exist), add all files, and make an initi
 ## git-touch [filename]
 
 Call `touch` on the given file, and add it to the current index. One-step creation of new files.
+
+## git-promote
+
+Promotes a local topic branch to a remote tracking branch of the same name, by pushing and then setting up the `git config`.

--- a/bin/git-promote
+++ b/bin/git-promote
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+branch=$(git symbolic-ref -q HEAD | sed -e 's|^refs/heads/||')
+
+remote_branch=$(git branch -r | grep "origin/${branch}")
+test -z "${remote_branch}" && ( git push origin "${branch}" )
+
+origin=$(git config --get "branch.${branch}.remote")
+test -z "${origin}" && ( git config --add "branch.${branch}.remote" origin )
+
+merge=$(git config --get "branch.${branch}.merge")
+test -z "${merge}" && ( git config --add "branch.${branch}.merge" "refs/heads/${branch}" )


### PR DESCRIPTION
Promotes a local topic branch to a remote tracking branch of the same name, by pushing and then setting up the git config.

Thanks to ENTP:
http://hoth.entp.com/2008/11/10/improving-my-git-workflow
