### PR TITLE
Add git-commit-message to construct commit message incrementally as you work

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,7 @@ $ brew install git-extras
  - `git refactor`
  - `git bug`
  - `git promote`
+ - `git commit-message`
 
 ## extras
 
@@ -423,3 +424,29 @@ Call `touch` on the given file, and add it to the current index. One-step creati
 ## git-promote
 
 Promotes a local topic branch to a remote tracking branch of the same name, by pushing and then setting up the `git config`.
+
+## git-commit-message
+
+Allows you to build up a commit message incrementally as you develop.
+
+Add a note to the commit message:
+
+```bash
+git commit-message add Changed function return value
+```
+
+See the notes you have written so far:
+
+```bash
+git commit-message
+Changed function return value
+Rewrote inner loop
+Added comments
+```
+
+Erase your notes:
+
+```bash
+git commit-message clear
+```
+

--- a/bin/git-commit-message
+++ b/bin/git-commit-message
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+USAGE="(add <msg> | edit | clear | show)"
+SUBDIRECTORY_OK=Sometimes
+
+. $(git --exec-path)/git-sh-setup
+require_work_tree
+
+test -z "$COMMIT_MSG" && COMMIT_MSG="$(git config core.commitmsg)"
+test -z "$COMMIT_MSG" && COMMIT_MSG="$GIT_DIR/info/next-commit-message"
+
+ACTION="$1"
+test -z "$ACTION" && ACTION="show"
+shift
+
+PREPARE_COMMIT_MSG='
+case "$2" in
+message|commit|template|"")
+    mv "$1" "$1.bak"
+    cat "'$COMMIT_MSG'" "$1.bak" > "$1"
+    rm "$1.bak"
+    ;;
+esac
+'
+
+POST_COMMIT='
+git commit-message clear
+'
+
+setup_hook() {
+	filename="$1"
+	script="$2"
+	force="$3"
+    hook_file="$GIT_DIR/hooks/$filename"
+	if [ "$force" != "" ] || [ ! -e "$hook_file" ]; then
+		echo "#!/bin/sh" > "$hook_file"
+		chmod +x "$hook_file"
+	fi
+	has_commitmsg=$(grep -s commit-message "$hook_file")
+	if [ -z "$has_commitmsg" ]; then
+		echo "$script" >> "$hook_file"
+	fi
+}
+
+init_commit_message() {
+	# set up commit msg
+	touch $COMMIT_MSG
+	# git prepare-commit-msg hook to initialize msg
+	setup_hook "prepare-commit-msg" "$PREPARE_COMMIT_MSG" $1
+	# git post commit hook to clear msg
+	setup_hook "post-commit" "$POST_COMMIT" $1
+}
+
+case $ACTION in
+help)
+	usage
+;;
+add)
+	if [ "$#" -ge 1 ]; then
+		init_commit_message
+		echo $* >> $COMMIT_MSG
+	else
+		usage
+	fi
+;;
+edit)
+	init_commit_message
+	editor="$(git var GIT_EDITOR)"
+	test -n "$editor" && $editor $COMMIT_MSG
+;;
+clear)
+	/bin/echo -n "" > $COMMIT_MSG
+;;
+show)
+	if [ -f $COMMIT_MSG ]; then
+		cat $COMMIT_MSG
+	fi
+;;
+init)
+	# The `init` action just overwrites the existing hooks.
+	# This is mainly needed when updating an existing repo
+	# to a new version of git-commit-message.
+	init_commit_message 1
+;;
+*)
+	echo "Unknown action '$ACTION' for git-commit-message"
+	usage
+esac
+

--- a/man/git-commit-message.1
+++ b/man/git-commit-message.1
@@ -1,0 +1,86 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-COMMIT\-MESSAGE" "1" "December 2011" "" "Git Extras"
+.
+.SH "NAME"
+\fBgit\-commit\-message\fR \- Builds commit message incrementally
+.
+.SH "SYNOPSIS"
+\fBgit commit\-message\fR add \fImessage\fR\|\.\|\.\|\.
+.
+.br
+\fBgit commit\-message\fR edit
+.
+.br
+\fBgit commit\-message\fR clear
+.
+.br
+\fBgit commit\-message\fR [show]
+.
+.SH "DESCRIPTION"
+\fBgit commit\-message\fR allows building a commit message incrementally during development instead of writing it all at once at the end\. When committing, the commit message will be prepopulated with all of your notes\. After committing, the commit message will be cleared to empty\.
+.
+.SH "EXAMPLES"
+Add a note to the commit message:
+.
+.IP "" 4
+.
+.nf
+
+  $ git commit\-message add Updated return value of my_function
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Edit the commit message so far:
+.
+.IP "" 4
+.
+.nf
+
+  $ git commit\-message edit
+.
+.fi
+.
+.IP "" 0
+.
+.P
+See the commit message so far:
+.
+.IP "" 4
+.
+.nf
+
+  $ git commit\-message
+  Updated return value of my_function
+  Changed the blargleflatz implementation
+  Added 6 new unit tests
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Clear the commit message: (This is done automatically after every commit\.)
+.
+.IP "" 4
+.
+.nf
+
+  $ git commit\-message clear
+.
+.fi
+.
+.IP "" 0
+.
+.SH "AUTHOR"
+Written by Russell Belfer <\fIarr2bee2@gmail\.com\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttp://github\.com/visionmedia/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttp://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-commit-message.html
+++ b/man/git-commit-message.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-commit-message(1) - Builds commit message incrementally</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-commit-message(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-commit-message(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-commit-message</code> - <span class="man-whatis">Builds commit message incrementally</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git commit-message</code> add <var>message</var>...<br />
+<code>git commit-message</code> edit<br />
+<code>git commit-message</code> clear<br />
+<code>git commit-message</code> [show]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p><strong>git commit-message</strong> allows building a commit message incrementally during
+development instead of writing it all at once at the end.  When
+committing, the commit message will be prepopulated with all of your
+notes.  After committing, the commit message will be cleared to empty.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>Add a note to the commit message:</p>
+
+<pre><code>  $ git commit-message add Updated return value of my_function
+</code></pre>
+
+<p>Edit the commit message so far:</p>
+
+<pre><code>  $ git commit-message edit
+</code></pre>
+
+<p>See the commit message so far:</p>
+
+<pre><code>  $ git commit-message
+  Updated return value of my_function
+  Changed the blargleflatz implementation
+  Added 6 new unit tests
+</code></pre>
+
+<p>Clear the commit message:  (This is done automatically after every commit.)</p>
+
+<pre><code>  $ git commit-message clear
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Russell Belfer &lt;<a href="&#x6d;&#97;&#105;&#108;&#x74;&#x6f;&#x3a;&#97;&#x72;&#x72;&#50;&#x62;&#101;&#x65;&#x32;&#x40;&#x67;&#109;&#x61;&#x69;&#108;&#x2e;&#99;&#111;&#109;" data-bare-link="true">&#97;&#114;&#x72;&#x32;&#98;&#101;&#101;&#50;&#x40;&#103;&#x6d;&#97;&#x69;&#x6c;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="http://github.com/visionmedia/git-extras/issues" data-bare-link="true">http://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="http://github.com/visionmedia/git-extras" data-bare-link="true">http://github.com/visionmedia/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>December 2011</li>
+    <li class='tr'>git-commit-message(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-commit-message.md
+++ b/man/git-commit-message.md
@@ -1,0 +1,49 @@
+git-commit-message(1) -- Builds commit message incrementally
+====================================
+
+## SYNOPSIS
+
+`git commit-message` add <message>...<br>
+`git commit-message` edit<br>
+`git commit-message` clear<br>
+`git commit-message` [show]
+
+## DESCRIPTION
+
+**git commit-message** allows building a commit message incrementally during
+development instead of writing it all at once at the end.  When
+committing, the commit message will be prepopulated with all of your
+notes.  After committing, the commit message will be cleared to empty.
+
+## EXAMPLES
+
+Add a note to the commit message:
+
+      $ git commit-message add Updated return value of my_function
+
+Edit the commit message so far:
+
+      $ git commit-message edit
+
+See the commit message so far:
+
+      $ git commit-message
+      Updated return value of my_function
+      Changed the blargleflatz implementation
+      Added 6 new unit tests
+
+Clear the commit message:  (This is done automatically after every commit.)
+
+      $ git commit-message clear
+
+## AUTHOR
+
+Written by Russell Belfer &lt;<arr2bee2@gmail.com>&gt;
+
+## REPORTING BUGS
+
+&lt;<http://github.com/visionmedia/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<http://github.com/visionmedia/git-extras>&gt;


### PR DESCRIPTION
This adds the `git commit-message` command with actions: add, edit, clear, and show (the default).  You can use it to build up a commit message while you are working, simply running:

```
git commit-message add A quick reminder
```

When you eventually do the `git commit`, the message that you have accumulated will be the seed for the commit message to be used.

Note that this sets up prepare-commit-msg and post-commit hooks for you when used so that it can inject the commit message and clear it out after the commit.
