### PR TITLE
Fixes sorting issues with annotated and lightweight tags.

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -6,7 +6,7 @@ DATE=`date +'%Y-%m-%d'`
 HEAD="\nn.n.n / $DATE \n==================\n"
 
 if test "$1" = "--list"; then
-  version=`git for-each-ref refs/tags --sort=-authordate --format='%(refname)' \
+  version=`git for-each-ref refs/tags --sort="-*authordate" --format='%(refname)' \
     --count=1 | sed 's/^refs\/tags\///'`
   if test -z "$version"; then
     git log --pretty="format:  * %s"


### PR DESCRIPTION
If you attempt to use git-changelog on a git repository with a mix of annotated an unannotated tags it missorts the tags which causes many extra commit messages to be included.

This fix resolves that, which I found mentioned in the [documentation](http://linux.die.net/man/1/git-for-each-ref).
