### PR TITLE
escape codes are not being escaped with echo

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -15,9 +15,9 @@ if test "$1" = "--list"; then
   fi
 else
   tmp="/tmp/changelog"
-  echo -e $HEAD > $tmp
+  printf $HEAD > $tmp
   git-changelog --list >> $tmp
-  echo -e '' >> $tmp
+  printf '\n' >> $tmp
   if [ -f $CHANGELOG ]; then cat $CHANGELOG >> $tmp; fi
   mv $tmp $CHANGELOG
   test -n "$EDITOR" && $EDITOR $CHANGELOG


### PR DESCRIPTION
```
\nn.n.n / 2012-03-07 \n===========\n
```

`echo` by default unless aliased to `echo -e` won't escape thus resulting in what you see above.  This should allow it to work even if if there isn't an alias.

ref: http://linux.about.com/library/cmd/blcmdl1_echo.htm
