### PR TITLE
use https in the automatic install script

### DIFF
--- a/bin/git-extras
+++ b/bin/git-extras
@@ -6,7 +6,7 @@ update() {
   local orig=$PWD
   cd /tmp \
     && rm -fr ./git-extras \
-    && git clone --depth 1 http://github.com/visionmedia/git-extras.git \
+    && git clone --depth 1 https://github.com/visionmedia/git-extras.git \
     && cd git-extras \
     && make install \
     && cd "$orig" \


### PR DESCRIPTION
The install script currently uses http to clone the repo, which fails as GitHub expects https connections. This pull request fixes it.
