### PR TITLE
Improvements to git-repl

### DIFF
--- a/bin/git-repl
+++ b/bin/git-repl
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 while true; do
   # Readline
-  read -r -p "git> " cmd
+  read -e -r -p "git> " cmd
 
   # EOF
   test $? -ne 0 && break
@@ -13,11 +13,12 @@ while true; do
   # Built-in commands
   case $cmd in
     ls) cmd=ls-files;;
+    "") continue;;
     quit) break;;
   esac
 
   # Execute
-  git $cmd
+  eval git "$cmd"
 done
 
 echo


### PR DESCRIPTION
Fixes history support by adding -e to read again, and forcing use of Bash instead of default shell. (Dash, the default non-interactive shell on Debian, doesn't work - I suspect that could be why it was removed in d666fa409a?)

Fixes support of quotes in commands (e.g. `commit -m "Commit message with 'quotes' in"`).

Doesn't show git help when pressing enter without typing a command - just shows another prompt (like Bash).
