### PR TITLE
Added displaying current branch name to git-repl(1) prompt

### DIFF
--- a/bin/git-repl
+++ b/bin/git-repl
@@ -1,8 +1,19 @@
 #!/bin/bash
 
 while true; do
+  # Current branch
+  cur=`git symbolic-ref HEAD 2> /dev/null | cut -d/ -f3-`
+
+  # Prompt
+  if [ $cur ]
+  then
+    prompt="git ($cur)> "
+  else
+    prompt="git> "
+  fi
+
   # Readline
-  read -e -r -p "git> " cmd
+  read -e -r -p "$prompt" cmd
 
   # EOF
   test $? -ne 0 && break


### PR DESCRIPTION
```
♪ git repl
git> init
Initialized empty Git repository in /Users/nulltask/test/.git/
git (master)> touch Readme.md
git (master)> add Readme.md
git (master)> commit -a
[master (root-commit) 9e4fa50] initial commit
 0 files changed
 create mode 100644 Readme.md
git (master)> branch dev
git (master)> checkout dev
Switched to branch 'dev'
git (dev)> 
```

:)
