### PR TITLE
git-local-commits: show a log of all commits not pushed to origin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,7 @@ $ brew install git-extras
  - `git refactor`
  - `git bug`
  - `git promote`
+ - `git local-commits`
 
 ## extras
 
@@ -445,3 +446,7 @@ Set up a git repository (if one doesn't exist), add all files, and make an initi
 ## git-touch [filename]
 
 Call `touch` on the given file, and add it to the current index. One-step creation of new files.
+
+## git-local-commits
+
+List all commits on the local branch that have not yet been sent to origin. Any additional arguments will be passed directly to git log.

--- a/bin/git-local-commits
+++ b/bin/git-local-commits
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+ref=$(git symbolic-ref HEAD)
+branch=${ref#refs/heads/}
+
+git log origin/${branch}..${branch} $*

--- a/man/git-local-commits.1
+++ b/man/git-local-commits.1
@@ -1,0 +1,36 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-LOCAL\-COMMITS" "1" "March 2012" "" "Git Extras"
+.
+.SH "NAME"
+\fBgit\-local\-commits\fR \- List local commits
+.
+.SH "SYNOPSIS"
+\fBgit\-local\-commits\fR <args>
+.
+.SH "DESCRIPTION"
+Lists commits in the local branch that have not been pushed to origin\.
+.
+.SH "OPTIONS"
+<args>
+.
+.P
+All arguments passed to \fBgit\-local\-commits\fR will be passed directly to \fBgit\-log\fR\.
+.
+.SH "EXAMPLES"
+.
+.nf
+
+$ git local\-commits \-\-graph
+.
+.fi
+.
+.SH "AUTHOR"
+Written by Michael Komitee <\fImkomitee@gmail\.com\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttp://github\.com/visionmedia/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttp://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-local-commits.html
+++ b/man/git-local-commits.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-local-commits(1) - List local commits</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-local-commits(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-local-commits(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-local-commits</code> - <span class="man-whatis">List local commits</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-local-commits</code> &lt;args&gt;</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>  Lists commits in the local branch that have not been pushed to origin.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  &lt;args&gt;</p>
+
+<p>  All arguments passed to <code>git-local-commits</code> will be passed directly to <code>git-log</code>.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<pre><code>$ git local-commits --graph
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Michael Komitee &lt;<a href="&#109;&#x61;&#x69;&#x6c;&#x74;&#111;&#58;&#109;&#107;&#x6f;&#x6d;&#x69;&#116;&#101;&#x65;&#x40;&#x67;&#109;&#x61;&#105;&#108;&#x2e;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#x6d;&#x6b;&#x6f;&#x6d;&#105;&#x74;&#x65;&#x65;&#64;&#103;&#109;&#97;&#105;&#x6c;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="http://github.com/visionmedia/git-extras/issues" data-bare-link="true">http://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="http://github.com/visionmedia/git-extras" data-bare-link="true">http://github.com/visionmedia/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>March 2012</li>
+    <li class='tr'>git-local-commits(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-local-commits.md
+++ b/man/git-local-commits.md
@@ -1,0 +1,32 @@
+git-local-commits(1) -- List local commits
+=======================================
+
+## SYNOPSIS
+
+`git-local-commits` &lt;args&gt;
+
+## DESCRIPTION
+
+  Lists commits in the local branch that have not been pushed to origin.
+
+## OPTIONS
+
+  &lt;args&gt;
+
+  All arguments passed to `git-local-commits` will be passed directly to `git-log`.
+
+## EXAMPLES
+
+    $ git local-commits --graph
+
+## AUTHOR
+
+Written by Michael Komitee &lt;<mkomitee@gmail.com>&gt;
+
+## REPORTING BUGS
+
+&lt;<http://github.com/visionmedia/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<http://github.com/visionmedia/git-extras>&gt;


### PR DESCRIPTION
I find this useful so that I can see what I've got locally that is pending a push to the origin remote.

All arguments are passed to git log, so you can do `git local-commits --pretty=oneline --decorate=full`, etc.
