### PR TITLE
changelog pulls tags in reverse order

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -6,7 +6,7 @@ DATE=`date +'%Y-%m-%d'`
 HEAD="\nn.n.n / $DATE \n==================\n\n"
 
 if test "$1" = "--list"; then
-  version=`git for-each-ref refs/tags --sort="-*authordate" --format='%(refname)' \
+  version=`git for-each-ref refs/tags --sort=-authordate --format='%(refname)' \
     --count=1 | sed 's/^refs\/tags\///'`
   if test -z "$version"; then
     git log --pretty="format:  * %s"


### PR DESCRIPTION
@visionmedia you can make the call on this one but two months ago you accepted a patch to get the correct order for annotated tags for use in git changelog (https://github.com/visionmedia/git-extras/commit/226f58ab6fef4b1e8ff788c84cf94bd14ab5a33f#bin/git-changelog).  that change broke the sorting for me and other collegues where I work (ubuntu/archlinux) and basically sorted in the opposite direction so git-changelog would always get us the full history from the beginning.  This patch reverts that change to @guille 's version which worked great for us.  Maybe there is a better solution.
