### PR TITLE
git-release: made `git commit` optional and added `-a -m` switches to `tag`

### DIFF
--- a/bin/git-release
+++ b/bin/git-release
@@ -11,8 +11,8 @@ hook() {
 if test $# -gt 0; then
   hook pre-release
   echo "... releasing $1"
-  git commit -a -m "Release $1" \
-    && git tag $1 \
+  git commit -a -m "Prepared release $1"
+  git tag $1 -a -m "Release $1"\
     && git push \
     && git push --tags \
     && hook post-release \


### PR DESCRIPTION
I made the `git commit` step optional and moved the `Release <version>` message to the tag. [AFAIK tags should always be annotated BTW](http://stackoverflow.com/questions/4971746/why-should-i-care-about-lightweight-vs-annotated-tags)

It's very frustrating to try to release only to fail because there's nothing to commit, so then you need to make some nonsensical change just to be able to run the command. 
And TBH, why would you EVER want to release anything that hasn't been committed already? That's just asking for trouble, or am I overlooking something important here?

And just to be clear, I absolutely love git-extras, it's made using git a lot easier. 

-- edit: toned it down
