### PR TITLE
modified changelog and added rename-tag

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -1,24 +1,30 @@
 #!/bin/sh
 
-CHANGELOG=`ls | egrep 'change|history' -i`
-if test "$CHANGELOG" = ""; then CHANGELOG='History.md'; fi
 DATE=`date +'%Y-%m-%d'`
 HEAD="\nn.n.n / $DATE \n==================\n\n"
 
-if test "$1" = "--list"; then
-  version=`git for-each-ref refs/tags --sort=-authordate --format='%(refname)' \
-    --count=1 | sed 's/^refs\/tags\///'`
-  if test -z "$version"; then
-    git log --pretty="format:  * %s"
-  else
-    git log --pretty="format:  * %s" $version..
-  fi
-else
-  tmp="/tmp/changelog"
-  printf "$HEAD" > $tmp
-  git-changelog --list >> $tmp
-  printf '\n' >> $tmp
-  if [ -f $CHANGELOG ]; then cat $CHANGELOG >> $tmp; fi
-  mv $tmp $CHANGELOG
-  test -n "$EDITOR" && $EDITOR $CHANGELOG
-fi
+case "$1" in
+  -l|--list)
+    version=`git for-each-ref refs/tags --sort=-authordate --format='%(refname)' \
+      --count=1 | sed 's/^refs\/tags\///'`
+    if test -z "$version"; then
+      git log --pretty="format:  * %s"
+    else
+      git log --pretty="format:  * %s" $version..
+    fi
+    ;;
+  *)
+    CHANGELOG=$1
+    if test "$CHANGELOG" = ""; then
+      CHANGELOG=`ls | egrep 'change|history' -i`
+      if test "$CHANGELOG" = ""; then CHANGELOG='History.md'; fi
+    fi
+    tmp="/tmp/changelog"
+    printf "$HEAD" > $tmp
+    git-changelog --list >> $tmp
+    printf '\n' >> $tmp
+    if [ -f $CHANGELOG ]; then cat $CHANGELOG >> $tmp; fi
+    mv $tmp $CHANGELOG
+    test -n "$EDITOR" && $EDITOR $CHANGELOG
+    ;;
+esac

--- a/bin/git-rename-tag
+++ b/bin/git-rename-tag
@@ -1,0 +1,10 @@
+old=$1
+new=$2
+
+test -z $old && echo "old tag name required." 1>&2 && exit 1
+test -z $new && echo "new tag name required." 1>&2 && exit 1
+
+git tag $new $old
+git tag -d $old
+git push origin $new
+git push origin :refs/tag/$old


### PR DESCRIPTION
I modified git-changelog to accept an output file as parameter:
`git changelog done.txt`
also I added `-l` as a shortcut switch for `--list`

then I created a git-rename-tag command, usage:
`git rename-tag old new`

I guess you'll have to bump the version number for this though. Is there a reason why you didn't with the last pull request??
