### PR TITLE
Add git-rebase-patch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Patches and Suggestions
 - Leila Muhtasib
 - Duane Johnson
 - Todd Wolfson
+- Niklas Fiekas

--- a/Readme.md
+++ b/Readme.md
@@ -533,3 +533,19 @@ $ git missing master
 < d14b8f0 only on current checked out branch
 > 97ef387 only on master
 ```
+
+## git-rebase-patch patch-file
+
+Given a patch that doesn't apply to the current HEAD, find the latest commit
+it applies to and do a rebase. For example:
+
+```bash
+$ git rebase-patch test.patch
+Trying to find a commit the patch applies to...
+Patch applied to dbcf408dd26 as 7dc8b23ae1a
+First, rewinding head to replay your work on top of it...
+Applying: test.patch
+Using index info to reconstruct a base tree...
+Falling back to patching base and 3-way merge...
+Auto-merging README.txt
+```

--- a/bin/git-rebase-patch
+++ b/bin/git-rebase-patch
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Warn on a dirty work tree.
+git rev-parse --verify HEAD >/dev/null || exit 1
+git update-index -q --ignore-submodules --refresh
+if ! git diff-files --quiet --ignore-submodules
+then
+        echo "WARNING (dirty work tree): The patch will only be checked against actual commits."
+fi
+
+# Warn on a dirty index.
+if ! git diff-index --cached --quiet --ignore-submodules HEAD --
+then
+        echo "WARNING (dirty index): The patch will only be checked against actual commits."
+fi
+
+# Use a temporary index.
+index="/tmp/$(basename $0).$$.tmp"
+cleanup() {
+        rm $index
+        exit 2
+}
+trap cleanup 2
+
+# Go back in history while parent commits are available.
+echo "Trying to find a commit the patch applies to..."
+rev=$(git rev-parse HEAD)
+while [ $? = 0 ]
+do
+        GIT_INDEX_FILE=$index git read-tree $rev
+
+        # Try to apply the patch.
+        GIT_INDEX_FILE=$index git apply --cached $1 >/dev/null 2>&1
+        patch_failed=$?
+
+        # Do it again, but show the error, if the problem is the patch itself.
+        if [ $patch_failed = 128 ]
+        then
+                GIT_INDEX_FILE=$index git apply --index --check $1
+                exit $patch_failed
+        fi
+
+        # The patch applied. Commit and rebase.
+        if [ $patch_failed = 0 ]
+        then
+                # Manufacture a commit.
+                tree=$(GIT_INDEX_FILE=$index git write-tree)
+                commit=$(git commit-tree $tree -p $rev -m "$1")
+                rm $index
+
+                echo "Patch applied to $(git rev-parse --short $rev) as $(git rev-parse --short $commit)"
+
+                git cherry-pick $commit
+                exit $?
+        fi
+
+        rev=$(git rev-parse --verify -q $rev^)
+done
+
+# No compatible commit found. Restore.
+echo "Failed to find a commit the patch applies to."
+rm $index
+exit 1

--- a/man/git-rebase-patch.1
+++ b/man/git-rebase-patch.1
@@ -1,0 +1,60 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-REBASE\-PATCH" "" "July 2014" "" "Git Extras"
+.
+.SH "SYNOPSIS"
+\fBgit\-rebase\-patch\fR <patch\-file>
+.
+.SH "DESCRIPTION"
+Given you have a patch that doesn\'t apply to the current HEAD, but you know it applied to some commit in the past, \fBgit\-rebase\-patch\fR will help you find that commit and do a rebase\.
+.
+.SH "OPTIONS"
+.
+.TP
+<patch\-file>
+The patch to be applied\.
+.
+.SH "EXAMPLES"
+Executing
+.
+.IP "" 4
+.
+.nf
+
+$ git rebase\-patch test\.patch
+.
+.fi
+.
+.IP "" 0
+.
+.P
+could give you something like that:
+.
+.IP "" 4
+.
+.nf
+
+Trying to find a commit the patch applies to\.\.\.
+Patch applied to dbcf408dd26 as 7dc8b23ae1a
+First, rewinding head to replay your work on top of it\.\.\.
+Applying: test\.patch
+Using index info to reconstruct a base tree\.\.\.
+Falling back to patching base and 3\-way merge\.\.\.
+Auto\-merging README\.txt
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Then your last commit has the changes of the patch and is named \fItest\.patch\fR\.
+.
+.SH "AUTHOR"
+Written by Niklas Fiekas <\fIniklas\.fiekas@tu\-clausthal\.de\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttp://github\.com/visionmedia/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttp://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-rebase-patch.html
+++ b/man/git-rebase-patch.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>&lt;git-rebase-patch&gt;(1) -- Rebases a patch</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-rebase-patch</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-rebase-patch</li>
+  </ol>
+
+  <h1><git-rebase-patch>(1) -- Rebases a patch</git-rebase-patch></h1>
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-rebase-patch</code> &lt;patch-file&gt;</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>Given you have a patch that doesn't apply to the current HEAD, but you know it
+applied to some commit in the past, <code>git-rebase-patch</code> will help you find that
+commit and do a rebase.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<dl>
+<dt>&lt;patch-file&gt;</dt><dd> The patch to be applied.</dd>
+</dl>
+
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>  Executing</p>
+
+<pre><code>$ git rebase-patch test.patch
+</code></pre>
+
+<p>  could give you something like that:</p>
+
+<pre><code>Trying to find a commit the patch applies to...
+Patch applied to dbcf408dd26 as 7dc8b23ae1a
+First, rewinding head to replay your work on top of it...
+Applying: test.patch
+Using index info to reconstruct a base tree...
+Falling back to patching base and 3-way merge...
+Auto-merging README.txt
+</code></pre>
+
+<p>  Then your last commit has the changes of the patch and is named <em>test.patch</em>.</p>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Niklas Fiekas &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#x74;&#111;&#x3a;&#110;&#x69;&#x6b;&#108;&#x61;&#115;&#x2e;&#x66;&#105;&#x65;&#107;&#x61;&#x73;&#64;&#x74;&#x75;&#x2d;&#x63;&#x6c;&#x61;&#x75;&#x73;&#116;&#x68;&#97;&#x6c;&#46;&#x64;&#x65;" data-bare-link="true">&#x6e;&#105;&#x6b;&#108;&#x61;&#115;&#x2e;&#102;&#x69;&#101;&#107;&#97;&#x73;&#x40;&#x74;&#x75;&#x2d;&#x63;&#x6c;&#97;&#117;&#115;&#x74;&#x68;&#x61;&#108;&#46;&#100;&#x65;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="http://github.com/visionmedia/git-extras/issues" data-bare-link="true">http://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="http://github.com/visionmedia/git-extras" data-bare-link="true">http://github.com/visionmedia/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>July 2014</li>
+    <li class='tr'>git-rebase-patch</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-rebase-patch.md
+++ b/man/git-rebase-patch.md
@@ -1,0 +1,47 @@
+<git-rebase-patch>(1) -- Rebases a patch
+================================
+
+## SYNOPSIS
+
+`git-rebase-patch` &lt;patch-file&gt;
+
+## DESCRIPTION
+
+Given you have a patch that doesn't apply to the current HEAD, but you know it
+applied to some commit in the past, `git-rebase-patch` will help you find that
+commit and do a rebase.
+
+## OPTIONS
+
+  * &lt;patch-file&gt;:
+     The patch to be applied.
+
+## EXAMPLES
+
+  Executing
+
+    $ git rebase-patch test.patch
+
+  could give you something like that:
+
+    Trying to find a commit the patch applies to...
+    Patch applied to dbcf408dd26 as 7dc8b23ae1a
+    First, rewinding head to replay your work on top of it...
+    Applying: test.patch
+    Using index info to reconstruct a base tree...
+    Falling back to patching base and 3-way merge...
+    Auto-merging README.txt
+
+  Then your last commit has the changes of the patch and is named *test.patch*.
+
+## AUTHOR
+
+Written by Niklas Fiekas &lt;<niklas.fiekas@tu-clausthal.de>&gt;
+
+## REPORTING BUGS
+
+&lt;<http://github.com/visionmedia/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<http://github.com/visionmedia/git-extras>&gt;


### PR DESCRIPTION
This is a script I think is worth sharing: When working with `git diff` patches (e.g. Drupal's current patch work flow) that no longer apply one has to find a commit in the past that the patch applies to - then do a rebase to reroll the patch. That can be automated by moving the index through history, trying to apply the patch.
