### PR TITLE
Uninstall bash completion from correct directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ uninstall:
 		echo "... uninstalling $(DESTDIR)$(MANPREFIX)/$(MAN)"; \
 		rm -f $(DESTDIR)$(MANPREFIX)/$(MAN); \
 	)
-	rm -f $(DESTDIR)$(PREFIX)/etc/bash_completion.d/git-extras
+	rm -f $(DESTDIR)/etc/bash_completion.d/git-extras
 
 clean: docclean
 


### PR DESCRIPTION
Target `$(DESTDIR)/etc` instead of `$(DESTDIR)$(PREFIX)/etc` to match install.

Thanks to @geoffgarside for pointing this out.
