### PR TITLE
Corrected `git extras update` where ${PREFIX} was not honored for `make install`

### DIFF
--- a/bin/git-extras
+++ b/bin/git-extras
@@ -3,9 +3,10 @@
 VERSION="1.5.1"
 
 update() {
-  local binfile=$(which git-extras 2>/dev/null)
-  local binpath=$(dirname $(dirname ${binfile} 2>/dev/null) 2>/dev/null)
+  local binfile=$(which git-extras)
+  local binpath=${binfile%/*/*}
   local orig=$PWD
+
   cd /tmp \
     && rm -fr ./git-extras \
     && git clone --depth 1 https://github.com/visionmedia/git-extras.git \


### PR DESCRIPTION
```
- query for $PREFIX given location of `git-extras` script
- prefix `make install` with ${PREFIX} -- empty is given if $PREFIX not
  set allowing makefile to continue to use it's default in that case.
```
