### PR TITLE
Require $2, so that you don't merge into master by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -367,13 +367,12 @@ Create empty local branch `name`:
 $ git fresh-branch docs
 ```
 
-## git-graft &lt;src-branch&gt; [dest-branch]
+## git-graft &lt;src-branch&gt; &lt;dest-branch&gt;
 
-Merge commits from `src-branch` into `dest-branch`. (`dest-branch` defaults to `master`.)
+Merge commits from `src-branch` into `dest-branch`.
 
 ```bash
 $ git graft new_feature dev
-$ git graft new_feature
 ```
 
 ## git-squash &lt;src-branch&gt; [msg]

--- a/bin/git-graft
+++ b/bin/git-graft
@@ -4,6 +4,7 @@ src=$1
 dst=$2
 
 test -z $src && echo "source branch required." 1>&2 && exit 1
+test -z $dst && echo "destination branch required." 1>&2 && exit 1
 
 git checkout $dst \
   && git merge --no-ff $src \

--- a/man/git-graft.1
+++ b/man/git-graft.1
@@ -1,16 +1,16 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-GRAFT" "1" "March 2011" "" "Git Extras"
+.TH "GIT\-GRAFT" "1" "June 2012" "" ""
 .
 .SH "NAME"
 \fBgit\-graft\fR \- Merge and destroy a given branch
 .
 .SH "SYNOPSIS"
-\fBgit\-graft\fR <src\-branch> [<dest\-branch>]
+\fBgit\-graft\fR <src\-branch> <dest\-branch>
 .
 .SH "DESCRIPTION"
-Merge commits from <src\-branch> into <dest\-branch> which defaults to <master>\.
+Merge commits from <src\-branch> into <dest\-branch>
 .
 .SH "OPTIONS"
 <src\-branch>
@@ -23,7 +23,6 @@ Merge commits from <src\-branch> into <dest\-branch> which defaults to <master>\
 .nf
 
 $ git graft new_feature dev
-$ git graft new_feature
 .
 .fi
 .

--- a/man/git-graft.html
+++ b/man/git-graft.html
@@ -61,11 +61,11 @@
     <a href="#AUTHOR">AUTHOR</a>
     <a href="#REPORTING-BUGS">REPORTING BUGS</a>
     <a href="#SEE-ALSO">SEE ALSO</a>
-    </div>
+  </div>
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-graft(1)</li>
-    <li class='tc'>Git Extras</li>
+    <li class='tc'></li>
     <li class='tr'>git-graft(1)</li>
   </ol>
 
@@ -76,11 +76,11 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-graft</code> &lt;src-branch&gt; [&lt;dest-branch&gt;]</p>
+<p><code>git-graft</code> &lt;src-branch&gt; &lt;dest-branch&gt;</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Merge commits from &lt;src-branch&gt; into &lt;dest-branch&gt; which defaults to &lt;master&gt;.</p>
+<p>  Merge commits from &lt;src-branch&gt; into &lt;dest-branch&gt;</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -91,12 +91,11 @@
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <pre><code>$ git graft new_feature dev
-$ git graft new_feature
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Kenneth Reitz &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#x3a;&#109;&#x65;&#x40;&#107;&#x65;&#110;&#110;&#x65;&#x74;&#x68;&#x72;&#101;&#x69;&#116;&#122;&#x2e;&#x63;&#111;&#x6d;" data-bare-link="true">&#x6d;&#x65;&#x40;&#107;&#101;&#110;&#110;&#x65;&#x74;&#104;&#114;&#101;&#105;&#x74;&#122;&#46;&#99;&#111;&#x6d;</a>&gt;</p>
+<p>Written by Kenneth Reitz &lt;<a href="&#109;&#x61;&#x69;&#108;&#x74;&#111;&#58;&#109;&#x65;&#64;&#x6b;&#x65;&#x6e;&#x6e;&#101;&#116;&#104;&#x72;&#x65;&#105;&#116;&#122;&#46;&#99;&#x6f;&#109;" data-bare-link="true">&#109;&#x65;&#x40;&#107;&#x65;&#110;&#110;&#x65;&#116;&#x68;&#x72;&#101;&#x69;&#116;&#x7a;&#x2e;&#99;&#111;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -109,7 +108,7 @@ $ git graft new_feature
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>March 2011</li>
+    <li class='tc'>June 2012</li>
     <li class='tr'>git-graft(1)</li>
   </ol>
 

--- a/man/git-graft.md
+++ b/man/git-graft.md
@@ -3,11 +3,11 @@ git-graft(1) -- Merge and destroy a given branch
 
 ## SYNOPSIS
 
-`git-graft` &lt;src-branch&gt; [&lt;dest-branch&gt;]
+`git-graft` &lt;src-branch&gt; &lt;dest-branch&gt;
 
 ## DESCRIPTION
 
-  Merge commits from &lt;src-branch&gt; into &lt;dest-branch&gt; which defaults to the current branch.
+  Merge commits from &lt;src-branch&gt; into &lt;dest-branch&gt;
 
 ## OPTIONS
 
@@ -18,7 +18,6 @@ git-graft(1) -- Merge and destroy a given branch
 ## EXAMPLES
 
     $ git graft new_feature dev
-    $ git graft new_feature
 
 ## AUTHOR
 


### PR DESCRIPTION
This is a fix for issue #23.