### PR TITLE
git-undo now includes -h | --hard option.

### DIFF
--- a/bin/git-undo
+++ b/bin/git-undo
@@ -1,13 +1,27 @@
 #!/bin/sh
 
-if test $# -eq 0; then
-  git reset --soft HEAD~1
-  git reset
+hard='no'
+digit=1
+
+parseArgs () {
+  for var in "$@"; do
+    if [ "$var" = "--hard" -o "$var" = "-h" ]; then
+      hard='yes';
+    elif `echo $var | grep -q [^[:digit:]]`; then
+      echo "You entered an invalid option. Valid options are [--hard|-h] [commitcount]." 1>&2
+      exit 1;
+    else
+      digit=$var
+      fi
+  done
+}
+
+parseArgs $@
+
+if [ "$hard" = "yes" ]; then
+  git reset --hard HEAD~$digit
 else
-  if `echo $1 | grep -q [^[:digit:]]`; then
-    echo "$1 is not a number" 1>&2
-  else
-    git reset --soft HEAD~$1
-    git reset
-  fi
+  git reset --soft HEAD~$digit
+  git reset
 fi
+

--- a/man/git-undo.1
+++ b/man/git-undo.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-UNDO" "1" "March 2011" "" "Git Extras"
+.TH "GIT\-UNDO" "1" "June 2012" "" ""
 .
 .SH "NAME"
 \fBgit\-undo\fR \- Remove latest commits
 .
 .SH "SYNOPSIS"
-\fBgit\-undo\fR [<commitcount>]
+\fBgit\-undo\fR [<commitcount>] [\-\-hard|\-h]
 .
 .SH "DESCRIPTION"
 Removes the latest commits\.
@@ -17,6 +17,12 @@ Removes the latest commits\.
 .
 .P
 Number of commits to remove\. Defaults to \fI1\fR, thus remove the latest commit\.
+.
+.P
+\-\-hard or \-h
+.
+.P
+This option wipes your commit(s), so that your changes cannot be recovered\. Use with care\.
 .
 .SH "EXAMPLES"
 Removes the latest commit\.

--- a/man/git-undo.html
+++ b/man/git-undo.html
@@ -61,11 +61,11 @@
     <a href="#AUTHOR">AUTHOR</a>
     <a href="#REPORTING-BUGS">REPORTING BUGS</a>
     <a href="#SEE-ALSO">SEE ALSO</a>
-    </div>
+  </div>
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-undo(1)</li>
-    <li class='tc'>Git Extras</li>
+    <li class='tc'></li>
     <li class='tr'>git-undo(1)</li>
   </ol>
 
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-undo</code> [&lt;commitcount&gt;]</p>
+<p><code>git-undo</code> [&lt;commitcount&gt;] [--hard|-h]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -87,6 +87,10 @@
 <p>  &lt;commitcount&gt;</p>
 
 <p>  Number of commits to remove. Defaults to <em>1</em>, thus remove the latest commit.</p>
+
+<p>  --hard or -h</p>
+
+<p>  This option wipes your commit(s), so that your changes cannot be recovered. Use with care.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -102,20 +106,20 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Kenneth Reitz &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#109;&#x65;&#64;&#107;&#x65;&#x6e;&#x6e;&#x65;&#x74;&#x68;&#x72;&#x65;&#105;&#x74;&#x7a;&#x2e;&#x63;&#111;&#x6d;" data-bare-link="true">&#x6d;&#101;&#64;&#107;&#x65;&#x6e;&#110;&#101;&#116;&#x68;&#114;&#x65;&#x69;&#116;&#x7a;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
+<p>Written by Kenneth Reitz &lt;<a data-bare-link="true" href="&#109;&#x61;&#x69;&#108;&#116;&#111;&#x3a;&#109;&#x65;&#x40;&#x6b;&#x65;&#x6e;&#x6e;&#x65;&#x74;&#104;&#x72;&#101;&#105;&#x74;&#x7a;&#x2e;&#99;&#x6f;&#109;">&#109;&#x65;&#x40;&#107;&#101;&#110;&#110;&#x65;&#116;&#104;&#x72;&#101;&#x69;&#116;&#x7a;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
-<p>&lt;<a href="http://github.com/visionmedia/git-extras/issues" data-bare-link="true">http://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+<p>&lt;<a data-bare-link="true" href="http://github.com/visionmedia/git-extras/issues">http://github.com/visionmedia/git-extras/issues</a>&gt;</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p>&lt;<a href="http://github.com/visionmedia/git-extras" data-bare-link="true">http://github.com/visionmedia/git-extras</a>&gt;</p>
+<p>&lt;<a data-bare-link="true" href="http://github.com/visionmedia/git-extras">http://github.com/visionmedia/git-extras</a>&gt;</p>
 
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>March 2011</li>
+    <li class='tc'>June 2012</li>
     <li class='tr'>git-undo(1)</li>
   </ol>
 

--- a/man/git-undo.md
+++ b/man/git-undo.md
@@ -3,7 +3,7 @@ git-undo(1) -- Remove latest commits
 
 ## SYNOPSIS
 
-`git-undo` [&lt;commitcount&gt;]
+`git-undo` [&lt;commitcount&gt;] [--hard|-h]
 
 ## DESCRIPTION
 
@@ -14,6 +14,10 @@ git-undo(1) -- Remove latest commits
   &lt;commitcount&gt;
 
   Number of commits to remove. Defaults to *1*, thus remove the latest commit.
+
+  --hard or -h
+
+  This option wipes your commit(s), so that your changes cannot be recovered. Use with care.
 
 ## EXAMPLES
 


### PR DESCRIPTION
-h option allows you to undo the last commit without keeping the
changes in the local working directory. Use with care.
Updated documentation to include new option.
