### PR TITLE
Bug/bashism in git effort

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -73,8 +73,9 @@ effort() {
     len=${#file}
     dot="."
     f_dot=$file
-    for ((i=0; i < 45-$len ;i++)); do
+    i=0 ; while test $i -lt 45-$len ; do
        f_dot=$f_dot$dot
+       i=$(($i+1))
     done
 
     printf "  \033[${color}m%s %-10d" $f_dot $commits


### PR DESCRIPTION
git-effort has #!/bin/sh on the shebang, but use a bashism in a for loop (to be correct must use bash on the shebang or use a POSIX sh standard loop)

http://mywiki.wooledge.org/Bashism
