### PR TITLE
Use git describe to fetch last tag in git-changelog

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -5,8 +5,7 @@ HEAD="\nn.n.n / $DATE \n==================\n\n"
 
 case "$1" in
   -l|--list)
-    version=`git for-each-ref refs/tags --sort=-authordate --format='%(refname)' \
-      --count=1 | sed 's/^refs\/tags\///'`
+    version=$(git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1))
     if test -z "$version"; then
       git log --pretty="format:  * %s"
     else


### PR DESCRIPTION
The current way of getting the last tag seems to be problematic to some people (#44) including myself.

git provides a nicer way to get the last tag with `git describe`. (found [here](http://stackoverflow.com/questions/1404796/how-to-get-the-latest-tag-name-in-current-branch-in-git))

The provided changes allow to fetch the last tag on all branches.
To get the one on the current branch only, this can be used instead.

``` shell
version=$(git describe --tags --abbrev=0)
```
