### PR TITLE
help ronn make hyperlinks.

### DIFF
--- a/man/git-extras.1
+++ b/man/git-extras.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-EXTRAS" "1" "June 2012" "" ""
+.TH "GIT\-EXTRAS" "1" "July 2012" "" ""
 .
 .SH "NAME"
 \fBgit\-extras\fR \- Awesome GIT utilities
@@ -12,49 +12,49 @@
 .SH "COMMANDS"
 .
 .IP "\(bu" 4
-\fBgit\-changelog\fR changelog population
+\fBgit\-changelog(1)\fR changelog population
 .
 .IP "\(bu" 4
-\fBgit\-commits\-since\fR show commit logs since some date
+\fBgit\-commits\-since(1)\fR show commit logs since some date
 .
 .IP "\(bu" 4
-\fBgit\-contrib\fR show a user\'s contribution
+\fBgit\-contrib(1)\fR show a user\'s contribution
 .
 .IP "\(bu" 4
-\fBgit\-count\fR show commit count
+\fBgit\-count(1)\fR show commit count
 .
 .IP "\(bu" 4
-\fBgit\-effort\fR show effort statistics on file(s)
+\fBgit\-effort(1)\fR show effort statistics on file(s)
 .
 .IP "\(bu" 4
-\fBgit\-fresh\-branch\fR create fresh branches
+\fBgit\-fresh\-branch(1)\fR create fresh branches
 .
 .IP "\(bu" 4
-\fBgit\-graft\fR merge and destroy a given branch
+\fBgit\-graft(1)\fR merge and destroy a given branch
 .
 .IP "\(bu" 4
-\fBgit\-ignore\fR add \.gitignore patterns
+\fBgit\-ignore(1)\fR add \.gitignore patterns
 .
 .IP "\(bu" 4
-\fBgit\-release\fR commit, tag and push changes to the repository
+\fBgit\-release(1)\fR commit, tag and push changes to the repository
 .
 .IP "\(bu" 4
-\fBgit\-setup\fR set up a git repository with initial commit
+\fBgit\-setup(1)\fR set up a git repository with initial commit
 .
 .IP "\(bu" 4
-\fBgit\-repl\fR GIT read\-eval\-print\-loop
+\fBgit\-repl(1)\fR GIT read\-eval\-print\-loop
 .
 .IP "\(bu" 4
-\fBgit\-summary\fR repository summary & contrib
+\fBgit\-summary(1)\fR repository summary & contrib
 .
 .IP "\(bu" 4
-\fBgit\-touch\fR touch and add file to the index
+\fBgit\-touch(1)\fR touch and add file to the index
 .
 .IP "\(bu" 4
-\fBgit\-undo\fR undo one or more of the latest commits
+\fBgit\-undo(1)\fR undo one or more of the latest commits
 .
 .IP "\(bu" 4
-\fBgit\-info\fR show information about the repository
+\fBgit\-info(1)\fR show information about the repository
 .
 .IP "" 0
 .

--- a/man/git-extras.html
+++ b/man/git-extras.html
@@ -79,40 +79,40 @@
 <h2 id="COMMANDS">COMMANDS</h2>
 
 <ul>
-<li> <code>git-changelog</code> changelog population</li>
-<li> <code>git-commits-since</code> show commit logs since some date</li>
-<li> <code>git-contrib</code> show a user's contribution</li>
-<li> <code>git-count</code> show commit count</li>
-<li> <code>git-effort</code> show effort statistics on file(s)</li>
-<li> <code>git-fresh-branch</code> create fresh branches</li>
-<li> <code>git-graft</code> merge and destroy a given branch</li>
-<li> <code>git-ignore</code> add .gitignore patterns</li>
-<li> <code>git-release</code> commit, tag and push changes to the repository</li>
-<li> <code>git-setup</code> set up a git repository with initial commit</li>
-<li> <code>git-repl</code> GIT read-eval-print-loop</li>
-<li> <code>git-summary</code> repository summary &amp; contrib</li>
-<li> <code>git-touch</code> touch and add file to the index</li>
-<li> <code>git-undo</code> undo one or more of the latest commits</li>
-<li> <code>git-info</code> show information about the repository</li>
+<li> <strong><a class="man-ref" href="git-changelog.html">git-changelog<span class="s">(1)</span></a></strong> changelog population</li>
+<li> <strong><a class="man-ref" href="git-commits-since.html">git-commits-since<span class="s">(1)</span></a></strong> show commit logs since some date</li>
+<li> <strong><a class="man-ref" href="git-contrib.html">git-contrib<span class="s">(1)</span></a></strong> show a user's contribution</li>
+<li> <strong><a class="man-ref" href="git-count.html">git-count<span class="s">(1)</span></a></strong> show commit count</li>
+<li> <strong><a class="man-ref" href="git-effort.html">git-effort<span class="s">(1)</span></a></strong> show effort statistics on file(s)</li>
+<li> <strong><a class="man-ref" href="git-fresh-branch.html">git-fresh-branch<span class="s">(1)</span></a></strong> create fresh branches</li>
+<li> <strong><a class="man-ref" href="git-graft.html">git-graft<span class="s">(1)</span></a></strong> merge and destroy a given branch</li>
+<li> <strong><a class="man-ref" href="git-ignore.html">git-ignore<span class="s">(1)</span></a></strong> add .gitignore patterns</li>
+<li> <strong><a class="man-ref" href="git-release.html">git-release<span class="s">(1)</span></a></strong> commit, tag and push changes to the repository</li>
+<li> <strong><a class="man-ref" href="git-setup.html">git-setup<span class="s">(1)</span></a></strong> set up a git repository with initial commit</li>
+<li> <strong><a class="man-ref" href="git-repl.html">git-repl<span class="s">(1)</span></a></strong> GIT read-eval-print-loop</li>
+<li> <strong><a class="man-ref" href="git-summary.html">git-summary<span class="s">(1)</span></a></strong> repository summary &amp; contrib</li>
+<li> <strong><a class="man-ref" href="git-touch.html">git-touch<span class="s">(1)</span></a></strong> touch and add file to the index</li>
+<li> <strong><a class="man-ref" href="git-undo.html">git-undo<span class="s">(1)</span></a></strong> undo one or more of the latest commits</li>
+<li> <strong><a class="man-ref" href="git-info.html">git-info<span class="s">(1)</span></a></strong> show information about the repository</li>
 </ul>
 
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a data-bare-link="true" href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#x3a;&#x74;&#x6a;&#x40;&#118;&#105;&#x73;&#x69;&#x6f;&#x6e;&#x2d;&#x6d;&#x65;&#x64;&#x69;&#97;&#46;&#x63;&#97;">&#x74;&#106;&#64;&#118;&#105;&#115;&#105;&#111;&#x6e;&#x2d;&#109;&#x65;&#100;&#105;&#97;&#x2e;&#99;&#x61;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#x61;&#105;&#108;&#116;&#111;&#x3a;&#116;&#x6a;&#x40;&#118;&#x69;&#x73;&#105;&#111;&#x6e;&#45;&#x6d;&#101;&#100;&#x69;&#97;&#46;&#x63;&#97;" data-bare-link="true">&#x74;&#x6a;&#64;&#x76;&#105;&#115;&#105;&#x6f;&#110;&#45;&#109;&#101;&#x64;&#105;&#97;&#46;&#99;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
-<p>&lt;<a data-bare-link="true" href="http://github.com/visionmedia/git-extras/issues">http://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+<p>&lt;<a href="http://github.com/visionmedia/git-extras/issues" data-bare-link="true">http://github.com/visionmedia/git-extras/issues</a>&gt;</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p>&lt;<a data-bare-link="true" href="http://github.com/visionmedia/git-extras">http://github.com/visionmedia/git-extras</a>&gt;</p>
+<p>&lt;<a href="http://github.com/visionmedia/git-extras" data-bare-link="true">http://github.com/visionmedia/git-extras</a>&gt;</p>
 
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>June 2012</li>
+    <li class='tc'>July 2012</li>
     <li class='tr'>git-extras(1)</li>
   </ol>
 

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -7,21 +7,21 @@ git-extras(1) -- Awesome GIT utilities
 
 ## COMMANDS
 
-   - `git-changelog` changelog population
-   - `git-commits-since` show commit logs since some date
-   - `git-contrib` show a user's contribution
-   - `git-count` show commit count
-   - `git-effort` show effort statistics on file(s)
-   - `git-fresh-branch` create fresh branches
-   - `git-graft` merge and destroy a given branch
-   - `git-ignore` add .gitignore patterns
-   - `git-release` commit, tag and push changes to the repository
-   - `git-setup` set up a git repository with initial commit
-   - `git-repl` GIT read-eval-print-loop
-   - `git-summary` repository summary & contrib
-   - `git-touch` touch and add file to the index
-   - `git-undo` undo one or more of the latest commits
-   - `git-info` show information about the repository
+   - **git-changelog(1)** changelog population
+   - **git-commits-since(1)** show commit logs since some date
+   - **git-contrib(1)** show a user's contribution
+   - **git-count(1)** show commit count
+   - **git-effort(1)** show effort statistics on file(s)
+   - **git-fresh-branch(1)** create fresh branches
+   - **git-graft(1)** merge and destroy a given branch
+   - **git-ignore(1)** add .gitignore patterns
+   - **git-release(1)** commit, tag and push changes to the repository
+   - **git-setup(1)** set up a git repository with initial commit
+   - **git-repl(1)** GIT read-eval-print-loop
+   - **git-summary(1)** repository summary & contrib
+   - **git-touch(1)** touch and add file to the index
+   - **git-undo(1)** undo one or more of the latest commits
+   - **git-info(1)** show information about the repository
 
 ## AUTHOR
 

--- a/man/index.txt
+++ b/man/index.txt
@@ -1,0 +1,17 @@
+# manuals
+git-changelog(1) git-changelog
+git-commits-since(1) git-commits-since
+git-contrib(1) git-contrib
+git-count(1) git-count
+git-effort(1) git-effort
+git-fresh-branch(1) git-fresh-branch
+git-graft(1) git-graft
+git-ignore(1) git-ignore
+git-release(1) git-release
+git-setup(1) git-setup
+git-repl(1) git-repl
+git-summary(1) git-summary
+git-touch(1) git-touch
+git-undo(1) git-undo
+git-info(1) git-info
+


### PR DESCRIPTION
With the manuals described in index.txt ronn will create hyperlinks of the (1) referenced words.

See [link indexes](http://rtomayko.github.com/ronn/ronn.1#LINK-INDEXES) from the [ronn man pages](http://rtomayko.github.com/ronn).

[git-extras.html](http://nickl-.github.com/git-extras/git-extras.html) is now browsable.
This should be true for referenced names ie. git-info(1) as defined in index.txt used  anywhere else and generated with ronn in exactly the same manner already specified

Keep in mind that backticks `` in markdown allows he block to be represented as is so this will bypass any form a markup to be generated. We opted to use the strong ** to have the markdown [git-extras.md](/nickl-/git-extras/blob/git-extras-html-hyperlinks/man/git-extras.md) look like the generated man pages which turns the code blocks to bold. Ideally ronn would've been compatible with markdown links to have the markdown source pages also generate links but unfortunately that is of course not in our scope to negotiate.

Although this is the proper way to address this crucial requirement as prescribed by ronn it does seem a little odd and for your benefit this is in a separate branch of its own so you would not feel pressed to commit because of other changes nor should this affect the decisions to commit the general fixes and improvements.

This is the highest priority fix for me, since git extras renders the manual it needs to be navigable. If not this fix then lets manually add the links to the html after it was generated by ronn, which is not ideal but better than nothing. 
