### PR TITLE
Added ignore through assume unchanged.

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -62,7 +62,7 @@ color_for() {
 
 effort() {
   for file in $@; do
-    commits=`git log --oneline $file | wc -l`
+    commits=`git log --oneline -- $file | wc -l`
     color='90'
 
     # ignore <= --above

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function show_contents {
-  test -f "$2" && echo "$1 gitignore: $2" && cat "$2"
+  test -f "$2" && echo -e "\n$1 gitignore: $2" && echo "----------------" && cat "$2"
 }
 
 function show_global {
@@ -20,6 +20,10 @@ function add_local {
   add_patterns .gitignore "$@"
 }
 
+function show_assume_unchanged {
+  git ls-files -v | grep ^[a-z] > /dev/null && echo -e "\nAssume unchanged:" && echo "-----------------" && git ls-files -v | grep ^[a-z]
+}
+
 function add_patterns {
   echo "Adding pattern(s) to: $1"
   for pattern in "${@:2}"; do
@@ -29,18 +33,25 @@ function add_patterns {
 }
 
 if test $# -eq 0; then
-   show_global
-   echo "---------------------------------"
-   show_local
+  show_global
+  show_local
+  show_assume_unchanged
 else
   case "$1" in
     -l|--local)
-      test $# -gt 1 && add_local "${@:2}" && echo
+      test $# -gt 1 && add_local "${@:2}" && echo Added the following to local gitignore: "${@:2}"
       show_local
       ;;
     -g|--global)
-      test $# -gt 1 && add_global "${@:2}" && echo
+      test $# -gt 1 && add_global "${@:2}" && echo Added the following to global gitignore: "${@:2}"
       show_global
+      ;;
+    -c|--changes)
+      test $# -gt 1 && git update-index --assume-unchanged -- "${@:2}" && echo Git now assumes the following to be unchanged: "${@:2}"
+      show_assume_unchanged
+      ;;
+    -a|--all-changes)
+      git ls-files --modified | xargs git ignore -c
       ;;
     *)
       add_local "$@"

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -47,11 +47,11 @@ _git_graft(){
 _git_ignore(){
   case "$cur" in
   --*)
-    __gitcomp "--global --local"
+    __gitcomp "--all-changes --changes --global --local"
     return
     ;;
   -*)
-    __gitcomp "--global --local -g -l"
+    __gitcomp "--all-changes --changes --global --local -a -c -g -l"
     return
     ;;
   esac

--- a/man/git-ignore.1
+++ b/man/git-ignore.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-IGNORE" "1" "July 2012" "" ""
+.TH "GIT\-IGNORE" "1" "August 2012" "" ""
 .
 .SH "NAME"
 \fBgit\-ignore\fR \- Add \.gitignore patterns
@@ -10,7 +10,15 @@
 \fBgit\-ignore\fR [<context>] [<pattern> [<pattern>]\.\.\.]
 .
 .SH "DESCRIPTION"
-Adds the given _pattern_s to a \.gitignore file if it doesn\'t already exist\.
+Instructs git to ignore files by either:
+.
+.IP "\(bu" 4
+Adding the given _pattern_s to a \.gitignore file for the supplied context, if it doesn\'t already exist; or
+.
+.IP "\(bu" 4
+Updating the index and flagging changed files as unchanged;
+.
+.IP "" 0
 .
 .SH "OPTIONS"
 <context>
@@ -25,7 +33,19 @@ Sets the context to the \.gitignore file in the current working directory\. (def
 \-g, \-\-global
 .
 .P
-Sets the context to the global gitignore file fol the current user\.
+Sets the context to the global gitignore file for the current user\.
+.
+.P
+\-c, \-\-changes
+.
+.P
+Ignore the changed files, currently being tracked, by assuming they are unchanged\. Note: <pattern> must be the path to filename(s)\.
+.
+.P
+\-a, \-\-all\-changes
+.
+.P
+Ignore all the changed files, currently being tracked, by assuming they are unchanged\. Note: <pattern> is ignored\.
 .
 .P
 <pattern>

--- a/man/git-ignore.html
+++ b/man/git-ignore.html
@@ -80,7 +80,13 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>Adds the given _pattern_s to a .gitignore file if it doesn't already exist.</p>
+<p>Instructs git to ignore files by either:</p>
+
+<ul>
+<li><p>Adding the given _pattern_s to a .gitignore file for the supplied context, if it doesn't already exist; or</p></li>
+<li><p>Updating the index and flagging changed files as unchanged;</p></li>
+</ul>
+
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -92,7 +98,15 @@
 
 <p>  -g, --global</p>
 
-<p>  Sets the context to the global gitignore file fol the current user.</p>
+<p>  Sets the context to the global gitignore file for the current user.</p>
+
+<p>  -c, --changes</p>
+
+<p>  Ignore the changed files, currently being tracked, by assuming they are unchanged. Note: &lt;pattern&gt; must be the path to filename(s).</p>
+
+<p>  -a, --all-changes</p>
+
+<p>  Ignore all the changed files, currently being tracked, by assuming they are unchanged. Note: &lt;pattern&gt; is ignored.</p>
 
 <p>  &lt;pattern&gt;</p>
 
@@ -188,8 +202,8 @@ index.tmp
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#x61;&#105;&#108;&#116;&#111;&#58;&#116;&#x6a;&#x40;&#118;&#105;&#x73;&#105;&#111;&#x6e;&#45;&#109;&#101;&#x64;&#105;&#97;&#x2e;&#99;&#97;" data-bare-link="true">&#116;&#x6a;&#64;&#x76;&#105;&#x73;&#x69;&#x6f;&#110;&#x2d;&#109;&#101;&#x64;&#105;&#x61;&#46;&#99;&#x61;</a>&gt; and Tema Bolshakov &lt;<a href="&#109;&#x61;&#x69;&#x6c;&#x74;&#x6f;&#x3a;&#116;&#119;&#x65;&#x65;&#107;&#x61;&#110;&#x65;&#x40;&#x67;&#109;&#x61;&#105;&#x6c;&#x2e;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#x74;&#x77;&#101;&#x65;&#107;&#x61;&#x6e;&#x65;&#64;&#103;&#109;&#97;&#x69;&#x6c;&#46;&#99;&#111;&#109;</a>&gt;
-and Nick Lombard &lt;<a href="&#x6d;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x67;&#x69;&#x74;&#x68;&#117;&#98;&#64;&#106;&#105;&#x67;&#115;&#x6f;&#x66;&#x74;&#x2e;&#x63;&#x6f;&#x2e;&#x7a;&#97;" data-bare-link="true">&#x67;&#x69;&#x74;&#x68;&#x75;&#x62;&#x40;&#106;&#x69;&#103;&#115;&#111;&#x66;&#x74;&#x2e;&#99;&#x6f;&#x2e;&#122;&#x61;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#105;&#108;&#116;&#x6f;&#58;&#x74;&#x6a;&#64;&#118;&#105;&#x73;&#105;&#111;&#110;&#45;&#109;&#101;&#100;&#x69;&#x61;&#46;&#x63;&#x61;" data-bare-link="true">&#116;&#106;&#64;&#x76;&#105;&#115;&#105;&#x6f;&#110;&#45;&#x6d;&#x65;&#100;&#x69;&#97;&#x2e;&#x63;&#97;</a>&gt; and Tema Bolshakov &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#x6f;&#x3a;&#116;&#119;&#101;&#101;&#x6b;&#97;&#x6e;&#101;&#64;&#103;&#109;&#97;&#105;&#x6c;&#46;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#x74;&#119;&#101;&#101;&#x6b;&#97;&#x6e;&#x65;&#x40;&#103;&#109;&#97;&#x69;&#108;&#46;&#99;&#x6f;&#109;</a>&gt;
+and Nick Lombard &lt;<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#x67;&#105;&#116;&#104;&#x75;&#x62;&#x40;&#x6a;&#x69;&#103;&#115;&#111;&#x66;&#116;&#x2e;&#x63;&#111;&#46;&#122;&#97;" data-bare-link="true">&#103;&#105;&#x74;&#104;&#117;&#x62;&#64;&#106;&#105;&#x67;&#115;&#x6f;&#x66;&#116;&#x2e;&#99;&#111;&#46;&#x7a;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -202,7 +216,7 @@ and Nick Lombard &lt;<a href="&#x6d;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x67;&#x6
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2012</li>
+    <li class='tc'>August 2012</li>
     <li class='tr'>git-ignore(1)</li>
   </ol>
 

--- a/man/git-ignore.md
+++ b/man/git-ignore.md
@@ -7,7 +7,11 @@ git-ignore(1) -- Add .gitignore patterns
 
 ## DESCRIPTION
 
-Adds the given _pattern_s to a .gitignore file if it doesn't already exist.
+Instructs git to ignore files by either:
+
+ * Adding the given _pattern_s to a .gitignore file for the supplied context, if it doesn't already exist; or
+
+ * Updating the index and flagging changed files as unchanged;
 
 ## OPTIONS
 
@@ -19,7 +23,15 @@ Adds the given _pattern_s to a .gitignore file if it doesn't already exist.
 
   -g, --global
 
-  Sets the context to the global gitignore file fol the current user.
+  Sets the context to the global gitignore file for the current user.
+
+  -c, --changes
+
+  Ignore the changed files, currently being tracked, by assuming they are unchanged. Note: &lt;pattern&gt; must be the path to filename(s).
+
+  -a, --all-changes
+
+  Ignore all the changed files, currently being tracked, by assuming they are unchanged. Note: &lt;pattern&gt; is ignored.
 
   &lt;pattern&gt;
 


### PR DESCRIPTION
As it turns out we have yet another scenario for wanting git to ignore something i.e when we made changes to a file that is already being tracked ex. database configuration for a local db, and we don't want git to report or accidentally add the changes to a commit we use: 

```
$ git update-index --assume-unchanged
```

Added to git-ignore for completion...

When git is already tracking a file adding it to gitignore wont do anything but you can flag it assume-unchanged through update-index.
Added -c, --changes attribute to ignore space delimited list of files.
Added -a, --all-changes to flag all the currently tracked files that have been modified to be assumed unchanged.
Better verbosity and better output current configurations.
Added output list of currently configured assume-unchanged files.
Updated documentation and fixed a typo.

Njoy! =)
