### PR TITLE
Introduce 'dry-merge' command

### DIFF
--- a/bin/dry-merge
+++ b/bin/dry-merge
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+git merge --no-commit --no-ff $1
+git merge --abort

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -28,6 +28,10 @@ _git_delete_tag(){
   __gitcomp "$(__git_tags)"
 }
 
+_git_dry_merge(){
+  __gitcomp "$(__git_heads)"
+}
+
 _git_extras(){
   __gitcomp "--version update"
 }

--- a/man/dry-merge.1
+++ b/man/dry-merge.1
@@ -1,0 +1,39 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-DRY\-MERGE" "1" "October 2012" "" ""
+.
+.SH "NAME"
+\fBgit\-dry\-merge\fR \- dry run a merge
+.
+.SH "SYNOPSIS"
+\fBgit\-dry\-merge\fR <branchname>
+.
+.SH "DESCRIPTION"
+If an automatic merge would be successful it prints changes that would be made by merging <branchname> into the current branch\. If an automatic merge wouldn\'t be successful it prints the first file which needs a manual merge\.
+.
+.SH "OPTIONS"
+<branchname>
+.
+.P
+The name of the branch to merge into the current branch\.
+.
+.SH "EXAMPLES"
+.
+.nf
+
+$ git dry\-merge master
+.
+.fi
+.
+.SH "AUTHOR"
+Written by Willi Müller <\fIwilli@jups42\.de\fR>
+.
+.P
+Inspired by mipaldi\'s answer on stackoverflow (see: http://stackoverflow\.com/questions/501407/)\.
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/visionmedia/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/visionmedia/git\-extras\fR>

--- a/man/dry-merge.html
+++ b/man/dry-merge.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-dry-merge(1) - dry run a merge</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-dry-merge(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-dry-merge(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-dry-merge</code> - <span class="man-whatis">dry run a merge</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-dry-merge</code> &lt;branchname&gt;</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>If an automatic merge would be successful it prints changes that would be made by merging &lt;branchname&gt; into the current branch.
+If an automatic merge wouldn't be successful it prints the first file which
+needs a manual merge.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>&lt;branchname&gt;</p>
+
+<p>The name of the branch to merge into the current branch.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<pre><code>$ git dry-merge master
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Willi Müller &lt;<a href="&#x6d;&#97;&#105;&#x6c;&#116;&#x6f;&#x3a;&#x77;&#x69;&#x6c;&#x6c;&#105;&#x40;&#x6a;&#x75;&#112;&#115;&#x34;&#x32;&#46;&#x64;&#x65;" data-bare-link="true">&#x77;&#105;&#108;&#x6c;&#x69;&#64;&#106;&#117;&#112;&#x73;&#x34;&#x32;&#x2e;&#x64;&#101;</a>&gt;</p>
+
+<p>Inspired by mipaldi's answer on stackoverflow (see: http://stackoverflow.com/questions/501407/).</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/visionmedia/git-extras/issues" data-bare-link="true">https://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/visionmedia/git-extras" data-bare-link="true">https://github.com/visionmedia/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>October 2012</li>
+    <li class='tr'>git-dry-merge(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/dry-merge.md
+++ b/man/dry-merge.md
@@ -1,0 +1,36 @@
+git-dry-merge(1) -- dry run a merge
+================================
+
+## SYNOPSIS
+
+`git-dry-merge` &lt;branchname&gt;
+
+## DESCRIPTION
+
+If an automatic merge would be successful it prints changes that would be made by merging &lt;branchname&gt; into the current branch.
+If an automatic merge wouldn't be successful it prints the first file which
+needs a manual merge.
+
+## OPTIONS
+
+&lt;branchname&gt;
+
+The name of the branch to merge into the current branch.
+
+## EXAMPLES
+
+	$ git dry-merge master
+
+## AUTHOR
+
+Written by Willi Müller &lt;<willi@jups42.de>&gt;
+
+Inspired by mipaldi's answer on stackoverflow (see: http://stackoverflow.com/questions/501407/).
+
+## REPORTING BUGS
+
+&lt;<https://github.com/visionmedia/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/visionmedia/git-extras>&gt;


### PR DESCRIPTION
I would appreciate a command to check if a merge can be performed automatically or which files need manual merging. In this pull request I already implemented a simple version of it.
### Proposal:

`git dry-merge <branchname>` prints which files can be automatically merged and which files need a manual merge.
### Current Implementation

It currently just runs

```
git merge --no-commit --no-ff $1
git merge --abort # to unstage automatically merged files
```
### Future Work

It should check the result of `git merge --no-commit --no-ff $1`. If it states 'Already up-to-date' it exits and prints no 'fatal: There is no merge to abort (MERGE_HEAD missing)'.
In addition it should not stop at the first 'error: Your local changes to the following files would be overwritten by merge'  and just print one file that would be overwritten but ALL the files that would be overwritten.

What is your opinion about it?

---

Note: I was inspired by: http://stackoverflow.com/questions/501407/
