### PR TITLE
Fix broken URL from Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ $ curl https://raw.github.com/visionmedia/git-extras/master/bin/git-extras | INS
 $ sudo port install git-extras
 ```
 
-[Brew](github.com/mxcl/homebrew/) (buggy):
+[Brew](http://github.com/mxcl/homebrew/) (buggy):
 
 ```bash
 $ brew install git-extras


### PR DESCRIPTION
Link to Homebrew repository was broken
because it did not have `https://` in the beginning.
