### PR TITLE
git review should support git diff's output options

### DIFF
--- a/bin/git-review
+++ b/bin/git-review
@@ -1,6 +1,26 @@
 #!/bin/sh
 
-branch=${1:-`git rev-parse --abbrev-ref HEAD`}
-master=${2:-master}
+is_diff_arg() {
+  if [ -n "$(echo $1 | grep ^- --color=never)" ]; then
+    return 0
+  else
+    return 1
+  fi   
+}
 
-git diff --name-status `git merge-base $branch $master`..$branch
+branch=$1
+master=$2
+
+if is_diff_arg $branch || [ -z "$branch" ]; then
+  branch=`git rev-parse --abbrev-ref HEAD`
+else
+  shift 1
+fi
+
+if is_diff_arg $master || [ -z "$master" ]; then
+  master="master"
+else
+  shift 1
+fi
+
+git diff $@ `git merge-base $branch $master`..$branch

--- a/man/git-review.1
+++ b/man/git-review.1
@@ -7,7 +7,7 @@
 \fBgit\-review\fR \- Review files changed since branch was created
 .
 .SH "SYNOPSIS"
-\fBgit\-review\fR [<branchname>] [<master>]
+\fBgit\-review\fR [<branchname>] [<master>] [<diffargs>]
 .
 .SH "DESCRIPTION"
 Shows all the file changes thave have happened since a a branch was created from it\'s master (parent) branch\. This can be useful for code reviews when you don\'t want to see the changes that have happened in master since the branching took place\.
@@ -23,6 +23,12 @@ The branch to compare with the <master branch>\. Defaults to the current branch\
 .
 .P
 The branch that the <branchname> was originally branched from\. Defaults to master\.
+.
+.P
+<diffargs>
+.
+.P
+Any options that can be passed into "git diff" can be used here\. For example to show a diff stat use the argument "\-\-stat"\. The arguments must appear after <branchname> and <master> though\.
 .
 .SH "EXAMPLES"
 Show changes in current branch since it was branched from master
@@ -58,6 +64,45 @@ Show changes in hotfix1\.1 branch since it was branched from v1\.0
 .nf
 
 $ git review hotfix1\.1 v1\.0
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Show changes but show as a diff stat
+.
+.IP "" 4
+.
+.nf
+
+$ git review \-\-stat
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Show changes but with only the file names
+.
+.IP "" 4
+.
+.nf
+
+$ git review \-\-name\-only
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Show changes but with only the file names and status
+.
+.IP "" 4
+.
+.nf
+
+$ git review \-\-name\-status
 .
 .fi
 .

--- a/man/git-review.1.html
+++ b/man/git-review.1.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-review</code> [&lt;branchname&gt;] [&lt;master&gt;]</p>
+<p><code>git-review</code> [&lt;branchname&gt;] [&lt;master&gt;] [&lt;diffargs&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -97,6 +97,12 @@ branching took place.</p>
 <p>  The branch that the &lt;branchname&gt; was originally branched
   from. Defaults to master.</p>
 
+<p>  &lt;diffargs&gt;</p>
+
+<p>  Any options that can be passed into "git diff" can be used here. For
+  example to show a diff stat use the argument "--stat". The arguments must
+  appear after &lt;branchname&gt; and &lt;master&gt; though.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <p>Show changes in current branch since it was branched from master</p>
@@ -114,9 +120,24 @@ branching took place.</p>
 <pre><code>$ git review hotfix1.1 v1.0
 </code></pre>
 
+<p>Show changes but show as a diff stat</p>
+
+<pre><code>$ git review --stat
+</code></pre>
+
+<p>Show changes but with only the file names</p>
+
+<pre><code>$ git review --name-only
+</code></pre>
+
+<p>Show changes but with only the file names and status</p>
+
+<pre><code>$ git review --name-status
+</code></pre>
+
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Craig MacGregor &lt;<a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#58;&#99;&#x72;&#97;&#x69;&#x67;&#101;&#x72;&#109;&#x40;&#x67;&#x6d;&#97;&#x69;&#108;&#46;&#x63;&#x6f;&#109;" data-bare-link="true">&#99;&#114;&#97;&#x69;&#x67;&#x65;&#x72;&#109;&#x40;&#103;&#x6d;&#97;&#x69;&#x6c;&#x2e;&#x63;&#111;&#109;</a>&gt;</p>
+<p>Written by Craig MacGregor &lt;<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#x3a;&#x63;&#114;&#97;&#x69;&#x67;&#101;&#114;&#x6d;&#64;&#x67;&#109;&#x61;&#105;&#x6c;&#x2e;&#x63;&#111;&#x6d;" data-bare-link="true">&#99;&#114;&#97;&#105;&#103;&#x65;&#114;&#109;&#64;&#103;&#109;&#97;&#x69;&#x6c;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-review.md
+++ b/man/git-review.md
@@ -2,8 +2,7 @@ git-review(1) -- Review files changed since branch was created
 ==============================================================
 
 ## SYNOPSIS
-
-`git-review` [&lt;branchname&gt;] [&lt;master&gt;]
+`git-review` [&lt;branchname&gt;] [&lt;master&gt;] [&lt;diffargs&gt;] 
 
 ## DESCRIPTION
 Shows all the file changes thave have happened since a a branch was
@@ -23,6 +22,12 @@ branching took place.
   The branch that the &lt;branchname&gt; was originally branched
   from. Defaults to master.
 
+  &lt;diffargs&gt;
+
+  Any options that can be passed into "git diff" can be used here. For
+  example to show a diff stat use the argument "--stat". The arguments must
+  appear after &lt;branchname&gt; and &lt;master&gt; though.
+
 ## EXAMPLES
   
 Show changes in current branch since it was branched from master
@@ -33,6 +38,15 @@ Show changes in test branch since it was branched from master
 
 Show changes in hotfix1.1 branch since it was branched from v1.0
     $ git review hotfix1.1 v1.0
+
+Show changes but show as a diff stat
+    $ git review --stat
+
+Show changes but with only the file names
+    $ git review --name-only
+
+Show changes but with only the file names and status
+    $ git review --name-status
 
 ## AUTHOR
   


### PR DESCRIPTION
I've changed git review to allow all the cool output options from git diff.

For example you can now do:

`git review --stat`
