### PR TITLE
Add remote parameter to git-release

### DIFF
--- a/bin/git-release
+++ b/bin/git-release
@@ -13,8 +13,8 @@ if test $# -gt 0; then
   echo "... releasing $1"
   git commit -a -m "Release $1"
   git tag $1 -a -m "Release $1" \
-    && git push \
-    && git push --tags \
+    && git push $2 \
+    && git push $2 --tags \
     && hook post-release \
     && echo "... complete"
 else

--- a/man/git-release.1
+++ b/man/git-release.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
-.\" https://github.com/rtomayko/ronn/tree/0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-RELEASE" "1" "July 2012" "" ""
+.TH "GIT\-RELEASE" "1" "October 2012" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-release\fR \- Commit, tag and push changes to the repository
 .
 .SH "SYNOPSIS"
-\fBgit\-release\fR <tagname>
+\fBgit\-release\fR <tagname> [<remote>]
 .
 .SH "DESCRIPTION"
 Commits changes with message "Release <tagname>", tags with the given <tagname> and pushes the branch / tags\.
@@ -15,16 +15,28 @@ Commits changes with message "Release <tagname>", tags with the given <tagname> 
 .SH "OPTIONS"
 <tagname>
 .
+.P
+The name of the newly created tag\. Also used in tag comment\.
+.
+.P
+<remote>
+.
+.P
+The "remote" repository that is destination of a push operation: it is passed to git push\.
+.
 .SH "EXAMPLES"
+.
+.IP "\(bu" 4
 Release commit with the given <tagname>\.
 .
-.IP "" 4
-.
-.nf
-
+.IP
 $ git release 0\.1\.0
 .
-.fi
+.IP "\(bu" 4
+Release commit with the given <tagname> and push to specific remote\.
+.
+.IP
+$ git release 0\.1\.0 github
 .
 .IP "" 0
 .
@@ -32,7 +44,7 @@ $ git release 0\.1\.0
 Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>
 .
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/visionmedia/git\-extras/issues\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras/issues\fR>
 .
 .SH "SEE ALSO"
-<\fIhttp://github\.com/visionmedia/git\-extras\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-release.html
+++ b/man/git-release.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (https://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
   <title>git-release(1) - Commit, tag and push changes to the repository</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -65,7 +65,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-release(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-release(1)</li>
   </ol>
 
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-release</code> &lt;tagname&gt;</p>
+<p><code>git-release</code> &lt;tagname&gt; [&lt;remote&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -86,16 +86,27 @@
 
 <p>  &lt;tagname&gt;</p>
 
+<p>  The name of the newly created tag. Also used in tag comment.</p>
+
+<p>  &lt;remote&gt;</p>
+
+<p>  The "remote" repository that is destination of a push operation: it is passed to git push.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p>  Release commit with the given &lt;tagname&gt;.</p>
+<ul>
+<li><p>Release commit with the given &lt;tagname&gt;.</p>
 
-<pre><code>$ git release 0.1.0
-</code></pre>
+<p>$ git release 0.1.0</p></li>
+<li><p>Release commit with the given &lt;tagname&gt; and push to specific remote.</p>
+
+<p>$ git release 0.1.0 github</p></li>
+</ul>
+
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#x3a;&#x74;&#106;&#x40;&#118;&#x69;&#115;&#105;&#x6f;&#x6e;&#x2d;&#x6d;&#x65;&#100;&#x69;&#97;&#46;&#x63;&#97;" data-bare-link="true">&#x74;&#x6a;&#x40;&#x76;&#105;&#115;&#105;&#x6f;&#110;&#45;&#109;&#101;&#100;&#x69;&#97;&#x2e;&#x63;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#x3a;&#x74;&#x6a;&#x40;&#118;&#x69;&#x73;&#x69;&#x6f;&#x6e;&#45;&#x6d;&#101;&#x64;&#x69;&#x61;&#46;&#x63;&#97;" data-bare-link="true">&#116;&#106;&#64;&#118;&#x69;&#115;&#105;&#x6f;&#110;&#45;&#109;&#x65;&#x64;&#x69;&#97;&#x2e;&#99;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -108,7 +119,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2012</li>
+    <li class='tc'>October 2012</li>
     <li class='tr'>git-release(1)</li>
   </ol>
 

--- a/man/git-release.md
+++ b/man/git-release.md
@@ -3,7 +3,7 @@ git-release(1) -- Commit, tag and push changes to the repository
 
 ## SYNOPSIS
 
-`git-release` &lt;tagname&gt;
+`git-release` &lt;tagname&gt; [&lt;remote&gt;]
 
 ## DESCRIPTION
 
@@ -13,11 +13,21 @@ git-release(1) -- Commit, tag and push changes to the repository
 
   &lt;tagname&gt;
 
+  The name of the newly created tag. Also used in tag comment.
+
+  &lt;remote&gt;
+
+  The "remote" repository that is destination of a push operation: it is passed to git push.
+
 ## EXAMPLES
 
-  Release commit with the given &lt;tagname&gt;.
-	
+  * Release commit with the given &lt;tagname&gt;.
+
     $ git release 0.1.0
+
+  * Release commit with the given &lt;tagname&gt; and push to specific remote.
+
+    $ git release 0.1.0 github
 
 ## AUTHOR
 


### PR DESCRIPTION
When present `remote` parameter is passed to `git push`
It makes `git-release` usable even when you have non-standard remotes configured.
When `remote` is not specified, `git-release` pushes to default remote, just like it did before this change.
