### PR TITLE
conventionally default make target is all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MANS = $(wildcard man/git-*.md)
 MAN_HTML = $(MANS:.md=.html)
 MAN_PAGES = $(MANS:.md=.1)
 
+all:
 install:
 	@mkdir -p $(DESTDIR)$(MANPREFIX)
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
when the user types

``` shell
$ make
```

and then gets the behaviour of

``` shell
$ make install
```

it is, to put it mildly, surprising. :)
