### PR TITLE
Update bin/git-count

### DIFF
--- a/bin/git-count
+++ b/bin/git-count
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if test "$1" = "--all"; then
-  git shortlog -n $@ | grep "):$" | sed 's|:||'
+  git shortlog -n -s $@ | awk '{print substr($0,index($0,$2)) " (" $1 ")"}'
   echo
 fi
 


### PR DESCRIPTION
Matching "):" in the end can match commit subjects by mistake i.e. if
commit subject ends with "):" too (e.g. linux project has one such
commit).

To avoid this and any similar problems print summary only (-s).
Restructure output to look exactly as it was before with awk.
