### PR TITLE
Delete tag on origin even if it wasn't locally fetched yet.

### DIFF
--- a/bin/git-delete-tag
+++ b/bin/git-delete-tag
@@ -2,4 +2,5 @@
 
 tagname=$1
 test -z $tagname && echo "tag required." 1>&2 && exit 1
-git tag -d $tagname && git push origin :refs/tags/$tagname
+git tag -d $tagname
+git push origin :refs/tags/$tagname


### PR DESCRIPTION
This should keep consistent logic among scripts i.e. git-delete-tag
should behave the same way as git-delete-branch.
