### PR TITLE
support PortableGit(msysgit)

### DIFF
--- a/Makefile.msys
+++ b/Makefile.msys
@@ -1,0 +1,30 @@
+MANPREFIX ?= /doc/git/html
+BINS = $(wildcard bin/git-*)
+MANS = $(wildcard man/git-*.md)
+MAN_HTML = $(MANS:.md=.html)
+
+install:
+	@mkdir -p $(DESTDIR)$(MANPREFIX)
+	@mkdir -p $(DESTDIR)/bin
+	@echo "... installing bins to $(DESTDIR)/bin"
+	@echo "... installing man pages to $(DESTDIR)$(MANPREFIX)"
+	@$(foreach BIN, $(BINS), \
+		echo "... installing `basename $(BIN)`"; \
+		cp -f $(BIN) $(DESTDIR)/$(BIN); \
+	)
+	cp -f man/git-*.html $(DESTDIR)$(MANPREFIX)
+	@mkdir -p $(DESTDIR)/etc/bash_completion.d
+	cp -f etc/bash_completion.sh $(DESTDIR)/etc/bash_completion.d/git-extras
+
+uninstall:
+	@$(foreach BIN, $(BINS), \
+		echo "... uninstalling $(DESTDIR)/$(BIN)"; \
+		rm -f $(DESTDIR)/$(BIN); \
+	)
+	@$(foreach MAN, $(MAN_HTML), \
+		echo "... uninstalling $(DESTDIR)$(MANPREFIX)/`basename $(MAN)`"; \
+		rm -f "$(DESTDIR)$(MANPREFIX)/`basename $(MAN)`"; \
+	)
+	rm -f $(DESTDIR)/etc/bash_completion.d/git-extras
+
+.PHONY: install uninstall

--- a/bin/git-alias
+++ b/bin/git-alias
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 case $# in
-  0) git config --get-regexp 'alias.*' | colrm 1 6 | sed 's/[ ]/ = /' | sort ;;
+  0) git config --get-regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort ;;
   1) git alias | grep -e "$1" ;;
   *) git config --global "alias.$1" "$2" ;;
 esac

--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -23,7 +23,7 @@ case "$1" in
     git-changelog --list >> $tmp
     printf '\n' >> $tmp
     if [ -f $CHANGELOG ]; then cat $CHANGELOG >> $tmp; fi
-    mv $tmp $CHANGELOG
+    cp $tmp $CHANGELOG
     test -n "$EDITOR" && $EDITOR $CHANGELOG
     ;;
 esac

--- a/bin/git-extras
+++ b/bin/git-extras
@@ -25,6 +25,6 @@ case "$1" in
     ;;
   *)
     test "$INSTALL" = "y" && update && exit
-    man git-extras
+    git extras --help
     ;;
 esac

--- a/bin/git-info
+++ b/bin/git-info
@@ -22,19 +22,19 @@ remote_urls() {
 
 # Show info similar to svn
 
-echo
-echo "## Remote URLs:\n"
-echo "$(remote_urls)\n"
+printf "\n"
+printf "## Remote URLs:\n\n"
+printf "%s\n\n" "$(remote_urls)"
 
-echo "## Remote Branches:\n"
-echo "$(remote_branches)\n"
+printf "## Remote Branches:\n\n"
+printf "%s\n\n" "$(remote_branches)"
 
-echo "## Local Branches:\n"
-echo "$(local_branches)\n"
+printf "## Local Branches:\n\n"
+printf "%s\n\n" "$(local_branches)"
 
-echo "## Most Recent Commit:\n"
-echo "$(most_recent_commit)\n"
-echo "Type 'git log' for more commits, or 'git show <commit id>' for full commit details.\n"
+printf "## Most Recent Commit:\n\n"
+printf "%s\n\n" "$(most_recent_commit)"
+printf "Type 'git log' for more commits, or 'git show <commit id>' for full commit details.\n\n"
 
-echo "## Configuration (.git/config):\n"
-echo "$(get_config)\n"
+printf "## Configuration (.git/config):\n\n"
+printf "%s\n\n" "$(get_config)"


### PR DESCRIPTION
fix below.

* git-extras

```
$ git extras
C:\PortableGit\bin\git-extras: line 28: man: command not found
fatal: 'extras' appears to be a git command, but we were not
able to execute it. Maybe git-extras is broken?
```

* git-changelog

```
$ git changelog
mv: cannot move `/tmp/changelog' to `History.md'
```

* git-info

```
$ git info

## Remote URLs:\n
origin  git@github.com:southly/git-extras.git (fetch)
origin  git@github.com:southly/git-extras.git (push)\n
## Remote Branches:\n
:
:
```

* git-alias

```
$ git alias
C:\PortableGit\bin\git-alias: line 4: colrm: command not found
```
