### PR TITLE
fix delete-branch to work with same-name tags

### DIFF
--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -4,4 +4,4 @@ branch=$1
 test -z $branch && echo "branch required." 1>&2 && exit 1
 git branch -D $branch
 git branch -d -r origin/$branch
-git push origin :$branch
+git push origin :refs/heads/$branch


### PR DESCRIPTION
when there's a tag and a branch with the same name, git errors out with

`error: dst refspec MY_BRANCH matches more than one.`

git-delete-tag is not affected by this bug
