### PR TITLE
Option to omit config on git-info

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -385,6 +385,12 @@ $ git info
 
 ```
 
+If you wish to omit the config section, you may use `--no-config`:
+
+```bash
+$ git info --no-config
+```
+
 ## git-create-branch &lt;name&gt;
 
 Create local and remote branch `name`:

--- a/bin/git-info
+++ b/bin/git-info
@@ -36,5 +36,7 @@ echo "## Most Recent Commit:\n"
 echo "$(most_recent_commit)\n"
 echo "Type 'git log' for more commits, or 'git show <commit id>' for full commit details.\n"
 
-echo "## Configuration (.git/config):\n"
-echo "$(get_config)\n"
+if test "$1" != "--no-config"; then
+  echo "## Configuration (.git/config):\n"
+  echo "$(get_config)\n"
+fi


### PR DESCRIPTION
I added an option to allow git-info to omit the config section.

In my case, I am working with quite a huge config (aliases, multiple diff and merge tools) and usually need to scroll way up to get to the content that i am looking for (being remotes, remote branches and the local branches).
