### PR TITLE
git-repl improvements

### DIFF
--- a/bin/git-repl
+++ b/bin/git-repl
@@ -29,6 +29,8 @@ while true; do
 
   if [[ $cmd == !*  ]]; then
     eval ${cmd:1} 
+  elif [[ $cmd == git* ]]; then
+    eval $cmd
   else
     eval git "$cmd"
   fi


### PR DESCRIPTION
Two improvements:
- `!pwd` directly executes `pwd` (git alias / Vim like syntax)
- `git status` used to throw an error in the repl, now it just executes `git status` directly.
