### PR TITLE
removed unnecessary git checkout for bug, feature and refactor

### DIFF
--- a/bin/git-bug
+++ b/bin/git-bug
@@ -8,5 +8,4 @@ else
   test -z $1 && echo "bug <name> required." && exit 1
   branch=bug/$1
   git checkout -b $branch &> /dev/null
-  git checkout $branch &> /dev/null
 fi

--- a/bin/git-feature
+++ b/bin/git-feature
@@ -8,5 +8,4 @@ else
   test -z $1 && echo "feature <name> required." 1>&2 && exit 1
   branch=feature/$1
   git checkout -b $branch &> /dev/null
-  git checkout $branch &> /dev/null
 fi

--- a/bin/git-refactor
+++ b/bin/git-refactor
@@ -8,5 +8,4 @@ else
   test -z $1 && echo "refactor <name> required." 1>&2 && exit 1
   branch=refactor/$1
   git checkout -b $branch &> /dev/null
-  git checkout $branch &> /dev/null
 fi


### PR DESCRIPTION
In ubuntu, when I run git bug|feature|refactor I get this error:

```
error: pathspec 'bug/test' did not match any file(s) known to git.
fatal: Unable to create '/var/www/leanin/.git/index.lock': File exists.

If no other git process is currently running, this probably means a
git process crashed in this repository earlier. Make sure no other git
process is running and remove the file manually to continue.
```

`git checkout -b [branch]` automatically puts you in that branch, so I removed that line and it works in ubuntu now.
