### PR TITLE
Added git-upstream to easily add upstream repository

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,7 @@ $ brew install git-extras
  - `git bug`
  - `git promote`
  - `git local-commits`
+ - `git upstream`
 
 ## git-extras
 
@@ -524,3 +525,11 @@ git obliterate secrets.json
 ## git-local-commits
 
 List all commits on the local branch that have not yet been sent to origin. Any additional arguments will be passed directly to git log.
+
+## git-upstream &lt;url&gt;
+
+Sets an upstream url, useful when forking repositories and want to set a remote upstream repository.
+
+```bash
+$ git upstream git://github.com/visionmedia/git-extras.git
+```

--- a/bin/git-upstream
+++ b/bin/git-upstream
@@ -1,0 +1,16 @@
+#/bin/sh
+
+upstream="$1"
+
+test -z $upstream  && echo "upstream url required" 1>&2 && exit 1
+
+git remote add upstream $upstream &> /dev/null
+
+if [ $? -ne 0 ]; then
+    read -p "Do you want to overwrite current upstream repository `git config --get remote.upstream.url` ? [yN]: " overwrite
+    if [ "$overwrite" == "y" ]; then
+        git config remote.upstream.url $upstream
+    fi
+fi
+echo "Remote upstream repository set to `git config --get remote.upstream.url`"
+

--- a/man/git-upstream.1
+++ b/man/git-upstream.1
@@ -1,0 +1,31 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-UPSTREAM" "1" "May 2013" "" ""
+.
+.SH "NAME"
+\fBgit\-upstream\fR \- Add/update remote upstream repository
+.
+.SH "SYNOPSIS"
+\fBgit\-upstream\fR <url>
+.
+.SH "DESCRIPTION"
+Adds or updates the remote upstream url\.
+.
+.SH "OPTIONS"
+<url>
+.
+.P
+Remote url\.
+.
+.SH "EXAMPLES"
+$ git upstream git://github\.com/visionmedia/git\-extras\.git
+.
+.SH "AUTHOR"
+Written by Jose V\. Trigueros <\fIj\.v\.trigueros@gmail\.com\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/visionmedia/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-upstream.html
+++ b/man/git-upstream.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-upstream(1) - Add/update remote upstream repository</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-upstream(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-upstream(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-upstream</code> - <span class="man-whatis">Add/update remote upstream repository</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-upstream</code> &lt;url&gt;</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>  Adds or updates the remote upstream url.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  &lt;url&gt;</p>
+
+<p>  Remote url.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>  $ git upstream git://github.com/visionmedia/git-extras.git</p>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Jose V. Trigueros &lt;<a href="&#109;&#x61;&#105;&#x6c;&#x74;&#111;&#58;&#x6a;&#x2e;&#118;&#46;&#x74;&#x72;&#105;&#x67;&#x75;&#101;&#x72;&#111;&#115;&#64;&#x67;&#x6d;&#97;&#105;&#108;&#x2e;&#x63;&#111;&#109;" data-bare-link="true">&#106;&#46;&#118;&#x2e;&#x74;&#114;&#x69;&#x67;&#117;&#101;&#114;&#111;&#115;&#64;&#x67;&#x6d;&#x61;&#x69;&#x6c;&#46;&#x63;&#x6f;&#x6d;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/visionmedia/git-extras/issues" data-bare-link="true">https://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/visionmedia/git-extras" data-bare-link="true">https://github.com/visionmedia/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>May 2013</li>
+    <li class='tr'>git-upstream(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-upstream.md
+++ b/man/git-upstream.md
@@ -1,0 +1,32 @@
+git-upstream(1) -- Add/update remote upstream repository
+================================
+
+## SYNOPSIS
+
+`git-upstream` &lt;url&gt;
+
+## DESCRIPTION
+
+  Adds or updates the remote upstream url.
+
+## OPTIONS
+
+  &lt;url&gt;
+
+  Remote url.
+
+## EXAMPLES
+   
+  $ git upstream git://github.com/visionmedia/git-extras.git
+
+## AUTHOR
+
+Written by Jose V. Trigueros &lt;<j.v.trigueros@gmail.com>&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/visionmedia/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/visionmedia/git-extras>&gt;


### PR DESCRIPTION
I thought that this shortcut might be useful to add to the list of extras. It is not very fancy, but it is something that I find myself doing every time I fork a repository.

Usage:

``` bash
$ git upstream git://github.com/visionmedia/git-extras.git
```
