### PR TITLE
a few fixes in a row

### DIFF
--- a/bin/git-back
+++ b/bin/git-back
@@ -3,7 +3,7 @@
 if test $# -eq 0; then
   git reset --soft HEAD~1
 else
-  if `echo $1 | grep -q [^[:digit:]]`; then
+  if `echo $1 | grep -qv [[:digit:]]`; then
     echo "$1 is not a number" 1>&2
   else
     git reset --soft HEAD~$1

--- a/bin/git-bug
+++ b/bin/git-bug
@@ -7,5 +7,5 @@ if test "$1" = "finish"; then
 else
   test -z $1 && echo "bug <name> required." && exit 1
   branch=bug/$1
-  git checkout -b $branch &> /dev/null
+  git checkout -b $branch > /dev/null 2>&1
 fi

--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 delete_all="no"
 current_branch=`git rev-parse --symbolic-full-name --abbrev-ref HEAD`

--- a/bin/git-extras
+++ b/bin/git-extras
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 VERSION="1.9.0"
 

--- a/bin/git-feature
+++ b/bin/git-feature
@@ -7,5 +7,5 @@ if test "$1" = "finish"; then
 else
   test -z $1 && echo "feature <name> required." 1>&2 && exit 1
   branch=feature/$1
-  git checkout -b $branch &> /dev/null
+  git checkout -b $branch > /dev/null 2>&1
 fi

--- a/bin/git-info
+++ b/bin/git-info
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 get_config() {
   git config --list
@@ -23,20 +23,20 @@ remote_urls() {
 # Show info similar to svn
 
 echo
-echo "## Remote URLs:\n"
-echo "$(remote_urls)\n"
+echo -e "## Remote URLs:\n"
+echo -e "$(remote_urls)\n"
 
-echo "## Remote Branches:\n"
-echo "$(remote_branches)\n"
+echo -e "## Remote Branches:\n"
+echo -e "$(remote_branches)\n"
 
-echo "## Local Branches:\n"
-echo "$(local_branches)\n"
+echo -e "## Local Branches:\n"
+echo -e "$(local_branches)\n"
 
-echo "## Most Recent Commit:\n"
-echo "$(most_recent_commit)\n"
-echo "Type 'git log' for more commits, or 'git show <commit id>' for full commit details.\n"
+echo -e "## Most Recent Commit:\n"
+echo -e "$(most_recent_commit)\n"
+echo -e "Type 'git log' for more commits, or 'git show <commit id>' for full commit details.\n"
 
 if test "$1" != "--no-config"; then
-  echo "## Configuration (.git/config):\n"
-  echo "$(get_config)\n"
+  echo -e "## Configuration (.git/config):\n"
+  echo -e "$(get_config)\n"
 fi

--- a/bin/git-obliterate
+++ b/bin/git-obliterate
@@ -1,3 +1,4 @@
+#!/bin/sh
 file=$1
 test -z $file && echo "file required." 1>&2 && exit 1
 git filter-branch -f --index-filter "git rm -r --cached $file --ignore-unmatch" --prune-empty --tag-name-filter cat -- --all

--- a/bin/git-pull-request
+++ b/bin/git-pull-request
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 #
 # Echo <msg> and exit

--- a/bin/git-refactor
+++ b/bin/git-refactor
@@ -7,5 +7,5 @@ if test "$1" = "finish"; then
 else
   test -z $1 && echo "refactor <name> required." 1>&2 && exit 1
   branch=refactor/$1
-  git checkout -b $branch &> /dev/null
+  git checkout -b $branch > /dev/null 2>&1
 fi

--- a/bin/git-release
+++ b/bin/git-release
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 hook() {
   local hook=.git/hooks/$1.sh

--- a/man/manning-up.sh
+++ b/man/manning-up.sh
@@ -9,7 +9,7 @@ for file in $(ls git*.md); do
   extra=${file/.md/}
   spaced="                           "
   echo "$extra(1)${spaced:${#extra}}$extra" >> index.txt.tmp;
-  title=$(grep -m=1 $extra"(1) -- " $file)
+  title=$(grep -m1 $extra"(1) -- " $file)
   test "$extra" != "git-extras" && echo "   - **"${title/" --"/"**"} >> git-extras.md.tmp
 done
 ln=$(awk '/## AUTHOR/{print NR};'  ./git-extras.md)

--- a/man/manning-up.sh
+++ b/man/manning-up.sh
@@ -16,6 +16,7 @@ ln=$(awk '/## AUTHOR/{print NR};'  ./git-extras.md)
 awk "NR >= $ln-1" git-extras.md >> git-extras.md.tmp && mv -f index.txt.tmp index.txt && mv -f git-extras.md.tmp git-extras.md
 
 for file in $(ls git*.md); do
+  echo -e "\nprocessing: $file"
   extra=${file/.md/}
   ronn $file && mv -f $extra.1.html $extra.html
 done


### PR DESCRIPTION
- fixed `grep: invalid max count`
  - manning-up.sh had an error making grep for title fail
- add output of file being processed
  - some output about which file gets processed by ronn, makes debugging easier
- add missing hashbang
  - there was the hashbang missing in `bin/git-obliterate`
- remove /usr/bin/env from hashbang
  - hashbang should not call shell-interpreter using env
- fix complains from `checkbashism -px`
  - some scripts used bashisms, but relied on /bin/sh
  - /bin/sh neccessarily not needs to be symlinked to /bin/bash
