### PR TITLE
Added git-sqwish(1)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Patches and Suggestions
 - David Baumgold
 - Leila Muhtasib
 - Duane Johnson
+- Todd Wolfson

--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,7 @@ $ brew install git-extras
  - `git promote`
  - `git local-commits`
  - `git archive-file`
+ - `git squash-all`
 
 ## git-extras
 
@@ -448,6 +449,15 @@ Merge commits from `src-branch` into the current branch as a _single_ commit. Wh
 ```bash
 $ git squash fixed-cursor-styling
 $ git squash fixed-cursor-styling "Fixed cursor styling"
+```
+
+## git-squash-all &lt;master-branch&gt; [msg]
+
+Squash all commits from current branch into _one_ commit and place it on top of `master-branch`. If `[msg]` is provided, `git-commit(1)` will be executed with `[msg]` and commit summaries of all squashed commits. Otherwise, a `git-commit(1)` prompt will be opened with commit summaries of all squashed commits. This is useful for squashing all commits on a topic branch and you want to prepare it for a pull request.
+
+```bash
+$ git squash-all master
+$ git squash-all master "Added support for Feature A"
 ```
 
 ## git-changelog

--- a/bin/git-squash-all
+++ b/bin/git-squash-all
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+master=$1
+message=$2
+
+# If no master branc is provided, complain and leave
+test -z $master && echo "Master branch required." 1>&2 && exit 1
+
+# If the working directory is dirty, complain and leave
+clean_status() {
+  git status | grep "nothing to commit (working directory clean)"
+}
+test -z "$(clean_status)" && echo "Working directory is dirty. Please stash or commit changes." 1>&2 && exit 1
+
+# Pull down changes from master
+git merge --no-commit $master 1> /dev/null 2> /dev/null
+
+# If the branch is dirty
+if test -z "$(clean_status)"; then
+  # Clean up changes
+  git reset --hard 1> /dev/null 2> /dev/null
+
+  # Complain and leave
+  echo "This branch is not up-to-date with $master. Please merge in changes." 1>&2
+  exit 1
+fi
+
+# Determine the starting branch
+#          Grab the branch                    | ltrim unused rows     Remove asterisk
+original=$(git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1/")
+
+# Create temporary backup branch
+tmpstr=$(date +%s)
+temporary='tmp.'$tmpstr
+
+# Copy and move ref to temporary branch
+git checkout -b $temporary || exit 1
+
+# Reset original branch to master
+git checkout -B $original $master
+
+# Pull over all files from temporary branch
+git checkout $temporary -- .
+
+# Collect the commit message of those in $original but not in $master (since..until)
+git log $master..$temporary --format=format:%s > .git/MERGE_MSG
+
+# If there is a message, commit files with input and aggregate messages
+if test -n "$message"; then
+  # Read in the message to memory and delete it
+  aggregate=$(cat .git/MERGE_MSG)
+  rm .git/MERGE_MSG
+
+  # Automatically commit with input and aggergate messages
+  git commit -F- <<EOF
+$message
+$aggregate
+EOF
+else
+# Otherwise, open a pre-filled commit dialog (via .git/MERGE_MSG)
+  git commit
+fi
+
+# Delete backup branch
+git branch -D $temporary

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -65,6 +65,10 @@ _git_squash(){
   __gitcomp "$(__git_heads)"
 }
 
+_git_squash_all(){
+  __gitcomp "$(__git_heads)"
+}
+
 _git_undo(){
    __gitcomp "--hard --soft -h -s"
 }

--- a/man/git-squash-all.1
+++ b/man/git-squash-all.1
@@ -1,0 +1,49 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-SQUASH\-ALL" "1" "June 2013" "" ""
+.
+.SH "NAME"
+\fBgit\-squash\-all\fR \- Compress changes in a branch
+.
+.SH "SYNOPSIS"
+\fBgit\-squash\-all\fR <master\-branch> [<commit\-message>]
+.
+.SH "DESCRIPTION"
+Take all commits in a branch, compress them into \fIone\fR commit on top of the \fBmaster\-branch\fR\.
+.
+.SH "OPTIONS"
+<master\-branch>
+.
+.P
+Branch to squash\-all commits on top of\.
+.
+.P
+<commit\-message>
+.
+.P
+If commit\-message is given, commit will be executed automatically and message will be prepended to the default summary (all commit summaries of squashed commits)\.
+.
+.SH "EXAMPLES"
+.
+.nf
+
+$ git squash\-all master
+Switched to a new branch \'tmp\.1OSwoYazcoc7Df\'
+Switched to and reset branch \'dev/my\.feature\'
+[dev/my\.feature 97b70be] Added abc\. Added def\.
+ 0 files changed
+ create mode 100644 abc
+ create mode 100644 def
+Deleted branch tmp\.1OSwoYazcoc7Df (was ade0637)\.
+.
+.fi
+.
+.SH "AUTHOR"
+Written by Todd Wolfson <\fItodd@twolfson\.com\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/visionmedia/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-squash-all.html
+++ b/man/git-squash-all.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-squash-all(1) - Compress changes in a branch</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-squash-all(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-squash-all(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-squash-all</code> - <span class="man-whatis">Compress changes in a branch</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-squash-all</code> &lt;master-branch&gt; [&lt;commit-message&gt;]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>  Take all commits in a branch, compress them into <em>one</em> commit on top of the <code>master-branch</code>.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  &lt;master-branch&gt;</p>
+
+<p>  Branch to squash-all commits on top of.</p>
+
+<p>  &lt;commit-message&gt;</p>
+
+<p>  If commit-message is given, commit will be executed automatically and message will be prepended to the default summary (all commit summaries of squashed commits).</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<pre><code>$ git squash-all master
+Switched to a new branch 'tmp.1OSwoYazcoc7Df'
+Switched to and reset branch 'dev/my.feature'
+[dev/my.feature 97b70be] Added abc. Added def.
+ 0 files changed
+ create mode 100644 abc
+ create mode 100644 def
+Deleted branch tmp.1OSwoYazcoc7Df (was ade0637).
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Todd Wolfson &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#116;&#111;&#58;&#x74;&#111;&#x64;&#x64;&#x40;&#116;&#119;&#x6f;&#x6c;&#x66;&#x73;&#111;&#110;&#46;&#99;&#111;&#x6d;" data-bare-link="true">&#x74;&#111;&#x64;&#100;&#x40;&#116;&#x77;&#111;&#x6c;&#x66;&#115;&#x6f;&#x6e;&#x2e;&#99;&#x6f;&#109;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/visionmedia/git-extras/issues" data-bare-link="true">https://github.com/visionmedia/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/visionmedia/git-extras" data-bare-link="true">https://github.com/visionmedia/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>June 2013</li>
+    <li class='tr'>git-squash-all(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-squash-all.md
+++ b/man/git-squash-all.md
@@ -1,0 +1,43 @@
+git-squash-all(1) -- Compress changes in a branch
+=============================================
+
+## SYNOPSIS
+
+`git-squash-all` &lt;master-branch&gt; [&lt;commit-message&gt;]
+
+## DESCRIPTION
+
+  Take all commits in a branch, compress them into _one_ commit on top of the `master-branch`.
+
+## OPTIONS
+
+  &lt;master-branch&gt;
+
+  Branch to squash-all commits on top of.
+
+  &lt;commit-message&gt;
+
+  If commit-message is given, commit will be executed automatically and message will be prepended to the default summary (all commit summaries of squashed commits).
+
+## EXAMPLES
+
+    $ git squash-all master
+    Switched to a new branch 'tmp.1OSwoYazcoc7Df'
+    Switched to and reset branch 'dev/my.feature'
+    [dev/my.feature 97b70be] Added abc. Added def.
+     0 files changed
+     create mode 100644 abc
+     create mode 100644 def
+    Deleted branch tmp.1OSwoYazcoc7Df (was ade0637).
+
+## AUTHOR
+
+Written by Todd Wolfson &lt;<todd@twolfson.com>&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/visionmedia/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/visionmedia/git-extras>&gt;

--- a/man/index.txt
+++ b/man/index.txt
@@ -1,5 +1,6 @@
 # manuals
 git-alias(1)                  git-alias
+git-archive-file(1)           git-archive-file
 git-back(1)                   git-back
 git-bug(1)                    git-bug
 git-changelog(1)              git-changelog
@@ -26,6 +27,7 @@ git-rename-tag(1)             git-rename-tag
 git-repl(1)                   git-repl
 git-setup(1)                  git-setup
 git-show-tree(1)              git-show-tree
+git-squash-all(1)             git-squash-all
 git-squash(1)                 git-squash
 git-summary(1)                git-summary
 git-touch(1)                  git-touch


### PR DESCRIPTION
Included in this pull request:
- Added `git-sqwish(1)` which compresses changes from **current branch** into one commit.
- Manual files and README updates for `git-sqwish(1)`

I use a variant of `git-sqwish(1)` every day at work since I work on a pull request system which demands all branches are ready to merge once reviewed.

I cannot use `git-squash(1)` since that requires being on `master` and merging from there. Everything we do is done via the GitHub UI.
