### PR TITLE
Make repository_age() "history rewrite safe"

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -59,7 +59,7 @@ authors() {
 #
 
 repository_age() {
-  git log --reverse --pretty=oneline --format="%cr" | head -n 1 | sed 's/ago//'
+  git log --reverse --pretty=oneline --format="%ar" | head -n 1 | sed 's/ago//'
 }
 
 # summary


### PR DESCRIPTION
Change commit date to author date, so that the repo age doesn't change if history rewriting tools (such as amend, rebase, filter-branch) are used.
