### PR TITLE
changed the code for git bug|feature|refactor to only accept single argument when not finishing a bug|feature|refactor.

### DIFF
--- a/bin/git-bug
+++ b/bin/git-bug
@@ -5,7 +5,10 @@ if test "$1" = "finish"; then
   branch=bug/$2
   git merge --no-ff $branch && git delete-branch $branch
 else
-  test -z $1 && echo "bug <name> required." && exit 1
+  test -z $1 && echo "bug <name> required." 1>&2 && exit 1
+  if test -n $2; then
+    echo "too many arguments; if not finishing a bug, only <name> of new bug is expected" && exit 1
+  fi
   branch=bug/$1
   git checkout -b $branch &> /dev/null
 fi

--- a/bin/git-feature
+++ b/bin/git-feature
@@ -6,6 +6,9 @@ if test "$1" = "finish"; then
   git merge --no-ff $branch && git delete-branch $branch
 else
   test -z $1 && echo "feature <name> required." 1>&2 && exit 1
+  if test -n $2; then
+    echo "too many arguments; if not finishing a feature, only <name> of new feature is expected" && exit 1
+  fi
   branch=feature/$1
   git checkout -b $branch &> /dev/null
 fi

--- a/bin/git-refactor
+++ b/bin/git-refactor
@@ -6,6 +6,9 @@ if test "$1" = "finish"; then
   git merge --no-ff $branch && git delete-branch $branch
 else
   test -z $1 && echo "refactor <name> required." 1>&2 && exit 1
+  if test -n $2; then
+    echo "too many arguments; if not finishing a refactor, only <name> of new refactoring is expected" && exit 1
+  fi
   branch=refactor/$1
   git checkout -b $branch &> /dev/null
 fi


### PR DESCRIPTION
Currently, when user will misspell the word **finish** like below:

```
git bug finsih bugbranch
```

The code will create a branch named `bug/finsih` and check it out. This is not the expected behaviour and with the changes from this commit, after typing the code above, an error message will be given to the user:

```
too many arguments; if not finishing a bug, only <name> of new bug is expected
```
