### PR TITLE
git-create-branch: bug fix for branch creation use HEAD instead of origin

### DIFF
--- a/bin/git-create-branch
+++ b/bin/git-create-branch
@@ -3,7 +3,6 @@
 branch=$1
 test -z $branch && echo "branch required." 1>&2 && exit 1
 
-git push origin origin:refs/heads/$branch
+git push origin HEAD:refs/heads/$branch
 git fetch origin
 git checkout --track -b $branch origin/$branch
-git pull


### PR DESCRIPTION
Getting error

```
error: src refspec origin does not match any.
error: failed to push some refs to '....git'
```

if you are trying to push the current branch head to remote, the command should be:

```
git push origin HEAD:refs/heads/$branch
```

re: comment via b74a9d7#L2R6
