### PR TITLE
Added multi-delete for git-delete-branch and git-delete-tag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Patches and Suggestions
 - David Baumgold
 - Leila Muhtasib
 - Duane Johnson
+- Todd Wolfson

--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -1,7 +1,20 @@
 #!/bin/sh
 
-branch=$1
-test -z $branch && echo "branch required." 1>&2 && exit 1
-git branch -D $branch
-git branch -d -r origin/$branch
-git push origin :refs/heads/$branch
+# Assert there is at least one branch provided
+test -z $1 && echo "branch required." 1>&2 && exit 1
+
+# Concatenate all branch references
+local_branches=""
+origin_branches=""
+origin_refs=""
+for branch in "$@"
+do
+  local_branches=$local_branches" $branch"
+  origin_branches=$origin_branches" origin/$branch"
+  origin_refs=$origin_refs" :refs/heads/$branch"
+done
+
+# Delete all branches
+git branch -D $local_branches
+git branch -d -r $origin_branches
+git push origin $origin_refs

--- a/bin/git-delete-tag
+++ b/bin/git-delete-tag
@@ -1,6 +1,17 @@
 #!/bin/sh
 
-tagname=$1
-test -z $tagname && echo "tag required." 1>&2 && exit 1
-git tag -d $tagname
-git push origin :refs/tags/$tagname
+# Assert there is at least one tag provided
+test -z $1 && echo "tag required." 1>&2 && exit 1
+
+# Concatenate all the tag references
+local_tags=""
+origin_refs=""
+for tagname in "$@"
+do
+  local_tags=$local_tags" $tagname"
+  origin_refs=$origin_refs" :refs/tags/$tagname"
+done
+
+# Delete all the tags
+git tag -d $local_tags
+git push origin $origin_refs

--- a/man/git-delete-branch.1
+++ b/man/git-delete-branch.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
-.\" https://github.com/rtomayko/ronn/tree/0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-DELETE\-BRANCH" "1" "July 2012" "" ""
+.TH "GIT\-DELETE\-BRANCH" "1" "September 2013" "" ""
 .
 .SH "NAME"
 \fBgit\-delete\-branch\fR \- Delete branches
@@ -10,19 +10,20 @@
 \fBgit\-delete\-branch\fR <branchname>
 .
 .SH "DESCRIPTION"
-Deletes local and remote branch named <branchname>\.
+Deletes local and remote branch named <branchname>\. Note that local deletion fails if the branch is checked out\.
 .
 .SH "OPTIONS"
 <branchname>
 .
 .P
-The name of the branch to delete\.
+The name of the branch to delete\. If multiple branches are provided, then they will all be deleted\.
 .
 .SH "EXAMPLES"
 .
 .nf
 
 $ git delete\-branch integration
+$ git delete\-branch integration bug/1234
 .
 .fi
 .
@@ -30,7 +31,7 @@ $ git delete\-branch integration
 Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>
 .
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/visionmedia/git\-extras/issues\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras/issues\fR>
 .
 .SH "SEE ALSO"
-<\fIhttp://github\.com/visionmedia/git\-extras\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-delete-branch.html
+++ b/man/git-delete-branch.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (https://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
   <title>git-delete-branch(1) - Delete branches</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -80,22 +80,25 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Deletes local and remote branch named &lt;branchname&gt;.</p>
+<p>  Deletes local and remote branch named &lt;branchname&gt;.
+  Note that local deletion fails if the branch is checked out.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <p>  &lt;branchname&gt;</p>
 
-<p>  The name of the branch to delete.</p>
+<p>  The name of the branch to delete.
+  If multiple branches are provided, then they will all be deleted.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <pre><code>$ git delete-branch integration
+$ git delete-branch integration bug/1234
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#116;&#106;&#x40;&#x76;&#x69;&#x73;&#x69;&#x6f;&#110;&#x2d;&#109;&#x65;&#100;&#105;&#x61;&#x2e;&#x63;&#x61;" data-bare-link="true">&#x74;&#x6a;&#64;&#118;&#105;&#115;&#x69;&#x6f;&#110;&#45;&#x6d;&#x65;&#100;&#x69;&#x61;&#x2e;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#x69;&#108;&#116;&#x6f;&#x3a;&#x74;&#106;&#64;&#118;&#105;&#115;&#x69;&#111;&#x6e;&#x2d;&#109;&#101;&#100;&#105;&#97;&#46;&#x63;&#97;" data-bare-link="true">&#116;&#106;&#64;&#118;&#105;&#x73;&#105;&#111;&#110;&#x2d;&#109;&#101;&#100;&#x69;&#97;&#46;&#99;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -108,7 +111,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2012</li>
+    <li class='tc'>September 2013</li>
     <li class='tr'>git-delete-branch(1)</li>
   </ol>
 

--- a/man/git-delete-branch.md
+++ b/man/git-delete-branch.md
@@ -15,10 +15,12 @@ git-delete-branch(1) -- Delete branches
   &lt;branchname&gt;
 
   The name of the branch to delete.
+  If multiple branches are provided, then they will all be deleted.
 
 ## EXAMPLES
 
     $ git delete-branch integration
+    $ git delete-branch integration bug/1234
 
 ## AUTHOR
 

--- a/man/git-delete-tag.1
+++ b/man/git-delete-tag.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
-.\" https://github.com/rtomayko/ronn/tree/0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-DELETE\-TAG" "1" "July 2012" "" ""
+.TH "GIT\-DELETE\-TAG" "1" "September 2013" "" ""
 .
 .SH "NAME"
 \fBgit\-delete\-tag\fR \- Delete tags
@@ -16,13 +16,14 @@ Deletes local and remote tag named <tagname>\.
 <tagname>
 .
 .P
-The name of the branch to delete\.
+The name of the tag to delete\. If multiple tags are provided, then they will all be deleted\.
 .
 .SH "EXAMPLES"
 .
 .nf
 
 $ git delete\-tag 0\.0\.1
+$ git delete\-tag 0\.0\.1 0\.0\.2
 .
 .fi
 .
@@ -30,7 +31,7 @@ $ git delete\-tag 0\.0\.1
 Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>
 .
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/visionmedia/git\-extras/issues\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras/issues\fR>
 .
 .SH "SEE ALSO"
-<\fIhttp://github\.com/visionmedia/git\-extras\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-delete-tag.html
+++ b/man/git-delete-tag.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (https://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
   <title>git-delete-tag(1) - Delete tags</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -86,16 +86,18 @@
 
 <p>  &lt;tagname&gt;</p>
 
-<p>  The name of the branch to delete.</p>
+<p>  The name of the tag to delete.
+  If multiple tags are provided, then they will all be deleted.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <pre><code>$ git delete-tag 0.0.1
+$ git delete-tag 0.0.1 0.0.2
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#116;&#106;&#x40;&#x76;&#x69;&#x73;&#x69;&#x6f;&#110;&#x2d;&#109;&#x65;&#100;&#105;&#x61;&#x2e;&#x63;&#x61;" data-bare-link="true">&#x74;&#x6a;&#64;&#118;&#105;&#115;&#x69;&#x6f;&#110;&#45;&#x6d;&#x65;&#100;&#x69;&#x61;&#x2e;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#97;&#105;&#x6c;&#x74;&#x6f;&#58;&#x74;&#x6a;&#64;&#118;&#x69;&#x73;&#x69;&#111;&#110;&#x2d;&#x6d;&#x65;&#100;&#105;&#97;&#46;&#x63;&#97;" data-bare-link="true">&#x74;&#x6a;&#x40;&#x76;&#105;&#115;&#105;&#111;&#110;&#x2d;&#109;&#x65;&#x64;&#x69;&#97;&#x2e;&#x63;&#97;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -108,7 +110,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2012</li>
+    <li class='tc'>September 2013</li>
     <li class='tr'>git-delete-tag(1)</li>
   </ol>
 

--- a/man/git-delete-tag.md
+++ b/man/git-delete-tag.md
@@ -13,11 +13,13 @@ git-delete-tag(1) -- Delete tags
 
   &lt;tagname&gt;
 
-  The name of the branch to delete.
+  The name of the tag to delete.
+  If multiple tags are provided, then they will all be deleted.
 
 ## EXAMPLES
 
     $ git delete-tag 0.0.1
+    $ git delete-tag 0.0.1 0.0.2
 
 ## AUTHOR
 


### PR DESCRIPTION
In order to more efficiently delete multiple branches and tags, I updated `git-delete-branch` and `git-delete-tag`. In this PR:
- Updated `git-delete-branch` to accept multiple branches
- Updated `git-delete-tag` to accept multiple tags
- Updated documentation to match changes
- Fix for documentation of `git-delete-tag` (said `branch`, corrected to `tag`)
