### PR TITLE
pass release arguments to pre/post-release scripts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -266,7 +266,7 @@ Matt Colyer (1)
 total 1844
 ```
 
-## git-release
+## git-release <tagname> [remote-url]
 
 Release commit with the given &lt;tag&gt;:
 
@@ -276,11 +276,11 @@ $ git release 0.1.0
 
 Does the following:
 
-  - Executes _.git/hooks/pre-release.sh_ (if present)
+  - Executes _.git/hooks/pre-release.sh_ (if present), passing it the given arguments
   - Commits changes (to changelog etc) with message "Release &lt;tag&gt;"
   - Tags with the given &lt;tag&gt;
   - Push the branch / tags
-  - Executes _.git/hooks/post-release.sh_ (if present)
+  - Executes _.git/hooks/post-release.sh_ (if present), passing it the given arguments
 
 ## git-alias
 

--- a/bin/git-release
+++ b/bin/git-release
@@ -1,21 +1,21 @@
 #!/usr/bin/env sh
 
 hook() {
-  local hook=.git/hooks/$1.sh
+  local hook=.git/hooks/$1.sh; shift
   if test -f $hook; then
-    echo "... $1"
-    . $hook
+    echo "... $hook $@"
+    . $hook "$@"
   fi
 }
 
 if test $# -gt 0; then
-  hook pre-release
-  echo "... releasing $1"
+  hook pre-release "$@"
+  echo "... releasing $1 to $2"
   git commit -a -m "Release $1"
   git tag $1 -a -m "Release $1" \
     && git push $2 \
     && git push $2 --tags \
-    && hook post-release \
+    && hook post-release "$@" \
     && echo "... complete"
 else
   echo "tag required" 1>&2 && exit 1


### PR DESCRIPTION
the _git-release_ command should pass the tagname to the pre-post/release scripts for them to be able to use this version string to automatically update some files in the repo.

when already at it, one can also pass all arguments to the hooks: the avid user is free to simply attach a third, fourth,... argument to _git-release_ without affecting that command's spec
