### PR TITLE
removing `git promote`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,6 @@ $ brew install git-extras
  - `git feature`
  - `git refactor`
  - `git bug`
- - `git promote`
  - `git local-commits`
  - `git archive-file`
 


### PR DESCRIPTION
I don't see a `git promote` command, so I am removing it from the Readme.
