### PR TITLE
git-changelog: don't output a trailing space after the date

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -21,7 +21,7 @@ while [ "$1" != "" ]; do
 done
 
 DATE=`date +'%Y-%m-%d'`
-HEAD="\n$TAG / $DATE \n==================\n\n"
+HEAD="\n$TAG / $DATE\n==================\n\n"
 
 if $LIST; then
   version=$(git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1))


### PR DESCRIPTION
This has been driving me and others crazy for forever.
/cc @guille @MatthewMueller
