### PR TITLE
Replaced $(DESTDIR) with $(PREFIX) and $(MANPREFIX)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,17 @@ MAN_PAGES = $(MANS:.md=.1)
 docs: $(MAN_HTML) $(MAN_PAGES)
 
 install:
-	@mkdir -p $(DESTDIR)$(MANPREFIX)
-	@mkdir -p $(DESTDIR)$(PREFIX)/bin
-	@echo "... installing bins to $(DESTDIR)$(PREFIX)/bin"
-	@echo "... installing man pages to $(DESTDIR)$(MANPREFIX)"
+	@mkdir -p $(MANPREFIX)
+	@mkdir -p $(PREFIX)/bin
+	@echo "... installing bins to $(PREFIX)/bin"
+	@echo "... installing man pages to $(MANPREFIX)"
 	@$(foreach BIN, $(BINS), \
 		echo "... installing `basename $(BIN)`"; \
-		cp -f $(BIN) $(DESTDIR)$(PREFIX)/$(BIN); \
+		cp -f $(BIN) $(PREFIX)/$(BIN); \
 	)
-	cp -f man/git-*.1 $(DESTDIR)$(MANPREFIX)
-	@mkdir -p $(DESTDIR)/etc/bash_completion.d
-	cp -f etc/bash_completion.sh $(DESTDIR)/etc/bash_completion.d/git-extras
+	cp -f man/git-*.1 $(MANPREFIX)
+	@mkdir -p $(PREFIX)/etc/bash_completion.d
+	cp -f etc/bash_completion.sh $(PREFIX)/etc/bash_completion.d/git-extras
 
 man/%.html: man/%.md
 	ronn \
@@ -35,14 +35,14 @@ man/%.1: man/%.md
 
 uninstall:
 	@$(foreach BIN, $(BINS), \
-		echo "... uninstalling $(DESTDIR)$(PREFIX)/$(BIN)"; \
-		rm -f $(DESTDIR)$(PREFIX)/$(BIN); \
+		echo "... uninstalling $(PREFIX)/$(BIN)"; \
+		rm -f $(PREFIX)/$(BIN); \
 	)
 	@$(foreach MAN, $(MAN_PAGES), \
-		echo "... uninstalling $(DESTDIR)$(MANPREFIX)/$(MAN)"; \
-		rm -f $(DESTDIR)$(MANPREFIX)/$(MAN); \
+		echo "... uninstalling $(MANPREFIX)/$(MAN)"; \
+		rm -f $(MANPREFIX)/$(MAN); \
 	)
-	rm -f $(DESTDIR)/etc/bash_completion.d/git-extras
+	rm -f $(PREFIX)/etc/bash_completion.d/git-extras
 
 clean: docclean
 


### PR DESCRIPTION
I noticed `$(DESTDIR)` wasn't being used, and it got in the way of
installing `git-extras` via the following command:

    PREFIX=$HOME make install

Since I like to avoid using `sudo`, I thought I'd rewrite it. Pretty
simple.