### PR TITLE
Fix changelog formatting for large version numbers

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -25,7 +25,9 @@ while [ "$1" != "" ]; do
 done
 
 DATE=`date +'%Y-%m-%d'`
-HEAD="\n$TAG / $DATE\n==================\n\n"
+HEAD="\n$TAG / $DATE\n"
+for i in $(seq 5 ${#HEAD}); do HEAD="$HEAD="; done
+HEAD="$HEAD\n\n"
 
 if $LIST; then
   version=$(git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1))


### PR DESCRIPTION
This allows for version numbers which require more than 5 characters to be underlined and pretty. :)
