### PR TITLE
Don't print duplicating '*' symbol

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -33,7 +33,7 @@ if $LIST; then
     git log $GIT_LOG_OPTS --pretty="format: * %s"
   else
     git log $GIT_LOG_OPTS --pretty="format: * %s" $version..
-  fi
+  fi | sed 's/^  \* \*/  */g'
   exit
 fi
 


### PR DESCRIPTION
$ git log --format=%s head^!
> * fix issue NNN

$ git-changelog -l | head -1
>  * * fix issue 56

$ git-changelog -l | head -1
>  * fix issue 56

fix #217