### PR TITLE
Add check for no changes in the tree (no sub-modules)

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -5,6 +5,11 @@ LIST=false
 TAG="n.n.n"
 GIT_LOG_OPTS=""
 
+if git diff-index --quiet --ignore-submodules HEAD --; then
+    echo 'No changes to log.';
+    exit 1;
+fi
+
 while [ "$1" != "" ]; do
   case $1 in
     -l | --list )


### PR DESCRIPTION
Add the check at the early stage, otherwise populates the $CHANGELOG with empty lines.
