### PR TITLE
Use two-space indents for log entry output, restoring debian changelog compatibility

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -30,9 +30,9 @@ HEAD="\n$TAG / $DATE\n==================\n\n"
 if $LIST; then
   version=$(git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1))
   if test -z "$version"; then
-    git log $GIT_LOG_OPTS --pretty="format: * %s"
+    git log $GIT_LOG_OPTS --pretty="format:  * %s"
   else
-    git log $GIT_LOG_OPTS --pretty="format: * %s" $version..
+    git log $GIT_LOG_OPTS --pretty="format:  * %s" $version..
   fi
   exit
 fi


### PR DESCRIPTION
git-changelog used to be debian changelog compatible up to commit 1235e4a5, where it seems to accidentally have changed the log entry output to be one-space indented.

The commit in this pull request restores the previous behaviour by again using two-space indents for the log entry outputs.
