### PR TITLE
Letter spacing in author list

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -48,7 +48,7 @@ authors() {
   { args[NR] = $0; sum += $0 }
   END {
     for (i = 1; i <= NR; ++i) {
-      printf "%-30s %2.1f%%\n", args[i], 100 * args[i] / sum
+      printf "%-30s\t %2.1f%%\n", args[i], 100 * args[i] / sum
     }
   }
   '


### PR DESCRIPTION
This is a quick fix for the letter spacing for the author list. 
It works a little bit better...
