### PR TITLE
invoke bash via /usr/bin/env for portability

### DIFF
--- a/bin/git-archive-file
+++ b/bin/git-archive-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # extract current branch name
 BRANCH=$(git name-rev HEAD 2> /dev/null | awk "{ print \$2 }")

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tmp=/tmp/.git-effort
 above='0'

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function show_contents {
   test -f "$2" && echo "$1 gitignore: $2" && cat "$2"

--- a/bin/git-line-summary
+++ b/bin/git-line-summary
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 project=${PWD##*/}
 

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while true; do
   # Current branch


### PR DESCRIPTION
Bash doesn't reside in the base system everywhere. /usr/bin/env should almost always be used for anything other than /bin/sh.
