### PR TITLE
Remove stale reference to git-promote

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,7 +63,6 @@ $ brew install git-extras
  - `git feature`
  - `git refactor`
  - `git bug`
- - `git promote`
  - `git local-commits`
  - `git archive-file`
 


### PR DESCRIPTION
Was removed years ago in 7a632e90262005d9cde0f3ad8a0664a1a8eb8f1d
