### PR TITLE
FIX (git-changelog): check if un-pushed commits

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -5,8 +5,8 @@ LIST=false
 TAG="n.n.n"
 GIT_LOG_OPTS=""
 
-if git diff-index --quiet --ignore-submodules HEAD --; then
-    echo 'No changes to log.';
+if [[ -z $(git log --ignore-submodules origin..HEAD) ]]; then
+    echo 'No unpushed commits.';
     exit 1;
 fi
 


### PR DESCRIPTION
- switch the check for un-pushed commits from `diff-index` to more simple check
- still ignores sub-modules

Closes #234

Clarification: 
As pointed by @cristiandouce in #234 - my flow was different (and pretty stupid to be honest on some particular project of mine) so some other work flow scenarios was failing to pass. 

I still feel such check is needed, because it is still populates Changelog|History files with empty lines if no un-pushed commits exist, so @hemanth merge this one or revert the [619232e](https://github.com/visionmedia/git-extras/commit/619232ef868a7ca275288d1f1ab787d087d758b0)
