### PR TITLE
Uses column -t to align summary output in a table.

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -48,10 +48,10 @@ authors() {
   { args[NR] = $0; sum += $0 }
   END {
     for (i = 1; i <= NR; ++i) {
-      printf "%-30s\t %2.1f%%\n", args[i], 100 * args[i] / sum
+      printf "%s,%2.1f%%\n", args[i], 100 * args[i] / sum
     }
   }
-  '
+  ' | column -t -s,
 }
 
 #


### PR DESCRIPTION
See #224 for a discussion.

The output from printf is changed from using a set maximum number of whitespace characters to simply outputting: `<author>,<percentage>'.

This output is then put through `column -t -s,` to split on the comma separator and lay the fields out in a table.

**Previously:**

``` shell
./bin/git-summary  | tail -20
```

```
     1  Jesse Sipprell           0.2%
     1  John Hoffmann            0.2%
     1  Konstantin Schukraft     0.2%
     1  Leandro López            0.2%
     1  Maarten Winter           0.2%
     1  Mathieu D. (MatToufoutu)         0.2%
     1  Matt Colyer              0.2%
     1  Michael Komitee          0.2%
     1  Michael Matuzak          0.2%
     1  Moritz Grauel            0.2%
     1  NANRI                    0.2%
     1  Nathan Rajlich           0.2%
     1  Nick Campbell            0.2%
     1  Nick Payne               0.2%
     1  Niklas Fiekas            0.2%
     1  Stephen Mathieson        0.2%
     1  Todd Wolfson             0.2%
     1  Tony                     0.2%
     1  TweeKane                 0.2%
```

**Current:**

``` shell
./bin/git-summary  | tail -20
```

```
     1  Jesse Sipprell            0.2%
     1  John Hoffmann             0.2%
     1  Joshua Appelman           0.2%
     1  Konstantin Schukraft      0.2%
     1  Leandro López             0.2%
     1  Maarten Winter            0.2%
     1  Mathieu D. (MatToufoutu)  0.2%
     1  Matt Colyer               0.2%
     1  Michael Komitee           0.2%
     1  Michael Matuzak           0.2%
     1  Moritz Grauel             0.2%
     1  NANRI                     0.2%
     1  Nathan Rajlich            0.2%
     1  Nick Campbell             0.2%
     1  Nick Payne                0.2%
     1  Niklas Fiekas             0.2%
     1  Stephen Mathieson         0.2%
     1  Todd Wolfson              0.2%
     1  Tony                      0.2%
```
