### PR TITLE
Refactor and improve `git squash`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -505,13 +505,20 @@ $ git graft new_feature dev
 $ git graft new_feature
 ```
 
-## git-squash &lt;src-branch&gt; [msg]
+## git-squash &lt;src-branch|commit ref&gt; [msg]
 
-Merge commits from `src-branch` into the current branch as a _single_ commit. When `[msg]` is given `git-commit(1)` will be invoked with that message. This is useful when small individual commits within a topic branch are irrelevant and you want to consider the topic as a single change.
+Merge commits from `src-branch` into the current branch as a _single_ commit.
+Also works if a commit reference from the current branch is provided.
+When `[msg]` is given `git-commit(1)` will be invoked with that message. This is
+useful when small individual commits within a topic branch are irrelevant and
+you want to consider the topic as a single change.
 
 ```bash
 $ git squash fixed-cursor-styling
 $ git squash fixed-cursor-styling "Fixed cursor styling"
+$ git squash 95b7c52
+$ git squash HEAD~3
+$ git squash HEAD~3 "Work on a feature"
 ```
 
 ## git-changelog

--- a/bin/git-squash
+++ b/bin/git-squash
@@ -1,38 +1,53 @@
-#!/bin/sh
+#!/bin/bash
 
-src=$1
-msg=$2
+src="$1"
+msg="$2"
 
-test -z $src && echo "source branch required, or use --me." && exit 1
+is_branch() {
+  git show-ref --verify --quiet "refs/heads/$src"
+}
 
-# squash current branch
-# TODO: do this in a less hacky way
-# TODO: less sketchy arguments
+is_commit_reference() {
+  git rev-parse --verify --quiet "$src" > /dev/null 2>&1
+}
 
-if [[ $1 == "--me" ]]; then
-  msg=$3
-  branch=`git rev-parse --abbrev-ref HEAD`
+is_on_current_branch() {
+  local commit_sha=`git rev-parse "$src"`
+  git rev-list HEAD |
+    grep -q "$commit_sha"
+}
 
-  # merge against target branch or master
-  git checkout ${2-master}
-
-  git checkout -B squash-tmp
-  git squash $branch
-  git branch -D $branch
-  git checkout -B $branch
-  git branch -D squash-tmp
-
+commit_if_msg_provided() {
   if test -n "$msg"; then
     git commit -a -m "$msg"
   fi
+}
 
-  exit
-fi
+prompt_continuation_if_squashing_master() {
+  if [[ $src =~ ^master$ ]]; then
+    read -p "Warning: squashing '$src'! Continue [y/N]? " -r
+    if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+      echo "Exiting"
+      exit 1
+    fi
+  fi
+}
 
-# squash $src
+squash_branch() {
+  prompt_continuation_if_squashing_master
+  git merge --squash "$src" || exit 1  # quits if `git merge` fails
+  commit_if_msg_provided
+}
 
-git merge --squash $src
+squash_current_branch() {
+  git reset --soft "$src" || exit 1    # quits if `git reset` fails
+  commit_if_msg_provided
+}
 
-if test -n "$msg"; then
-  git commit -a -m "$msg" && git branch -D $src
+if `is_branch`; then
+  squash_branch
+elif `is_commit_reference` && `is_on_current_branch`; then
+  squash_current_branch
+else
+  echo "Source branch or commit reference required." 1>&2 && exit 1
 fi

--- a/man/git-squash.1
+++ b/man/git-squash.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
-.\" https://github.com/rtomayko/ronn/tree/0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SQUASH" "1" "July 2012" "" ""
+.TH "GIT\-SQUASH" "1" "July 2014" "" ""
 .
 .SH "NAME"
-\fBgit\-squash\fR \- Import changes from a branch
+\fBgit\-squash\fR \- Import changes form a branch
 .
 .SH "SYNOPSIS"
-\fBgit\-squash\fR <source\-branch> [<commit\-message>]
+\fBgit\-squash\fR <source\-branch|commit ref> [<commit\-message>]
 .
 .SH "DESCRIPTION"
 Produce the working tree and index state as if a real merge happened without the commit or merge marks\.
@@ -17,6 +17,9 @@ Produce the working tree and index state as if a real merge happened without the
 .
 .P
 Branch to squash on the actual branch\.
+.
+.P
+<commit reference> A commit reference (has to be from the current branch) can also be used as the first argument\. A range of commits \fIsha\fR\.\.HEAD will be squashed\.
 .
 .P
 <commit\-message>
@@ -35,6 +38,8 @@ Squash commit \-\- not updating HEAD
  my\-changed\-file | 1 +
  1 file changed, 1 insertion(+)
 $ git commit \-m "New commit without a real merge"
+
+$ git squash HEAD~3 "Commit message"
 .
 .fi
 .
@@ -42,7 +47,7 @@ $ git commit \-m "New commit without a real merge"
 Written by Jesús Espino <\fIjespinog@gmail\.com\fR>
 .
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/visionmedia/git\-extras/issues\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras/issues\fR>
 .
 .SH "SEE ALSO"
-<\fIhttp://github\.com/visionmedia/git\-extras\fR>
+<\fIhttps://github\.com/visionmedia/git\-extras\fR>

--- a/man/git-squash.html
+++ b/man/git-squash.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (https://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
   <title>git-squash(1) - Import changes form a branch</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-squash</code> &lt;source-branch&gt; [&lt;commit-message&gt;]</p>
+<p><code>git-squash</code> &lt;source-branch|commit ref&gt; [&lt;commit-message&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -88,6 +88,10 @@
 <p>  &lt;source-branch&gt;</p>
 
 <p>  Branch to squash on the actual branch.</p>
+
+<p>  &lt;commit reference&gt;
+  A commit reference (has to be from the current branch) can also be used as the
+  first argument. A range of commits <var>sha</var>..HEAD will be squashed.</p>
 
 <p>  &lt;commit-message&gt;</p>
 
@@ -102,11 +106,13 @@ Squash commit -- not updating HEAD
  my-changed-file | 1 +
  1 file changed, 1 insertion(+)
 $ git commit -m "New commit without a real merge"
+
+$ git squash HEAD~3 "Commit message"
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Jesús Espino &lt;<a href="&#109;&#x61;&#x69;&#x6c;&#116;&#111;&#x3a;&#106;&#101;&#115;&#112;&#x69;&#110;&#x6f;&#x67;&#64;&#103;&#x6d;&#x61;&#105;&#x6c;&#x2e;&#99;&#x6f;&#x6d;" data-bare-link="true">&#106;&#x65;&#115;&#112;&#105;&#110;&#x6f;&#x67;&#x40;&#103;&#109;&#x61;&#x69;&#108;&#x2e;&#99;&#x6f;&#x6d;</a>&gt;</p>
+<p>Written by Jesús Espino &lt;<a href="&#x6d;&#x61;&#x69;&#x6c;&#x74;&#x6f;&#58;&#106;&#x65;&#x73;&#112;&#x69;&#110;&#111;&#x67;&#64;&#103;&#109;&#x61;&#105;&#108;&#x2e;&#99;&#x6f;&#109;" data-bare-link="true">&#106;&#x65;&#115;&#112;&#105;&#x6e;&#x6f;&#x67;&#x40;&#103;&#109;&#97;&#105;&#108;&#x2e;&#x63;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -119,7 +125,7 @@ $ git commit -m "New commit without a real merge"
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2012</li>
+    <li class='tc'>July 2014</li>
     <li class='tr'>git-squash(1)</li>
   </ol>
 

--- a/man/git-squash.md
+++ b/man/git-squash.md
@@ -3,7 +3,7 @@ git-squash(1) -- Import changes form a branch
 
 ## SYNOPSIS
 
-`git-squash` &lt;source-branch&gt; [&lt;commit-message&gt;] 
+`git-squash` &lt;source-branch|commit ref&gt; [&lt;commit-message&gt;]
 
 ## DESCRIPTION
 
@@ -15,6 +15,10 @@ git-squash(1) -- Import changes form a branch
   &lt;source-branch&gt;
 
   Branch to squash on the actual branch.
+
+  &lt;commit reference&gt;
+  A commit reference (has to be from the current branch) can also be used as the
+  first argument. A range of commits <sha>..HEAD will be squashed.
 
   &lt;commit-message&gt;
 
@@ -29,6 +33,8 @@ git-squash(1) -- Import changes form a branch
      my-changed-file | 1 +
      1 file changed, 1 insertion(+)
     $ git commit -m "New commit without a real merge"
+
+    $ git squash HEAD~3 "Commit message"
 
 ## AUTHOR
 


### PR DESCRIPTION
This pull request contains refactoring work and improvements for `git squash`.

These issues are handled:
- `reset --soft` is used as per issue #198
- added prompt if master branch is squashed as per issue #198
- command arguments should be more consistent, inline TODO
  [here](https://github.com/bruno-/git-extras/commit/c136afba673e5d53c7c4c7be2407245158f2523b#diff-eb9f2ea45b9ddfbb3aa2bfdbdcaa44b0R10)
- I strived for things to be less hacky now e.g. no temporary branches and
  heavy branch manipulation. Inline todo
  [here](https://github.com/bruno-/git-extras/commit/c136afba673e5d53c7c4c7be2407245158f2523b#diff-eb9f2ea45b9ddfbb3aa2bfdbdcaa44b0R9)
- handles bug from #95

I did a decent round of testing for this locally and everything was fine.

Please let me know if you have any questions or code has to be tweaked etc.
