### PR TITLE
Revert 2 commits to `git-changelog`

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -5,11 +5,6 @@ LIST=false
 TAG="n.n.n"
 GIT_LOG_OPTS=""
 
-if [[ -z $(git log --ignore-submodules origin..HEAD) ]]; then
-    echo 'No unpushed commits.';
-    exit 1;
-fi
-
 while [ "$1" != "" ]; do
   case $1 in
     -l | --list )


### PR DESCRIPTION
- Revert "FIX: check if un-pushed commits". This reverts commit bd80a4e51255d5d64ebfbb6ad6c28f44ef867470.
- Revert "Add check for no changes in the tree (no sub-modules)". This reverts commit f2a41c54b1a2d64cf09c537308976392e8a403b7.

Resolves #234
