### PR TITLE
Fix wrong git-info heading level in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -400,7 +400,7 @@ build
 *.log
 ```
 
-# git-info
+## git-info
 
 Show information about the repo:
 


### PR DESCRIPTION
Fixed wrong git-info heading level: h1 -> h2
