### PR TITLE
[RFC] git tag last, shows the latest semver revision

### DIFF
--- a/bin/git-tag
+++ b/bin/git-tag
@@ -6,6 +6,6 @@ function _gittag()
 }
 
 case $1 in
-	last) _gittag | tail -1;;
+	last) git describe | cut -d- -f1;;
 	*)    git tag $@ ;;
 esac


### PR DESCRIPTION
Often enough I would like to know what is the latest tag number, but there are no simple commands e.g. `git tag last` or `git tag --last`

In git version >=2.0, there is now a `--sort="version:refname"` which could be helpful for this command:

```
       --sort=<type>
           Sort in a specific order. Supported type is "refname" (lexicographic order), "version:refname" or "v:refname" (tag names are treated as versions). Prepend "-" to reverse
           sort order.
```
