### PR TITLE
Update homebrew URL and remove ‘buggy’ label

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ $ (cd /tmp && git clone --depth 1 https://github.com/visionmedia/git-extras.git 
 $ sudo port install git-extras
 ```
 
-[Brew](http://github.com/mxcl/homebrew/) (buggy):
+[Brew](http://brew.sh/):
 
 ```bash
 $ brew install git-extras


### PR DESCRIPTION
The ‘buggy’ label was added almost four years ago (bf25069fab320cfceec5321899fff5ba0c196892) without clarification, so we assume it was motivated by issues that have long since been fixed.
