### PR TITLE
use mixin to add 'is git repo' check for some commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ MANS = $(wildcard man/git-*.md)
 MAN_HTML = $(MANS:.md=.html)
 MAN_PAGES = $(MANS:.md=.1)
 
+COMMANDS_USED_WITHOUT_GIT_REPO = git-alias git-extras git-fork git-setup
+COMMANDS_USED_WITH_GIT_REPO = $(filter-out $(COMMANDS_USED_WITHOUT_GIT_REPO), \
+							  $(subst bin/, , $(BINS)))
+
 docs: $(MAN_HTML) $(MAN_PAGES)
 
 install:
@@ -13,9 +17,18 @@ install:
 	@mkdir -p $(DESTDIR)$(BINPREFIX)
 	@echo "... installing bins to $(DESTDIR)$(BINPREFIX)"
 	@echo "... installing man pages to $(DESTDIR)$(MANPREFIX)"
-	@$(foreach BIN, $(BINS), \
-		echo "... installing $(notdir $(BIN))"; \
-		cp -f $(BIN) $(DESTDIR)$(BINPREFIX); \
+	$(eval TEMPFILE := $(shell mktemp))
+	@# chmod from rw-------(default) to rwxrwxr-x, so that users can exec the scripts
+	@chmod 775 $(TEMPFILE)
+	@$(foreach COMMAND, $(COMMANDS_USED_WITH_GIT_REPO), \
+		echo "... installing $(COMMAND)"; \
+		head -1 bin/$(COMMAND) | cat - ./helper/is-git-repo > $(TEMPFILE); \
+		tail -n +2 bin/$(COMMAND) >> $(TEMPFILE); \
+		cp -f $(TEMPFILE) $(DESTDIR)$(BINPREFIX)/$(COMMAND); \
+	)
+	@$(foreach COMMAND, $(COMMANDS_USED_WITHOUT_GIT_REPO), \
+		echo "... installing $(COMMAND)"; \
+		cp -f bin/$(COMMAND) $(DESTDIR)$(BINPREFIX); \
 	)
 	cp -f man/git-*.1 $(DESTDIR)$(MANPREFIX)
 	@mkdir -p $(DESTDIR)/etc/bash_completion.d

--- a/helper/is-git-repo
+++ b/helper/is-git-repo
@@ -1,0 +1,14 @@
+#
+# check whether current directory is inside a git repository
+#
+
+is_git_repo() {
+  git rev-parse --show-toplevel > /dev/null 2>&1
+  result=$?
+  if test $result != 0; then
+    >&2 echo 'Not a git repo!'
+    exit $result
+  fi
+}
+
+is_git_repo


### PR DESCRIPTION
When those commands are used outside a git repo, 'Not a git repo!' will be
printed to stderr
