### PR TITLE
Fix #267, git-missing did not catch branch name.

### DIFF
--- a/bin/git-missing
+++ b/bin/git-missing
@@ -2,9 +2,9 @@
 
 # grab first two non-option arguments
 for arg in $*; do
-    if [[ $arg != -* ]]; then
-        test -z "$firstbranch" && firstbranch=$arg && continue
-        test -z "$secondbranch" && secondbranch=$arg && continue
+    if [ -n "${arg}" ]; then
+        test -z "$firstbranch" && firstbranch="${arg}" && continue
+        test -z "$secondbranch" && secondbranch="${arg}" && continue
     else
         # add anything else to a passthrough
         passthrough="$passthrough $arg"


### PR DESCRIPTION
It was a bug on my setup, the test did no detect the
branch name, so I change:
if [[ $arg != -\* ]]; then
by
if [ -n "${arg}" ]; then

According to test man page, -n:
«True if the length of string is non-zero.»

I also added quote and {} around the param,
to prevent bash expension around strange char.
