### PR TITLE
changing incorrect reference of tag to tags

### DIFF
--- a/bin/git-rename-tag
+++ b/bin/git-rename-tag
@@ -9,4 +9,4 @@ test -z $new && echo "new tag name required." 1>&2 && exit 1
 git tag $new $old
 git tag -d $old
 git push origin $new
-git push origin :refs/tag/$old
+git push origin :refs/tags/$old


### PR DESCRIPTION
The git-rename-tag script was referencing refs/tag.  I changed it to the correct reference of refs/tags
