### PR TITLE
Update `mktemp` command to work on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install:
 	@mkdir -p $(DESTDIR)$(BINPREFIX)
 	@echo "... installing bins to $(DESTDIR)$(BINPREFIX)"
 	@echo "... installing man pages to $(DESTDIR)$(MANPREFIX)"
-	$(eval TEMPFILE := $(shell mktemp))
+	$(eval TEMPFILE := $(shell mktemp -t git-extra.XXX))
 	@# chmod from rw-------(default) to rwxrwxr-x, so that users can exec the scripts
 	@chmod 775 $(TEMPFILE)
 	@$(foreach COMMAND, $(COMMANDS_USED_WITH_GIT_REPO), \


### PR DESCRIPTION
It seens like the same with this issue: https://github.com/StanAngeloff/lotte/issues/1
Therefore, I use the same way to fix it : https://github.com/StanAngeloff/lotte/commit/6a08b13148c4d39d8fbb04ac257183d0d67c04d6
