### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -336,8 +336,8 @@ Does the following:
 $ cd expect.js && git remote -v
 origin          git@github.com:<user>/expect.js (fetch)
 origin          git@github.com:<user>/expect.js (push)
-original        git@github.com:LearnBoost/expect.js (fetch)
-original        git@github.com:LearnBoost/expect.js (push)
+upstream        git@github.com:LearnBoost/expect.js (fetch)
+upstream        git@github.com:LearnBoost/expect.js (push)
 ```
 
 


### PR DESCRIPTION
Original repo remote is named 'upstream' and not 'original' as Readme suggests.
