### PR TITLE
added --no-color to git-delete-merged-branches

### DIFF
--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-git branch --merged | grep -v "\*" | grep -v master | xargs -n 1 git branch -d
+git branch --no-color --merged | grep -v "\*" | grep -v master | xargs -n 1 git branch -d


### PR DESCRIPTION
If you have colours turned on for displaying branches when you type `git branch` then the current `git-delete-merged-branches` will break. Adding the `--no-color` option fixes that.
