### PR TITLE
make release hook more flexible

### DIFF
--- a/bin/git-release
+++ b/bin/git-release
@@ -2,9 +2,18 @@
 
 hook() {
   local hook=.git/hooks/$1.sh
+  # compat without extname
+  if test ! -f $hook; then
+    hook=.git/hooks/$1
+  fi
+
   if test -f $hook; then
     echo "... $1"
-    . $hook
+    if test -x $hook; then
+      $hook
+    else
+      . $hook
+    fi
   fi
 }
 


### PR DESCRIPTION
1. fall back to find `pre-release` / `post-release` like other git hooks.
2. if the hook is executable, just run it, so we can run hooks written by node.
