### PR TITLE
make will not assume man pages already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,12 @@ install:
 		echo "... installing $(COMMAND)"; \
 		cp -f bin/$(COMMAND) $(DESTDIR)$(BINPREFIX); \
 	)
-	cp -f man/git-*.1 $(DESTDIR)$(MANPREFIX)
+	@if [ -z "$(wildcard man/git-*.1)" ]; then \
+		echo "WARNING: man pages not created, use 'make docs' (which requires 'ronn' ruby lib)"; \
+	else \
+		cp -f man/git-*.1 $(DESTDIR)$(MANPREFIX); \
+		echo "cp -f man/git-*.1 $(DESTDIR)$(MANPREFIX)"; \
+	fi
 	@mkdir -p $(DESTDIR)/etc/bash_completion.d
 	cp -f etc/bash_completion.sh $(DESTDIR)/etc/bash_completion.d/git-extras
 


### PR DESCRIPTION
They where removed from the repo by issue #291.

I think this is a bad choice, as it requires every user to generate their own man pages, which again requires them to use `ronn` (which they might not even have installed).

Why not just make it easy for your users, and provide them? Otherwise people _will_ ignore this, and loose the benefit of all the hard work you put into making them.

Should also be fairly easy to autogenerate them whenever one of the markdown files where changed.
