### PR TITLE
Add ref completion to git-missing.

### DIFF
--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -57,6 +57,11 @@ _git_ignore(){
   esac
 }
 
+_git_missing(){
+    # Suggest all known refs
+    __gitcomp "$(git for-each-ref --format='%(refname:short)')"
+}
+
 _git_refactor(){
   __git_extras_workflow "refactor"
 }


### PR DESCRIPTION
I find useful to get the ref completion in the git-missing command,
the behavior is the _like_ the one on 'git log --pretty' it use the
'git for-each-ref' command to provide shortname of :
- All local branches.
- All remote/branches.
- All tags.
- The stash.

The output can be a bit huge, but provide a standard git / bash completion.
