### PR TITLE
Don't assume that the remote is always origin and that the remote branch name is the same as the local one.

### DIFF
--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -3,18 +3,14 @@
 # Assert there is at least one branch provided
 test -z $1 && echo "branch required." 1>&2 && exit 1
 
-# Concatenate all branch references
-local_branches=""
-origin_branches=""
-origin_refs=""
 for branch in "$@"
 do
-  local_branches=$local_branches" $branch"
-  origin_branches=$origin_branches" origin/$branch"
-  origin_refs=$origin_refs" :refs/heads/$branch"
-done
+  remote=$(git config branch.$branch.remote)
+  test -z $remote && remote="origin"
+  ref=$(git config branch.$branch.merge)
+  test -z $ref && ref="refs/heads/$branch"
 
-# Delete all branches
-git branch -D $local_branches
-git branch -d -r $origin_branches
-git push origin $origin_refs
+  git branch -D $branch
+  git branch -d -r $remote/$branch
+  git push $remote :$ref
+done


### PR DESCRIPTION
For example, I can have a branch named `foo` that follows the branch `bar` in the remote `github`.
Without this patch `git-delete-branch foo` will try to delete `origin/foo` when it should really delete `github/bar`.

If the branch has no config it uses the default values, origin as remote and the same branch name.
