### PR TITLE
add enough X to fix #303.

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -47,10 +47,10 @@ if test "$CHANGELOG" = ""; then
     CHANGELOG='History.md';
   fi
 fi
-tmp=`mktemp -t $(basename $0)`
+tmp=`mktemp -t $(basename $0).XXX`
 printf "$HEAD" > $tmp
 git-changelog $GIT_LOG_OPTS --list >> $tmp
-printf '\n' >> $tmp
+printf '\n\n' >> $tmp
 if [ -f $CHANGELOG ]; then cat $CHANGELOG >> $tmp; fi
 mv -f $tmp $CHANGELOG
 test -n "$EDITOR" && $EDITOR $CHANGELOG


### PR DESCRIPTION
GNU mktemp requires at least three X in the last part of template.