### PR TITLE
Add git-authors

### DIFF
--- a/bin/git-authors
+++ b/bin/git-authors
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+LIST=false
+FILE=""
+
+if test "$1" = "-l" || test "$1" = "--list"; then
+  LIST=true
+else
+  FILE=$1
+  if test "$FILE" = ""; then
+    FILE=`ls | egrep 'authors|contributors' -i|head -n1`
+    if test "$FILE" = ""; then
+      FILE='AUTHORS'
+    fi
+  fi
+fi
+
+#
+# list authors sorted by number of commits (descending).
+#
+
+authors() {
+  git shortlog -sne | awk '{$1=""; sub(" ", ""); print}'
+}
+
+#
+# authors.
+#
+
+if $LIST; then
+  echo "$(authors)"
+else
+  authors >> $FILE
+  test -n "$EDITOR" && $EDITOR $FILE
+fi

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -10,6 +10,9 @@ _git_changelog(){
 
 _git_chore(){
   __git_extras_workflow "chore"
+
+_git_authors(){
+  __gitcomp "-l --list"
 }
 
 _git_contrib(){

--- a/man/git-authors.1
+++ b/man/git-authors.1
@@ -1,0 +1,61 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-AUTHORS" "1" "February 2015" "" "Git Extras"
+.
+.SH "NAME"
+\fBgit\-authors\fR \- Generate authors report
+.
+.SH "SYNOPSIS"
+\fBgit\-authors\fR [\-l, \-\-list]
+.
+.SH "DESCRIPTION"
+Populates the file matching \fIauthors|contributors \-i\fR with the authors of commits, according to the number of commits per author\. Opens the file in \fB$EDITOR\fR when set\.
+.
+.P
+See the "MAPPING AUTHORS" section of \fBgit\-shortlog\fR(1) to coalesce together commits by the same person\.
+.
+.SH "OPTIONS"
+\-l, \-\-list
+.
+.P
+Show authors\.
+.
+.SH "EXAMPLES"
+.
+.TP
+Updating AUTHORS file:
+.
+.IP
+$ git authors
+.
+.TP
+Listing authors:
+.
+.IP
+$ git authors \-\-list
+.
+.IP "" 4
+.
+.nf
+
+TJ Holowaychuk <tj@vision\-media\.ca>
+Tj Holowaychuk <tj@vision\-media\.ca>
+hemanth\.hm <hemanth\.hm@gmail\.com>
+Jonhnny Weslley <jw@jonhnnyweslley\.net>
+nickl\- <github@jigsoft\.co\.za>
+Leila Muhtasib <muhtasib@gmail\.com>
+.
+.fi
+.
+.IP "" 0
+
+.
+.SH "AUTHOR"
+Written by Titus Wormer <\fItituswormer@gmail\.com\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-authors.html
+++ b/man/git-authors.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-authors(1) - Generate authors report</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-authors(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-authors(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-authors</code> - <span class="man-whatis">Generate authors report</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-authors</code> [-l, --list]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>  Populates the file matching <em>authors|contributors -i</em> with the authors of commits, according to the number of commits per author.
+  Opens the file in <strong>$EDITOR</strong> when set.</p>
+
+<p>  See the "MAPPING AUTHORS" section of <strong>git-shortlog</strong>(1) to coalesce together commits by the same person.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -l, --list</p>
+
+<p>  Show authors.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<dl>
+<dt>Updating AUTHORS file:</dt><dd><p></p>
+
+<p>$ git authors</p></dd>
+<dt>Listing authors:</dt><dd><p></p>
+
+<p>$ git authors --list</p>
+
+<pre><code>TJ Holowaychuk &lt;tj@vision-media.ca&gt;
+Tj Holowaychuk &lt;tj@vision-media.ca&gt;
+hemanth.hm &lt;hemanth.hm@gmail.com&gt;
+Jonhnny Weslley &lt;jw@jonhnnyweslley.net&gt;
+nickl- &lt;github@jigsoft.co.za&gt;
+Leila Muhtasib &lt;muhtasib@gmail.com&gt;
+</code></pre></dd>
+</dl>
+
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Titus Wormer &lt;<a href="&#109;&#97;&#x69;&#x6c;&#x74;&#111;&#x3a;&#x74;&#x69;&#116;&#117;&#115;&#119;&#x6f;&#x72;&#109;&#101;&#x72;&#x40;&#x67;&#109;&#97;&#x69;&#x6c;&#x2e;&#x63;&#111;&#109;" data-bare-link="true">&#x74;&#105;&#116;&#x75;&#115;&#x77;&#111;&#x72;&#x6d;&#101;&#114;&#x40;&#103;&#x6d;&#x61;&#105;&#108;&#x2e;&#99;&#111;&#109;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>February 2015</li>
+    <li class='tr'>git-authors(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-authors.md
+++ b/man/git-authors.md
@@ -1,0 +1,50 @@
+git-authors(1) -- Generate authors report
+=================================================
+
+## SYNOPSIS
+
+`git-authors` [-l, --list]
+
+## DESCRIPTION
+
+  Populates the file matching _authors|contributors -i_ with the authors of commits, according to the number of commits per author.
+  Opens the file in **$EDITOR** when set.
+
+  See the "MAPPING AUTHORS" section of **git-shortlog**(1) to coalesce together commits by the same person.
+
+## OPTIONS
+
+  -l, --list
+
+  Show authors.
+
+## EXAMPLES
+
+  * Updating AUTHORS file:
+
+    $ git authors
+
+  * Listing authors:
+
+    $ git authors --list
+
+    ```
+    TJ Holowaychuk <tj@vision-media.ca>
+    Tj Holowaychuk <tj@vision-media.ca>
+    hemanth.hm <hemanth.hm@gmail.com>
+    Jonhnny Weslley <jw@jonhnnyweslley.net>
+    nickl- <github@jigsoft.co.za>
+    Leila Muhtasib <muhtasib@gmail.com>
+    ```
+
+## AUTHOR
+
+Written by Titus Wormer &lt;<tituswormer@gmail.com>&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;


### PR DESCRIPTION
A bit like **git-changelog**(1), or **git-summary**(1), but quite different.

Creates a simple list of authors, ordered by number of commits (descending). By default adding it to `/authors|contributors/i`, this can be configured by passing a path in, or omitted by passing in `-l` or `--list`, which would simple write the authors to stdout.
