### PR TITLE
Fix completion, add completion for git-delta

### DIFF
--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -10,6 +10,7 @@ _git_changelog(){
 
 _git_chore(){
   __git_extras_workflow "chore"
+}
 
 _git_authors(){
   __gitcomp "-l --list"

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -93,3 +93,7 @@ _git_squash(){
 _git_undo(){
    __gitcomp "--hard --soft -h -s"
 }
+
+_git_delta(){
+   __gitcomp "$(__git_heads)"
+}


### PR DESCRIPTION
The latest `bash-completion.sh` causes an error (`syntax error: unexpected end of file`) due to a missing brace. This PR fixes the completion script and adds branch autocomplete for `git delta`.
