### PR TITLE
Fix missing closing curly brance in `bash_completion.sh`

### DIFF
--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -10,6 +10,7 @@ _git_changelog(){
 
 _git_chore(){
   __git_extras_workflow "chore"
+}
 
 _git_authors(){
   __gitcomp "-l --list"


### PR DESCRIPTION
- Introduced in b0a6d04f9ff303a9864070eda45c7309e3789ad4;
- Comments: https://github.com/tj/git-extras/commit/b0a6d04f9ff303a9864070eda45c7309e3789ad4#commitcomment-9687275.