### PR TITLE
use standard git editor in git-authors & git-changelog

### DIFF
--- a/bin/git-authors
+++ b/bin/git-authors
@@ -2,6 +2,7 @@
 
 LIST=false
 FILE=""
+EDITOR=$(git var GIT_EDITOR)
 
 if test "$1" = "-l" || test "$1" = "--list"; then
   LIST=true

--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -4,6 +4,7 @@ FILE=""
 LIST=false
 TAG="n.n.n"
 GIT_LOG_OPTS=""
+EDITOR=$(git var GIT_EDITOR)
 
 while [ "$1" != "" ]; do
   case $1 in


### PR DESCRIPTION
The editor used will be chosen from the GIT_EDITOR environment variable,
the core.editor configuration variable, the VISUAL environment variable,
or the EDITOR environment variable (in that order).

That ensures that `git-changelog` and `git-authors` will use the same editor
as `git-commit`, `git-merge` etc.