### PR TITLE
changelog config

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -3,7 +3,9 @@
 FILE=""
 LIST=false
 TAG="n.n.n"
-GIT_LOG_OPTS=""
+GIT_LOG_OPTS=$(git config changelog.opts)
+GIT_LOG_FORMAT=$(git config changelog.format)
+test -z "$GIT_LOG_FORMAT" && GIT_LOG_FORMAT='  * %s'
 EDITOR=$(git var GIT_EDITOR)
 
 while [ "$1" != "" ]; do
@@ -25,21 +27,21 @@ while [ "$1" != "" ]; do
   shift
 done
 
-DATE=`date +'%Y-%m-%d'`
-HEAD="\n$TAG / $DATE\n"
-for i in $(seq 5 ${#HEAD}); do HEAD="$HEAD="; done
-HEAD="$HEAD\n\n"
-
 if $LIST; then
   lasttag=$(git rev-list --tags --max-count=1 2>/dev/null)
   version=$(git describe --tags --abbrev=0 $lasttag 2>/dev/null)
   if test -z "$version"; then
-    git log $GIT_LOG_OPTS --pretty="format:  * %s"
+    git log $GIT_LOG_OPTS --pretty=format:"${GIT_LOG_FORMAT}"
   else
-    git log $GIT_LOG_OPTS --pretty="format:  * %s" $version..
+    git log $GIT_LOG_OPTS --pretty=format:"${GIT_LOG_FORMAT}" $version..
   fi | sed 's/^  \* \*/  */g'
   exit
 fi
+
+DATE=`date +'%Y-%m-%d'`
+HEAD="\n$TAG / $DATE\n"
+for i in $(seq 5 ${#HEAD}); do HEAD="$HEAD="; done
+HEAD="$HEAD\n\n"
 
 CHANGELOG=$FILE
 if test "$CHANGELOG" = ""; then
@@ -51,7 +53,7 @@ fi
 tmp=`mktemp -t $(basename $0).XXX`
 printf "$HEAD" > $tmp
 git-changelog $GIT_LOG_OPTS --list >> $tmp
-printf '\n\n' >> $tmp
+printf '\n' >> $tmp
 if [ -f $CHANGELOG ]; then cat $CHANGELOG >> $tmp; fi
 mv -f $tmp $CHANGELOG
 test -n "$EDITOR" && $EDITOR $CHANGELOG


### PR DESCRIPTION
Added support for git config:
- `changelog.format` - let's you change the `--pretty` format
- `changelog.opts` - is passed directly to git-log when generating

The idea behind those is that by manipulating global (per machine) and local (per repo) git config you can make `git-changelog` work seamlessly with all the legacy formats people use in various projects.

The defaults remain unchanged - if you don't configure any options, the changelog behaves as it did before those changes.

Also: some  superfluous white-space removal - if it turns our I am seeing things just don't take that commit.