### PR TITLE
git-summary correctly displays project name

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+SUBDIRECTORY_OK=Yes
+source "$(git --exec-path)/git-sh-setup"
+cd_to_toplevel
+
 commit=""
 test $# -ne 0 && commit=$@
 project=${PWD##*/}


### PR DESCRIPTION
git-summary correctly displays project name when not executed in the top
level directory of a repository.  Fixes tj/git-extras#302.

Uses the git-sh-setup script to find top level directory and then uses
that directory name for the project name.