### PR TITLE
Allow empty initial commit when setup repo.

### DIFF
--- a/bin/git-setup
+++ b/bin/git-setup
@@ -13,4 +13,4 @@ mkdir -p "$dir" \
   && gitdirexists \
   && git init \
   && git add . \
-  && git commit -m 'Initial commit'
+  && git commit --allow-empty -m 'Initial commit'


### PR DESCRIPTION
When hit `git setup` in an empty directory, it doesn't create a commit. But often we need an empty initial commit for future rebasing and reseting, etc. Fixes #318.