### PR TITLE
Prevent strange input and environment variables from causing issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINS = $(wildcard bin/git-*)
 MANS = $(wildcard man/git-*.md)
 MAN_HTML = $(MANS:.md=.html)
 MAN_PAGES = $(MANS:.md=.1)
-LIB = "helper/git-extra-utility"
+LIB = "helper/reset-env" "helper/git-extra-utility"
 
 COMMANDS_USED_WITHOUT_GIT_REPO = git-alias git-extras git-fork git-setup
 COMMANDS_USED_WITH_GIT_REPO = $(filter-out $(COMMANDS_USED_WITHOUT_GIT_REPO), \

--- a/bin/git-alias
+++ b/bin/git-alias
@@ -2,6 +2,6 @@
 
 case $# in
   0) git config --get-regexp 'alias.*' | colrm 1 6 | sed 's/[ ]/ = /' | sort ;;
-  1) git alias | grep -e "$1" ;;
+  1) git alias | grep -e -- "$1" ;;
   *) git config --global "alias.$1" "$2" ;;
 esac

--- a/bin/git-contrib
+++ b/bin/git-contrib
@@ -4,6 +4,6 @@ user="$*"
 
 test -z "$user" && echo "user name required." 1>&2 && exit 1
 
-count=`git log --oneline --pretty="format: %an" | grep "$user" | wc -l`
+count=`git log --oneline --pretty="format: %an" | grep -- "$user" | wc -l`
 test $count -eq 0 && echo "$user did not contribute." && exit 1
-git shortlog | grep "$user (" -A $count
+git shortlog | grep -- "$user (" -A $count

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -32,7 +32,7 @@ function add_patterns {
   local file="${1/#~/$HOME}"
   for pattern in "${@:2}"; do
     echo "... adding '$pattern'"
-    (test -f "$file" && test "$pattern" && grep -q "$pattern" "$file") || echo "$pattern" >> "$file"
+    (test -f "$file" && test "$pattern" && grep -q -- "$pattern" "$file") || echo "$pattern" >> "$file"
   done
 }
 

--- a/bin/git-scp
+++ b/bin/git-scp
@@ -18,7 +18,7 @@ function _test_git_scp()
 function set_remote()
 {
 	remote=$1
-	if [ $(git remote | grep -c ^$remote$) -eq 0 ]
+	if [ $(git remote | grep -c -- ^$remote$) -eq 0 ]
 	then
 		COLOR_RED
 		echo "Remote $remote does not exist in your git config"

--- a/bin/git-squash
+++ b/bin/git-squash
@@ -14,7 +14,7 @@ is_commit_reference() {
 is_on_current_branch() {
   local commit_sha=`git rev-parse "$src"`
   git rev-list HEAD |
-    grep -q "$commit_sha"
+    grep -q -- "$commit_sha"
 }
 
 commit_if_msg_provided() {

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -69,7 +69,7 @@ _git_extras(){
 }
 
 __git_extras_workflow(){
-  __gitcomp "$(__git_heads | grep ^$1/ | sed s/^$1\\///g) finish"
+  __gitcomp "$(__git_heads | grep -- ^$1/ | sed s/^$1\\///g) finish"
 }
 
 _git_feature(){

--- a/helper/reset-env
+++ b/helper/reset-env
@@ -1,0 +1,2 @@
+# reset environment variables that could interfere with normal usage
+export GREP_OPTIONS=


### PR DESCRIPTION
GNU `grep` always looks for GREP_OPTIONS in the environment, and since
we don't unset it on run, this can result in some issues concerning the
usage of `grep` in scripts. So, we should unset it so nothing strange
can occur.

In addition, strange things can happen if you give `grep` input, and
it interprets it as an argument. So, we should use `--` whenever using
it for patterns that have a chance to be influenced by the user.