### PR TITLE
git-merge-repo

### DIFF
--- a/bin/git-merge-repo
+++ b/bin/git-merge-repo
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+repo=$1
+branch=$2
+prefix=$3
+flat=0
+
+if test $prefix = "."; then
+	prefix=$(mktemp -u 'git-merge-repo.XXXXXXX')
+	flat=1
+fi
+
+git subtree add -P "$prefix" "$repo" "$branch" "${@:4}"
+
+message=$(git log -1 --pretty=%B)
+
+if test $flat -eq 1; then
+	git stash -u
+	mv -i $prefix/* ./
+	git undo
+	git add .
+	git commit -am "$message"
+	git stash apply
+	rm -drf $prefix
+fi

--- a/man/git-merge-repo.1
+++ b/man/git-merge-repo.1
@@ -1,0 +1,51 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-MERGE\-REPO" "1" "April 2015" "" "Git Extras"
+.
+.SH "NAME"
+\fBgit\-merge\-repo\fR \- Merge two repo histories
+.
+.SH "SYNOPSIS"
+\fBgit\-merge\-repo\fR <repo> <branch> <directory> [\-\-squash]
+.
+.SH "DESCRIPTION"
+Merges a repository\'s history with the current repository, inside a specified directory\.
+.
+.P
+Optional \fB\-\-squash\fR flag skips the full history and generates only one commit for the merge\.
+.
+.SH "EXAMPLES"
+Merges a local repo\'s \fBfrontend\fR branch into the current repo\'s \fBweb\fR folder:
+.
+.IP "" 4
+.
+.nf
+
+$ git merge\-repo \.\./app/\.git frontend web
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Merges a remote repo\'s \fBmaster\fR branch into the current repo\'s folder:
+.
+.IP "" 4
+.
+.nf
+
+$ git merge\-repo git@github\.com:tj/git\-extras\.git master \.
+.
+.fi
+.
+.IP "" 0
+.
+.SH "AUTHOR"
+Written by Ivan Malopinsky <\fIhello@imsky\.co\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-merge-repo.html
+++ b/man/git-merge-repo.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-merge-repo(1) - Merge two repo histories</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-merge-repo(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-merge-repo(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-merge-repo</code> - <span class="man-whatis">Merge two repo histories</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-merge-repo</code> &lt;repo&gt; &lt;branch&gt; &lt;directory&gt; [--squash]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>Merges a repository's history with the current repository, inside a specified directory.</p>
+
+<p>Optional <code>--squash</code> flag skips the full history and generates only one commit for the merge.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>  Merges a local repo's <code>frontend</code> branch into the current repo's <code>web</code> folder:</p>
+
+<pre><code>$ git merge-repo ../app/.git frontend web
+</code></pre>
+
+<p>  Merges a remote repo's <code>master</code> branch into the current repo's folder:</p>
+
+<pre><code>$ git merge-repo git@github.com:tj/git-extras.git master .
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Ivan Malopinsky &lt;<a href="&#109;&#x61;&#105;&#108;&#116;&#x6f;&#x3a;&#104;&#x65;&#x6c;&#x6c;&#x6f;&#x40;&#105;&#109;&#x73;&#x6b;&#x79;&#x2e;&#x63;&#111;" data-bare-link="true">&#104;&#x65;&#108;&#108;&#x6f;&#x40;&#105;&#x6d;&#x73;&#107;&#x79;&#46;&#99;&#x6f;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>April 2015</li>
+    <li class='tr'>git-merge-repo(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-merge-repo.md
+++ b/man/git-merge-repo.md
@@ -1,0 +1,34 @@
+git-merge-repo(1) -- Merge two repo histories
+=============================================
+
+## SYNOPSIS
+
+`git-merge-repo` &lt;repo&gt; &lt;branch&gt; &lt;directory&gt; [--squash]
+
+## DESCRIPTION
+
+Merges a repository's history with the current repository, inside a specified directory.
+
+Optional `--squash` flag skips the full history and generates only one commit for the merge.
+
+## EXAMPLES
+
+  Merges a local repo's `frontend` branch into the current repo's `web` folder:
+
+    $ git merge-repo ../app/.git frontend web
+
+  Merges a remote repo's `master` branch into the current repo's folder:
+
+    $ git merge-repo git@github.com:tj/git-extras.git master .
+
+## AUTHOR
+
+Written by Ivan Malopinsky &lt;<hello@imsky.co>&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;


### PR DESCRIPTION
This command merges two repo histories. There's an optional `--squash` flag and an optional "flat merge" mode - if the incoming repo's directory is set to `.`, then a squash-like commit is added for the files added to the current directory.