### PR TITLE
correct the broken regex

### DIFF
--- a/bin/git-line-summary
+++ b/bin/git-line-summary
@@ -8,7 +8,7 @@ project=${PWD##*/}
 function single_file {
   while read data
   do
-	if [[ $(file $data) = *text ]]; then   # 
+	if [[ $(file $data) = *text* ]]; then   # 
       git blame --line-porcelain $data | sed -n 's/^author //p';
     fi
   done


### PR DESCRIPTION
'*text' only matches string ended with 'text'. So it matches 'ASCII text', but does not match 'ASCII text executable'. Before, `git summary --line` just counts for plain text file, now we fix it.