### PR TITLE
Fix git tag substring extraction for bash 3.2.

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -219,7 +219,7 @@ commitList() {
     [[ -z "${_tag}" ]] && continue
     # strip out tags form ()
     # git v2.2.0+ supports '%D', like '%d' without the " (", ")" wrapping. One day we should use it instead.
-    _tag="${_tag:2:-1}"
+    _tag="${_tag# }"; _tag="${_tag//[()]/}"
     # trap tag if it points to last commit (HEAD)
     _tag="${_tag##HEAD, }"
     # strip out any additional tags pointing to same commit, remove tag label


### PR DESCRIPTION
Found it and fixed it. I tested this on:

- CentOS 7
- OSX Bash 4.3.33
- OSX Bash 3.2.57

Output appears to be consistent.