### PR TITLE
git-effort: replace "wc | cut" with "wc | awk"

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -139,7 +139,7 @@ trap show_cursor_and_cleanup INT
 heading
 
 effort "${files[@]}" | tee $tmp
-test "$(wc -l $tmp | cut -d' ' -f1 )" -gt 1 && sort_effort
+test "$(wc -l $tmp | awk '{print $1}')" -gt 1 && sort_effort
 echo
 
 show_cursor_and_cleanup


### PR DESCRIPTION
It looks "cut" may have different behaviour, e.g. BSD one works the way
git-effort doesn't expect. "awk" looks to be one of possible fixes here.