### PR TITLE
add install.cmd for installation on windows

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -26,3 +26,23 @@ One-liner:
 ```bash
 curl -sSL http://git.io/git-extras-setup | sudo bash /dev/stdin
 ```
+
+## Windows (use it at your own risk)
+
+First, please install `Git for Windows 2.x` from 'https://github.com/git-for-windows/git/releases'
+and the basic [msys2][1].
+Second, clone the `git-extras` repo into any folder you like.
+```bash
+git clone https://github.com/tj/git-extras.git
+```
+After that, open the script `install.cmd` in the folder with any text editor you like.
+Modify the `PREFIX` variable to where your `Git for Windows 2.x` is installed.
+For example, I install it in the folder called `C:\SCM\PortableGit` and
+the `PREFIX` should be `C:\SCM\PortableGit\mingw64` (for 64-bit release)
+or `C:\SCM\PortableGit\mingw32` (for 32-bit release).
+Third, execute the `install.cmd` directly or in the command prompt.
+Last, please copy `colrm.exe` and `column.exe` from `folder-your-msys2-installed/usr/bin` to
+`folder-your-git-installed/usr/bin`.
+Enjoy `git-extras`!
+
+[1]: http://sourceforge.net/projects/msys2/

--- a/install.cmd
+++ b/install.cmd
@@ -17,9 +17,9 @@ FOR /R %GITEXTRAS%\bin %%i in (*.*) DO (
 
 FOR %%i in (%COMMANDS_WITHOUT_REPO%) DO (
 	ECHO #!/usr/bin/env bash > %PREFIX%\bin\%%i
-    TYPE %GITEXTRAS%\helper\reset-env >> %PREFIX%\bin\%%i
-    TYPE %GITEXTRAS%\helper\git-extra-utility >> %PREFIX%\bin\%%i
-    MORE +2 %GITEXTRAS%\bin\%%i >> %PREFIX%\bin\%%i
+	TYPE %GITEXTRAS%\helper\reset-env >> %PREFIX%\bin\%%i
+	TYPE %GITEXTRAS%\helper\git-extra-utility >> %PREFIX%\bin\%%i
+	MORE +2 %GITEXTRAS%\bin\%%i >> %PREFIX%\bin\%%i
 )
 
 ROBOCOPY %GITEXTRAS%\man %HTMLDIR% *.html

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,27 @@
+@ECHO OFF
+SET PREFIX=C:\SCM\PortableGit\mingw64
+SET HTMLDIR=%PREFIX%\share\doc\git-doc
+SET GITEXTRAS=%~dp0
+
+IF NOT EXIST %PREFIX%\bin MKDIR %PREFIX%\bin
+
+SET COMMANDS_WITHOUT_REPO=git-alias git-extras git-fork git-setup
+
+FOR /R %GITEXTRAS%\bin %%i in (*.*) DO (
+	ECHO #!/usr/bin/env bash > %PREFIX%\bin\%%~ni
+	TYPE %GITEXTRAS%\helper\reset-env >> %PREFIX%\bin\%%~ni
+	TYPE %GITEXTRAS%\helper\git-extra-utility >> %PREFIX%\bin\%%~ni
+	TYPE %GITEXTRAS%\helper\is-git-repo >> %PREFIX%\bin\%%~ni
+	MORE +2 %GITEXTRAS%\bin\%%~ni >> %PREFIX%\bin\%%~ni
+)
+
+FOR %%i in (%COMMANDS_WITHOUT_REPO%) DO (
+	ECHO #!/usr/bin/env bash > %PREFIX%\bin\%%i
+    TYPE %GITEXTRAS%\helper\reset-env >> %PREFIX%\bin\%%i
+    TYPE %GITEXTRAS%\helper\git-extra-utility >> %PREFIX%\bin\%%i
+    MORE +2 %GITEXTRAS%\bin\%%i >> %PREFIX%\bin\%%i
+)
+
+ROBOCOPY %GITEXTRAS%\man %HTMLDIR% *.html
+
+@ECHO ON


### PR DESCRIPTION
The script install.cmd has two environment variables `PREFIX` and `HTMLDIR`.
`PREFIX` is where your git is installed and `HTMLDIR` is the location of html files under `PREFIX`.
This script is written for the latest `Git for Windows 2.x` installed from https://github.com/git-for-windows/git/releases.
Moreover, the executables `colrm.exe` and `column.exe` are needed from [msys2][1]'s installtion directory.

[1]: http://sourceforge.net/projects/msys2/