### PR TITLE
effort: Make coloring respect --above. Fix #74

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -68,7 +68,7 @@ effort() {
     test $commits -le $above && exit 0
 
     # commits
-    color_for $commits
+    color_for $(( $commits - $above ))
     len=${#file}
     dot="."
     f_dot="$file"
@@ -81,7 +81,7 @@ effort() {
 
     # active days
     active=`active_days "$commit_dates"`
-    color_for $active
+    color_for $(( $active - $above ))
     msg="$msg $(printf "\033[${color}m %d\033[0m\n" $active)"
     echo "$msg"
 }


### PR DESCRIPTION
As said in the issue "When --above is 20, then 20 commits should be gray".