### PR TITLE
[RFC] effort: Allow sending options to log. Fix #326

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -107,12 +107,32 @@ sort_effort() {
   < $tmp sort -rn -k 2
 }
 
-# --above <n-commits>
+#
+# parse arguments
+# we handle --above, and send the rest to git log
+#
+while [[ $# > 0 ]] ; do
+  key=$1
+  declare -a log_args
 
-if test "$1" = "--above"; then
-  shift; above=$1
+  case $key in
+    --above)
+            shift; above=$1
+            ;;
+        --*)
+            log_args+=$1
+            ;;
+         --)
+            shift
+            break # files from here on
+            ;;
+          *)
+            break # files from here on
+            ;;
+  esac
   shift
-fi
+done
+
 
 # [file ...]
 

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 
 tmp=$(git_extra_mktemp)
-above='0'
+above=0
 color=
 
 #
-# get date for the given <commit>
+# get dates for the given <commit>
 #
-
-date() {
-  git log --pretty='format: %ad' --date=short $1
+dates() {
+  eval "git log --pretty='format: %ad' --date=short $args_to_git_log "$1""
 }
 
 #
@@ -28,7 +27,7 @@ show_cursor_and_cleanup() {
   printf '\033[?25h'
   printf '\033[m\n'
   rm "$tmp" > /dev/null 2>&1
-  exit 1
+  exit 0
 }
 
 #
@@ -60,7 +59,9 @@ color_for() {
 
 effort() {
     file=$1
-    local commit_dates=`date $file`
+    local commit_dates
+    commit_dates=`dates $file`
+    [ $? -gt 0 ] && exit 255
     commits=`wc -l <<<"$(echo "$commit_dates")"`
     color='90'
 
@@ -107,32 +108,51 @@ sort_effort() {
   < $tmp sort -rn -k 2
 }
 
-#
-# parse arguments
-# we handle --above, and send the rest to git log
-#
-while [[ $# > 0 ]] ; do
-  key=$1
-  declare -a log_args
+above_index=0
+has_above=false
+next_is_above=false
+num_files=0
+for i in `seq ${#@}`
+do
+  cur="${!i}"
 
-  case $key in
+  if "$next_is_above" ; then
+    above="$cur"
+    next_is_above=false
+    continue
+  fi
+
+  case "$cur" in
     --above)
-            shift; above=$1
+            if "$has_above" ; then
+              echo "error: --above can only be specified one time" 1>&2
+              exit 1
+            fi
+            next_is_above=true
+            has_above=true
+            above_index=$(( i - 1 ))
             ;;
         --*)
-            log_args+=$1
-            ;;
-         --)
-            shift
-            break # files from here on
             ;;
           *)
-            break # files from here on
+            num_files=$(( num_files + 1 ))
             ;;
   esac
-  shift
 done
 
+args_before_above=`printf " %q" "${@:1:$above_index}"`
+
+num_args=$(( i - num_files ))
+if $has_above ; then offset=2 ; else offset=0 ; fi
+from=$(( 1 + above_index + offset ))
+len=$(( num_args - $(( above_index + offset)) ))
+args_after_above=`printf " %q" "${@:$from:$len}"`
+
+args_to_git_log="${args_before_above#\ \'\'}${args_after_above#\ \'\'}"
+
+shift $num_args
+
+export args_to_git_log
 
 # [file ...]
 
@@ -156,8 +176,9 @@ trap show_cursor_and_cleanup INT
 export -f effort
 export -f color_for
 export -f active_days
-export -f date
+export -f dates
 export above
+export log_args
 
 heading
 # send files to effort

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -61,7 +61,18 @@ _git_delete_tag(){
 }
 
 _git_effort(){
-  __gitcomp "--above"
+  __git_has_doubledash && return
+
+  case "$cur" in
+  --*)
+    __gitcomp "
+      --above
+      $__git_log_common_options
+      $__git_log_shortlog_options
+      "
+    return
+    ;;
+  esac
 }
 
 _git_extras(){

--- a/man/git-effort.1
+++ b/man/git-effort.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-EFFORT" "1" "April 2015" "" ""
+.TH "GIT\-EFFORT" "1" "July 2015" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-effort\fR \- Show effort statistics on file(s)
 .
 .SH "SYNOPSIS"
-\fBgit\-effort\fR [\-\-above <value>] [<filename>]
+\fBgit\-effort\fR [\-\-above <value>] [<options>] [<filename>]
 .
 .SH "DESCRIPTION"
 Shows effort statistics about files in the repository\.
@@ -26,6 +26,18 @@ Display includes:
 .
 .P
 Ignore files with commits <= a value\.
+.
+.P
+Run
+.
+.br
+man \-P \'less +/Commit\e Limiting\' git\-log
+.
+.br
+to read about options to limit which commits are counted\.
+.
+.P
+Note: \fBgit\-effort\fR does not accept commit ranges\.
 .
 .P
 <filename>
@@ -53,6 +65,18 @@ $ git effort \-\-above 5
   git\-summary                                   8          6
   git\-delete\-branch                             8          6
   git\-repl                                      7          5
+
+
+$ git effort \-\-after="one year ago" \-\-above 5 \-\-author="Leila Muhtasib"
+
+  file                                          commits    active days
+
+  git\-extras                                    15         12
+  git\-release                                   6          9
+  git\-effort                                    6          2
+  git\-ignore                                    4          4
+  git\-changelog                                 3          5
+  git\-graft                                     2          3
 .
 .fi
 .

--- a/man/git-effort.html
+++ b/man/git-effort.html
@@ -65,7 +65,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-effort(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-effort(1)</li>
   </ol>
 
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-effort</code> [--above &lt;value&gt;] [&lt;filename&gt;]</p>
+<p><code>git-effort</code> [--above &lt;value&gt;] [&lt;options&gt;] [&lt;filename&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -91,6 +91,12 @@
 <p>  --above &lt;value&gt;</p>
 
 <p>  Ignore files with commits &lt;= a value.</p>
+
+<p>  Run<br />
+  man -P 'less +/Commit\ Limiting' git-log<br />
+  to read about options to limit which commits are counted.</p>
+
+<p>  Note: <code>git-effort</code> does not accept commit ranges.</p>
 
 <p>  &lt;filename&gt;</p>
 
@@ -113,11 +119,23 @@
   git-summary                                   8          6
   git-delete-branch                             8          6
   git-repl                                      7          5
+
+
+$ git effort --after="one year ago" --above 5 --author="Leila Muhtasib"
+
+  file                                          commits    active days
+
+  git-extras                                    15         12
+  git-release                                   6          9
+  git-effort                                    6          2
+  git-ignore                                    4          4
+  git-changelog                                 3          5
+  git-graft                                     2          3
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#109;&#97;&#x69;&#108;&#116;&#x6f;&#x3a;&#x6d;&#117;&#104;&#116;&#x61;&#x73;&#x69;&#x62;&#64;&#x67;&#x6d;&#97;&#105;&#x6c;&#x2e;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#x6d;&#117;&#x68;&#116;&#97;&#115;&#105;&#98;&#x40;&#103;&#x6d;&#97;&#105;&#108;&#46;&#99;&#111;&#x6d;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#97;&#105;&#108;&#x74;&#111;&#58;&#109;&#117;&#x68;&#x74;&#97;&#x73;&#x69;&#98;&#x40;&#x67;&#109;&#97;&#x69;&#108;&#46;&#99;&#111;&#x6d;" data-bare-link="true">&#x6d;&#117;&#104;&#x74;&#97;&#x73;&#105;&#98;&#x40;&#103;&#x6d;&#97;&#x69;&#108;&#46;&#99;&#x6f;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -130,7 +148,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2015</li>
+    <li class='tc'>July 2015</li>
     <li class='tr'>git-effort(1)</li>
   </ol>
 

--- a/man/git-effort.md
+++ b/man/git-effort.md
@@ -3,7 +3,7 @@ git-effort(1) -- Show effort statistics on file(s)
 
 ## SYNOPSIS
 
-`git-effort` [--above &lt;value&gt;] [&lt;filename&gt;]
+`git-effort` [--above &lt;value&gt;] [&lt;options&gt;] [&lt;filename&gt;]
 
 ## DESCRIPTION
 
@@ -18,6 +18,12 @@ git-effort(1) -- Show effort statistics on file(s)
   --above &lt;value&gt;
 
   Ignore files with commits &lt;= a value.
+
+  Run  
+  man -P 'less +/Commit\ Limiting' git-log  
+  to read about options to limit which commits are counted.  
+
+  Note: `git-effort` does not accept commit ranges.  
 
   &lt;filename&gt;
 
@@ -41,6 +47,17 @@ git-effort(1) -- Show effort statistics on file(s)
       git-delete-branch                             8          6
       git-repl                                      7          5
 
+
+    $ git effort --after="one year ago" --above 5 --author="Leila Muhtasib"
+
+      file                                          commits    active days
+
+      git-extras                                    15         12
+      git-release                                   6          9
+      git-effort                                    6          2
+      git-ignore                                    4          4
+      git-changelog                                 3          5
+      git-graft                                     2          3
 
 ## AUTHOR
 


### PR DESCRIPTION
Putting this up for discussion.

This makes it possible for `git effort` to take other options other than `--above`.
These get sent to `git log` in effort().

So this is possible now:
`git effort --since="one year ago" --until="one week ago" --above 10 mydir/*`

Invalid options is handled by git log, which I think is nice.

Note though: The original issue wanted to have these options to speed up the process by limiting the commit history, but there is no remarkable performance gain by this as far as I were able to see.  

TODO if this is wanted:
 - [x] Man pages
 - [x] Completion