### PR TITLE
[RFC] Improve speed of git effort

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -62,12 +62,12 @@ color_for() {
 #
 
 effort() {
-  for file in "$@"; do
+    file=$1
     commits=`git log --oneline "$file" | wc -l`
     color='90'
 
     # ignore <= --above
-    test $commits -le $above && continue
+    test $commits -le $above && exit 0
 
     # commits
     color_for $commits
@@ -79,13 +79,13 @@ effort() {
       i=$(($i+1))
     done
 
-    printf "  \033[${color}m%s %-10d" $f_dot $commits
+    msg=$(printf "  \033[${color}m%s %-10d" $f_dot $commits)
 
     # active days
     active=`active_days "$file"`
     color_for $active
-    printf "\033[${color}m %d\033[0m\n" $active
-  done
+    msg="$msg $(printf "\033[${color}m %d\033[0m\n" $active)"
+    echo "$msg"
 }
 
 #
@@ -134,11 +134,18 @@ fi
 hide_cursor
 trap show_cursor_and_cleanup INT
 
-# loop files
+# export functions so subshells can call them
+export -f effort
+export -f color_for
+export -f active_days
+export -f date
+export above
 
 heading
+# send files to effort
+printf "%s\0" "${files[@]}" | xargs -0 -n 1 -P 4 -I % bash -c "effort \"%\"" | tee $tmp
 
-effort "${files[@]}" | tee $tmp
+# if more than one file, sort and print
 test "$(wc -l $tmp | awk '{print $1}')" -gt 1 && sort_effort
 echo
 

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -9,7 +9,7 @@ color=
 #
 
 date() {
-  git log --pretty='format: %ai' $1 | cut -d ' ' -f 2
+  git log --pretty='format: %ad' --date=short $1
 }
 
 #

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -61,7 +61,7 @@ color_for() {
 effort() {
     file=$1
     local commit_dates=`date $file`
-    commits=`echo "$commit_dates" | wc -l`
+    commits=`wc -l <<<"$(echo "$commit_dates")"`
     color='90'
 
     # ignore <= --above

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -104,7 +104,7 @@ sort_effort() {
   clear
   echo
   heading
-  cat $tmp | sort -rn -k 2
+  < $tmp sort -rn -k 2
 }
 
 # --above <n-commits>

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -36,10 +36,7 @@ show_cursor_and_cleanup() {
 #
 
 active_days() {
-  date $1 | uniq | awk '
-    { sum += 1 }
-    END { print sum }
-  '
+  uniq <(echo "$1") | wc -l
 }
 
 #
@@ -63,7 +60,8 @@ color_for() {
 
 effort() {
     file=$1
-    commits=`git log --oneline "$file" | wc -l`
+    local commit_dates=`date $file`
+    commits=`echo "$commit_dates" | wc -l`
     color='90'
 
     # ignore <= --above
@@ -82,7 +80,7 @@ effort() {
     msg=$(printf "  \033[${color}m%s %-10d" $f_dot $commits)
 
     # active days
-    active=`active_days "$file"`
+    active=`active_days "$commit_dates"`
     color_for $active
     msg="$msg $(printf "\033[${color}m %d\033[0m\n" $active)"
     echo "$msg"


### PR DESCRIPTION
Speedup is gained by two main edits
 - run effort in parallel
 - remove one call to git log (we can use one for both statistics)


This PR will conflict with #390 and/or #391, so I will do a rebase if those are merged.


I have tested this with the Hugo blog engine, with 24 seconds on git effort vs. 7 seconds with this patch. (Those numbers are obviously to be taken with a grain of salt) This was on my computer with two physical cores.