### PR TITLE
Catch "HEAD -> master" when creating the changelog

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -221,7 +221,7 @@ commitList() {
     # git v2.2.0+ supports '%D', like '%d' without the " (", ")" wrapping. One day we should use it instead.
     _tag="${_tag# }"; _tag="${_tag//[()]/}"
     # trap tag if it points to last commit (HEAD)
-    _tag="${_tag##HEAD, }"
+    _tag="${_tag#HEAD*, }"
     # strip out any additional tags pointing to same commit, remove tag label
     _tag="${_tag%%,*}"; _tag="${_tag#tag: }"
     # strip out tags that are actually feature branches (git-flow support)


### PR DESCRIPTION
Fixes #395.

`git log` may report `(HEAD -> master, tag:...)` instead of `(HEAD, tag:...)`.

    3582b9a$        2015-07-19$      (HEAD -> master, tag: v0.6, tag: lightweight)

This causes changelog to fail:

```
$ git changelog -x -p
fatal: ambiguous argument 'HEAD -> master..': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```


This PR will fix this issue by matching anything coming after HEAD up to the *first* comma.