### PR TITLE
effort: don't count untouched files

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -62,6 +62,13 @@ effort() {
     local commit_dates
     commit_dates=`dates $file`
     [ $? -gt 0 ] && exit 255
+
+    # Ensure it's not just an empty line
+    if [ -z "`head -c 1 <<<$(echo $commit_dates)`" ]
+    then
+      exit 0
+    fi
+
     commits=`wc -l <<<"$(echo "$commit_dates")"`
     color='90'
 


### PR DESCRIPTION
This makes `git effort` able to differentiate between a file that was touched by 1 commit and one that was not touched by a commit.

So if you run  
`git effort --author="Nicolai Skogheim"`  
it will list only files that was touched, and not pretend that every single file has at least one commit touching it.