### PR TITLE
effort: error out on bad value to --above

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -140,6 +140,12 @@ do
   esac
 done
 
+# Exit if above-value is not an int
+if [ -z "${above##*[!0-9]*}" ] ; then
+  echo "error: argument to --above was not an integer" 1>&2
+  exit 1
+fi
+
 args_before_above=`printf " %q" "${@:1:$above_index}"`
 
 num_args=$(( i - num_files ))


### PR DESCRIPTION
Just because the output is so massive and ugly if you pass anything other than an integer to `--above`, we should exit early with a message.