### PR TITLE
contrib: refactor, and conform to git

### DIFF
--- a/bin/git-contrib
+++ b/bin/git-contrib
@@ -4,6 +4,4 @@ user="$*"
 
 test -z "$user" && echo "user name required." 1>&2 && exit 1
 
-count=`git log --oneline --pretty="format: %an" | grep -- "$user" | wc -l`
-test $count -eq 0 && echo "$user did not contribute." && exit 1
-git shortlog | grep -A $count -- "$user ("
+git shortlog --author="$user"


### PR DESCRIPTION
`git contrib` is much more complex than it needs to be.

Moreover, it will now behave like other git commands - output in a pager if that's the default setting for the user, and to STDOUT otherwise.
Also, you could't do `git --no-pager contrib`, but now you can.

I am certain there are even more benefits by doing it this way.  
Edit: Yes, now you can glob on names.
Ex: `git contrib "Nicolai*"`