### PR TITLE
Refactor alias

### DIFF
--- a/bin/git-alias
+++ b/bin/git-alias
@@ -2,6 +2,6 @@
 
 case $# in
   0) git config --get-regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort ;;
-  1) git alias | grep -e -- "$1" ;;
-  *) git config --global "alias.$1" "$2" ;;
+  1) git alias | grep -e "$1" ;;
+  *) git config --global alias."$1" "$2" ;;
 esac

--- a/man/git-alias.md
+++ b/man/git-alias.md
@@ -3,12 +3,19 @@ git-alias(1) -- Define, search and show aliases
 
 ## SYNOPSIS
 
-`git-alias` [&lt;alias-name&gt; &lt;command&gt;]|[&lt;search-term&gt;]
+`git-alias`
+`git-alias` &lt;search-term&gt;
+`git-alias` &lt;alias-name&gt; &lt;command&gt;
 
 ## DESCRIPTION
 
+  List all aliases, show one alias, or set one (global) alias.
 
 ## OPTIONS
+
+  &lt;search-term&gt;
+
+  The pattern used for search aliases.
 
   &lt;alias-name&gt;
 
@@ -17,10 +24,6 @@ git-alias(1) -- Define, search and show aliases
   &lt;command&gt;
 
   The command for which you are creating an alias.
-
-  &lt;search-term&gt;
-
-  The pattern used for search aliases.
 
 
 ## EXAMPLES


### PR DESCRIPTION
Showing one alias stopped working after 5b1ac3ccc69f65f8670746f5e0b9c14653cf6685
This removes the double dash that was added.

Also some small alterations on the man page for `git alias` while I were at it.