### PR TITLE
changelog: wording in docs

### DIFF
--- a/man/git-changelog.1
+++ b/man/git-changelog.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-CHANGELOG" "1" "April 2015" "" ""
+.TH "GIT\-CHANGELOG" "1" "August 2015" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-changelog\fR \- Generate a changelog report
@@ -28,7 +28,7 @@ The name of the output file\. By default the new file will be \fIHistory\.md\fR 
 \-a, \-\-all
 .
 .P
-Retrieve all commits\. Ignores \-s|\-\-start\-tag and \-f|\-\-final\-tag options (if set)\.
+Retrieve all commits\. Overrides \-s|\-\-start\-tag and \-f|\-\-final\-tag options\.
 .
 .P
 \-l, \-\-list
@@ -64,7 +64,7 @@ Filters out merge commits (commits with more than 1 parent) from generated chang
 \-p, \-\-prune\-old
 .
 .P
-Replace existing changelog entirely with newly generated content, thereby disabling the default behavior of appending the content of any detected changelog to the end of newly generated content\.
+Replace existing changelog entirely with newly generated content\.
 .
 .P
 \-x, \-\-stdout

--- a/man/git-changelog.html
+++ b/man/git-changelog.html
@@ -65,7 +65,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-changelog(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-changelog(1)</li>
   </ol>
 
@@ -93,7 +93,7 @@
 
 <p>  -a, --all</p>
 
-<p>  Retrieve all commits. Ignores -s|--start-tag and -f|--final-tag options (if set).</p>
+<p>  Retrieve all commits. Overrides -s|--start-tag and -f|--final-tag options.</p>
 
 <p>  -l, --list</p>
 
@@ -117,7 +117,7 @@
 
 <p>  -p, --prune-old</p>
 
-<p>  Replace existing changelog entirely with newly generated content, thereby disabling the default behavior of appending the content of any detected changelog to the end of newly generated content.</p>
+<p>  Replace existing changelog entirely with newly generated content.</p>
 
 <p>  -x, --stdout</p>
 
@@ -159,7 +159,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Mark Eissler &lt;<a href="&#109;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x6d;&#x61;&#x72;&#x6b;&#64;&#x6d;&#x69;&#120;&#x74;&#x75;&#114;&#x2e;&#99;&#111;&#109;" data-bare-link="true">&#109;&#x61;&#x72;&#107;&#64;&#109;&#x69;&#x78;&#116;&#117;&#x72;&#x2e;&#x63;&#111;&#109;</a>&gt;</p>
+<p>Written by Mark Eissler &lt;<a href="&#109;&#97;&#105;&#108;&#x74;&#111;&#58;&#x6d;&#x61;&#114;&#107;&#x40;&#x6d;&#x69;&#120;&#x74;&#x75;&#x72;&#46;&#x63;&#111;&#109;" data-bare-link="true">&#109;&#x61;&#x72;&#107;&#x40;&#109;&#105;&#120;&#116;&#x75;&#114;&#46;&#x63;&#x6f;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -172,7 +172,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2015</li>
+    <li class='tc'>August 2015</li>
     <li class='tr'>git-changelog(1)</li>
   </ol>
 

--- a/man/git-changelog.md
+++ b/man/git-changelog.md
@@ -20,7 +20,7 @@ git-changelog(1) -- Generate a changelog report
 
   -a, --all
 
-  Retrieve all commits. Ignores -s|--start-tag and -f|--final-tag options (if set).
+  Retrieve all commits. Overrides -s|--start-tag and -f|--final-tag options.
 
   -l, --list
 
@@ -44,7 +44,7 @@ git-changelog(1) -- Generate a changelog report
 
   -p, --prune-old
 
-  Replace existing changelog entirely with newly generated content, thereby disabling the default behavior of appending the content of any detected changelog to the end of newly generated content.
+  Replace existing changelog entirely with newly generated content.
 
   -x, --stdout
 


### PR DESCRIPTION
I think this is a slightly better way to put it.

Also, I think we could remove most of the examples as many of them are very trivial and well explained in the options section anyway. With me on that?