### PR TITLE
fork: original->upstream in docs

### DIFF
--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-FORK" "1" "April 2015" "" ""
+.TH "GIT\-FORK" "1" "August 2015" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-fork\fR \- Fork a repo on github
@@ -19,7 +19,7 @@ forks the repo on github
 clones the repo into the current dir
 .
 .IP "3." 4
-adds the original repo as a remote
+adds the original repo as a remote called upstream
 .
 .IP "" 0
 .
@@ -62,8 +62,8 @@ $ cd expect\.js && git remote \-v
 
   origin          git@github\.com:<user>/expect\.js (fetch)
   origin          git@github\.com:<user>/expect\.js (push)
-  original        git@github\.com:LearnBoost/expect\.js (fetch)
-  original        git@github\.com:LearnBoost/expect\.js (push)
+  upstream        git@github\.com:LearnBoost/expect\.js (fetch)
+  upstream        git@github\.com:LearnBoost/expect\.js (push)
 .
 .fi
 .

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -64,7 +64,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-fork(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-fork(1)</li>
   </ol>
 
@@ -82,9 +82,9 @@
 <p>  Fork the given github repo. Like clone but forks first.</p>
 
 <ol>
-<li>forks the repo on github</li>
-<li>clones the repo into the current dir</li>
-<li>adds the original repo as a remote</li>
+<li> forks the repo on github</li>
+<li> clones the repo into the current dir</li>
+<li> adds the original repo as a remote called upstream</li>
 </ol>
 
 
@@ -108,13 +108,13 @@ $ cd expect.js &amp;&amp; git remote -v
 
   origin          git@github.com:&lt;user>/expect.js (fetch)
   origin          git@github.com:&lt;user>/expect.js (push)
-  original        git@github.com:LearnBoost/expect.js (fetch)
-  original        git@github.com:LearnBoost/expect.js (push)
+  upstream        git@github.com:LearnBoost/expect.js (fetch)
+  upstream        git@github.com:LearnBoost/expect.js (push)
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Andrew Griffiths &lt;<a href="&#x6d;&#97;&#105;&#108;&#116;&#111;&#x3a;&#109;&#97;&#105;&#x6c;&#x40;&#97;&#x6e;&#x64;&#114;&#101;&#119;&#x67;&#x72;&#x69;&#x66;&#102;&#x69;&#116;&#104;&#115;&#x6f;&#110;&#108;&#x69;&#x6e;&#x65;&#x2e;&#99;&#x6f;&#109;" data-bare-link="true">&#x6d;&#97;&#105;&#108;&#x40;&#x61;&#110;&#100;&#x72;&#x65;&#119;&#x67;&#114;&#x69;&#x66;&#x66;&#105;&#116;&#x68;&#115;&#x6f;&#110;&#x6c;&#x69;&#110;&#101;&#46;&#x63;&#111;&#109;</a>&gt;</p>
+<p>Written by Andrew Griffiths &lt;<a href="&#109;&#x61;&#105;&#108;&#116;&#111;&#x3a;&#x6d;&#97;&#x69;&#108;&#64;&#97;&#110;&#100;&#114;&#101;&#119;&#x67;&#x72;&#105;&#x66;&#102;&#105;&#x74;&#104;&#x73;&#111;&#x6e;&#108;&#105;&#x6e;&#101;&#46;&#x63;&#111;&#109;" data-bare-link="true">&#x6d;&#x61;&#105;&#108;&#64;&#97;&#110;&#100;&#114;&#101;&#119;&#103;&#114;&#x69;&#102;&#x66;&#x69;&#x74;&#104;&#x73;&#111;&#110;&#108;&#105;&#110;&#x65;&#46;&#99;&#x6f;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -127,7 +127,7 @@ $ cd expect.js &amp;&amp; git remote -v
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2015</li>
+    <li class='tc'>August 2015</li>
     <li class='tr'>git-fork(1)</li>
   </ol>
 

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -11,7 +11,7 @@ git-fork(1) -- Fork a repo on github
 
   1. forks the repo on github
   2. clones the repo into the current dir
-  3. adds the original repo as a remote
+  3. adds the original repo as a remote called upstream
 
 ## EXAMPLE
 
@@ -31,8 +31,8 @@ git-fork(1) -- Fork a repo on github
 
       origin          git@github.com:<user>/expect.js (fetch)
       origin          git@github.com:<user>/expect.js (push)
-      original        git@github.com:LearnBoost/expect.js (fetch)
-      original        git@github.com:LearnBoost/expect.js (push)
+      upstream        git@github.com:LearnBoost/expect.js (fetch)
+      upstream        git@github.com:LearnBoost/expect.js (push)
 
 
 ## AUTHOR


### PR DESCRIPTION
The man page for `git fork` said that `git fork` adds the forked repo as a remote called 'original'.
Change that to upstream, as that is what it actually is called.