### PR TITLE
fork: http-urls had colon instead of slash

### DIFF
--- a/bin/git-fork
+++ b/bin/git-fork
@@ -26,9 +26,9 @@ curl -X POST -u "$user" "https://api.github.com/repos/$owner/$project/forks"
 [ $? = 0 ] || abort "fork failed"
 
 # clone forked repo into current dir
-git clone "https://github.com:$user/$project" "$project"
+git clone "https://github.com/$user/$project" "$project"
 
 # add reference to origin fork so can merge in upstream changes
 cd "$project"
-git remote add upstream "https://github.com:$owner/$project"
+git remote add upstream "https://github.com/$owner/$project"
 git fetch upstream


### PR DESCRIPTION
13842de9e0ceb86d6de3ea51fb2740d1e9262819 broke `git fork` since the conversion from ssl to https wasn't finished. git tried to fetch from urls like `https://github.com:user/repo`
This is just replacing those colons with forward slashes.