### PR TITLE
effort: fix active days always 1

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -35,7 +35,7 @@ show_cursor_and_cleanup() {
 #
 
 active_days() {
-  uniq <<<$(echo "$1") | wc -l
+  echo "$1" | uniq | wc -l
 }
 
 #


### PR DESCRIPTION
Introduced in cdb773c06 (Fix error on FreeBSD with process substitution)
when trying to squash a bug.
This fix should be valid for that bug as well.

I have no idea how I missed this. But all is well now.

The problem was that for any input, `git effort` would report `active days` to be 1.