### PR TITLE
effort: document that it takes any path, not just filenames

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -54,13 +54,13 @@ color_for() {
 }
 
 #
-# compute the effort of the given <file ...>
+# compute the effort of the given <path ...>
 #
 
 effort() {
-    file=$1
+    path=$1
     local commit_dates
-    commit_dates=`dates "$file"`
+    commit_dates=`dates "$path"`
     [ $? -gt 0 ] && exit 255
 
     # Ensure it's not just an empty line
@@ -77,9 +77,9 @@ effort() {
 
     # commits
     color_for $(( $commits - $above ))
-    len=${#file}
+    len=${#path}
     dot="."
-    f_dot="$file"
+    f_dot="$path"
     i=0 ; while test $i -lt $((45-$len)) ; do
       f_dot=$f_dot$dot
       i=$(($i+1))
@@ -100,7 +100,7 @@ effort() {
 
 heading() {
   echo
-  printf "  %-45s %-10s %s\n" 'file' 'commits' 'active days'
+  printf "  %-45s %-10s %s\n" 'path' 'commits' 'active days'
   echo
 }
 
@@ -118,7 +118,7 @@ sort_effort() {
 above_index=0
 has_above=false
 next_is_above=false
-num_files=0
+num_paths=0
 
 # Some implementations of `seq` gives "1\n0" for seq 0
 if [ $# -gt 0 ] ; then
@@ -145,7 +145,7 @@ if [ $# -gt 0 ] ; then
           --*)
               ;;
             *)
-              num_files=$(( num_files + 1 ))
+              num_paths=$(( num_paths + 1 ))
               ;;
     esac
   done
@@ -159,7 +159,7 @@ fi
 
 args_before_above=`printf " %q" "${@:1:$above_index}"`
 
-num_args=$(( i - num_files ))
+num_args=$(( i - num_paths ))
 if $has_above ; then offset=2 ; else offset=0 ; fi
 from=$(( 1 + above_index + offset ))
 len=$(( num_args - $(( above_index + offset)) ))
@@ -171,15 +171,15 @@ shift $num_args
 
 export args_to_git_log
 
-# [file ...]
+# [path ...]
 
-declare -a files=()
+declare -a paths=()
 if test $# -ge 1; then
-  files=("$@")
+  paths=("$@")
 else
   save_ifs=$IFS
   IFS=`echo -en "\n\b"`
-  files=(`git ls-files`)
+  paths=(`git ls-files`)
   IFS=$safe_ifs
   unset save_ifs
 fi
@@ -207,10 +207,10 @@ if [ $? -eq 0 ] ; then
 fi
 
 heading
-# send files to effort
-printf "%s\0" "${files[@]}" | xargs -0 -n 1 -P 4 -I % bash $bash_params -c "effort \"%\"" | tee $tmp
+# send paths to effort
+printf "%s\0" "${paths[@]}" | xargs -0 -n 1 -P 4 -I % bash $bash_params -c "effort \"%\"" | tee $tmp
 
-# if more than one file, sort and print
+# if more than one path, sort and print
 test "$(wc -l $tmp | awk '{print $1}')" -gt 1 && sort_effort
 echo
 

--- a/man/git-effort.1
+++ b/man/git-effort.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-EFFORT" "1" "July 2015" "" "Git Extras"
+.TH "GIT\-EFFORT" "1" "August 2015" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-effort\fR \- Show effort statistics on file(s)
 .
 .SH "SYNOPSIS"
-\fBgit\-effort\fR [\-\-above <value>] [<options>] [<filename>]
+\fBgit\-effort\fR [\-\-above <value>] [<options>] [[\-\-] <path>\.\.\.]
 .
 .SH "DESCRIPTION"
 Shows effort statistics about files in the repository\.
@@ -40,10 +40,10 @@ to read about options to limit which commits are counted\.
 Note: \fBgit\-effort\fR does not accept commit ranges\.
 .
 .P
-<filename>
+[\-\-] <path>\.\.\.
 .
 .P
-Only display effort statistics for a specific filename\.
+Only count commits that touches the given paths\.
 .
 .SH "EXAMPLES"
 Displays "effort" statistics:
@@ -72,11 +72,29 @@ $ git effort \-\-after="one year ago" \-\-above 5 \-\-author="Leila Muhtasib"
   file                                          commits    active days
 
   git\-extras                                    15         12
-  git\-release                                   6          9
+  git\-release                                   6          4
   git\-effort                                    6          2
   git\-ignore                                    4          4
-  git\-changelog                                 3          5
-  git\-graft                                     2          3
+  git\-changelog                                 3          2
+  git\-graft                                     2          2
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Showing statistics on directories is also possible
+.
+.IP "" 4
+.
+.nf
+
+$ git effort bin man
+
+  file                                          commits    active days
+
+  bin\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\. 406         232
+  man\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\. 118         80
 .
 .fi
 .

--- a/man/git-effort.1
+++ b/man/git-effort.1
@@ -46,6 +46,9 @@ Note: \fBgit\-effort\fR does not accept commit ranges\.
 Only count commits that touches the given paths\.
 .
 .SH "EXAMPLES"
+Note: Output will first appear unsorted, then the screen is cleared and the sorted list is output\. The initial unsorted list is not shown in the examples for brevity\.
+.
+.P
 Displays "effort" statistics:
 .
 .IP "" 4

--- a/man/git-effort.html
+++ b/man/git-effort.html
@@ -104,6 +104,9 @@
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
+<p> Note: Output will first appear unsorted, then the screen is cleared and the sorted
+ list is output. The initial unsorted list is not shown in the examples for brevity.</p>
+
 <p> Displays "effort" statistics:</p>
 
 <pre><code>$ git effort --above 5
@@ -145,7 +148,7 @@ $ git effort --after="one year ago" --above 5 --author="Leila Muhtasib"
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#109;&#x61;&#105;&#x6c;&#x74;&#x6f;&#58;&#109;&#x75;&#x68;&#x74;&#97;&#x73;&#x69;&#x62;&#64;&#x67;&#x6d;&#97;&#105;&#x6c;&#46;&#x63;&#111;&#x6d;" data-bare-link="true">&#x6d;&#117;&#104;&#116;&#97;&#x73;&#x69;&#x62;&#x40;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#99;&#111;&#109;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#x61;&#x69;&#x6c;&#116;&#x6f;&#58;&#109;&#x75;&#104;&#x74;&#97;&#115;&#x69;&#x62;&#64;&#103;&#x6d;&#x61;&#x69;&#108;&#46;&#x63;&#111;&#x6d;" data-bare-link="true">&#x6d;&#117;&#x68;&#116;&#97;&#x73;&#x69;&#x62;&#64;&#x67;&#x6d;&#97;&#x69;&#108;&#x2e;&#x63;&#x6f;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-effort.html
+++ b/man/git-effort.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-effort</code> [--above &lt;value&gt;] [&lt;options&gt;] [&lt;filename&gt;]</p>
+<p><code>git-effort</code> [--above &lt;value&gt;] [&lt;options&gt;] [[--] &lt;path&gt;...]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -98,9 +98,9 @@
 
 <p>  Note: <code>git-effort</code> does not accept commit ranges.</p>
 
-<p>  &lt;filename&gt;</p>
+<p>  [--] &lt;path&gt;...</p>
 
-<p>  Only display effort statistics for a specific filename.</p>
+<p>  Only count commits that touches the given paths.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -126,16 +126,26 @@ $ git effort --after="one year ago" --above 5 --author="Leila Muhtasib"
   file                                          commits    active days
 
   git-extras                                    15         12
-  git-release                                   6          9
+  git-release                                   6          4
   git-effort                                    6          2
   git-ignore                                    4          4
-  git-changelog                                 3          5
-  git-graft                                     2          3
+  git-changelog                                 3          2
+  git-graft                                     2          2
+</code></pre>
+
+<p> Showing statistics on directories is also possible</p>
+
+<pre><code>$ git effort bin man
+
+  file                                          commits    active days
+
+  bin.......................................... 406         232
+  man.......................................... 118         80
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#97;&#105;&#108;&#x74;&#111;&#58;&#109;&#117;&#x68;&#x74;&#97;&#x73;&#x69;&#98;&#x40;&#x67;&#109;&#97;&#x69;&#108;&#46;&#99;&#111;&#x6d;" data-bare-link="true">&#x6d;&#117;&#104;&#x74;&#97;&#x73;&#105;&#98;&#x40;&#103;&#x6d;&#97;&#x69;&#108;&#46;&#99;&#x6f;&#x6d;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#109;&#x61;&#105;&#x6c;&#x74;&#x6f;&#58;&#109;&#x75;&#x68;&#x74;&#97;&#x73;&#x69;&#x62;&#64;&#x67;&#x6d;&#97;&#105;&#x6c;&#46;&#x63;&#111;&#x6d;" data-bare-link="true">&#x6d;&#117;&#104;&#116;&#97;&#x73;&#x69;&#x62;&#x40;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#99;&#111;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -148,7 +158,7 @@ $ git effort --after="one year ago" --above 5 --author="Leila Muhtasib"
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2015</li>
+    <li class='tc'>August 2015</li>
     <li class='tr'>git-effort(1)</li>
   </ol>
 

--- a/man/git-effort.md
+++ b/man/git-effort.md
@@ -53,11 +53,12 @@ git-effort(1) -- Show effort statistics on file(s)
       file                                          commits    active days
 
       git-extras                                    15         12
-      git-release                                   6          9
+      git-release                                   6          4
       git-effort                                    6          2
       git-ignore                                    4          4
-      git-changelog                                 3          5
-      git-graft                                     2          3
+      git-changelog                                 3          2
+      git-graft                                     2          2
+
 
 ## AUTHOR
 

--- a/man/git-effort.md
+++ b/man/git-effort.md
@@ -59,6 +59,15 @@ git-effort(1) -- Show effort statistics on file(s)
       git-changelog                                 3          2
       git-graft                                     2          2
 
+ Showing statistics on directories is also possible
+
+    $ git effort bin man
+
+      file                                          commits    active days
+
+      bin.......................................... 406         232
+      man.......................................... 118         80
+
 
 ## AUTHOR
 

--- a/man/git-effort.md
+++ b/man/git-effort.md
@@ -3,7 +3,7 @@ git-effort(1) -- Show effort statistics on file(s)
 
 ## SYNOPSIS
 
-`git-effort` [--above &lt;value&gt;] [&lt;options&gt;] [&lt;filename&gt;]
+`git-effort` [--above &lt;value&gt;] [&lt;options&gt;] [[--] &lt;path&gt;...]
 
 ## DESCRIPTION
 
@@ -25,9 +25,9 @@ git-effort(1) -- Show effort statistics on file(s)
 
   Note: `git-effort` does not accept commit ranges.  
 
-  &lt;filename&gt;
+  [--] &lt;path&gt;...
 
-  Only display effort statistics for a specific filename.
+  Only count commits that touches the given paths.
 
 ## EXAMPLES
 

--- a/man/git-effort.md
+++ b/man/git-effort.md
@@ -31,6 +31,9 @@ git-effort(1) -- Show effort statistics on file(s)
 
 ## EXAMPLES
 
+ Note: Output will first appear unsorted, then the screen is cleared and the sorted
+ list is output. The initial unsorted list is not shown in the examples for brevity.
+
  Displays "effort" statistics:
 
     $ git effort --above 5


### PR DESCRIPTION
In addition to what the title says
 - Adjust some of the numbers in one of the examples to be realistic
 - Add a note in the docs that the examples omit showing the initial list output by `git effort`, which is the same list, but unsorted.