### PR TITLE
Set default make task to be install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ docclean:
 	rm -f man/*.1
 	rm -f man/*.html
 
-.PHONY: docs clean docclean install uninstall
+.PHONY: default docs clean docclean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ COMMANDS_USED_WITHOUT_GIT_REPO = git-alias git-extras git-fork git-setup
 COMMANDS_USED_WITH_GIT_REPO = $(filter-out $(COMMANDS_USED_WITHOUT_GIT_REPO), \
 							  $(subst bin/, , $(BINS)))
 
+default: install
+
 docs: $(MAN_HTML) $(MAN_PAGES)
 
 install:


### PR DESCRIPTION
The default task for `make` now is `docs`, just because that task is defined earliest in the file.
This commit sets the default task explicitly to `install`. This is to avoid confusing people who want to build git-extras themselves.

This partially adresses #269