### PR TITLE
abort git-alias when too many arguments given.

### DIFF
--- a/bin/git-alias
+++ b/bin/git-alias
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+usage() {
+cat <<HERE
+usage: git alias                         # list all aliases
+   or: git alias <search-pattern>        # show aliases matching pattern
+   or: git alias <alias-name> <command>  # alias a command
+HERE
+}
+
 case $# in
   0) git config --get-regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort ;;
   1) git alias | grep -e "$1" ;;
-  *) git config --global alias."$1" "$2" ;;
+  2) git config --global alias."$1" "$2" ;;
+  *) >&2 echo "error: too many arguments." && usage && exit 1 ;;
 esac

--- a/man/git-alias.1
+++ b/man/git-alias.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-ALIAS" "1" "August 2015" "" "Git Extras"
+.TH "GIT\-ALIAS" "1" "August 2015" "" ""
 .
 .SH "NAME"
 \fBgit\-alias\fR \- Define, search and show aliases
@@ -10,7 +10,7 @@
 \fBgit\-alias\fR
 .
 .br
-\fBgit\-alias\fR <search\-term>
+\fBgit\-alias\fR <search\-pattern>
 .
 .br
 \fBgit\-alias\fR <alias\-name> <command>
@@ -19,7 +19,7 @@
 List all aliases, show one alias, or set one (global) alias\.
 .
 .SH "OPTIONS"
-<search\-term>
+<search\-pattern>
 .
 .P
 The pattern used to search aliases\.

--- a/man/git-alias.1.html
+++ b/man/git-alias.1.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-alias(1) - Define, search and show aliases</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-alias(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-alias(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-alias</code> - <span class="man-whatis">Define, search and show aliases</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-alias</code><br />
+<code>git-alias</code> &lt;search-pattern&gt;<br />
+<code>git-alias</code> &lt;alias-name&gt; &lt;command&gt;</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>  List all aliases, show one alias, or set one (global) alias.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  &lt;search-pattern&gt;</p>
+
+<p>  The pattern used to search aliases.</p>
+
+<p>  &lt;alias-name&gt;</p>
+
+<p>  The name of the alias to create.</p>
+
+<p>  &lt;command&gt;</p>
+
+<p>  The command for which you are creating an alias.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p> Defining a new alias:</p>
+
+<pre><code>$ git alias last "cat-file commit HEAD"
+</code></pre>
+
+<p> Providing only one argument, <code>git-alias</code> searchs for aliases matching the given value:</p>
+
+<pre><code>$ git alias ^la
+last = cat-file commit HEAD
+</code></pre>
+
+<p> <code>git-alias</code> will show all aliases if no argument is given:</p>
+
+<pre><code>$ git alias
+s = status
+amend = commit --amend
+rank = shortlog -sn --no-merges
+whatis = show -s --pretty='tformat:%h (%s, %ad)' --date=short
+whois = !sh -c 'git log -i -1 --pretty="format:%an &lt;%ae>
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Jonhnny Weslley &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#x3a;&#x6a;&#x77;&#64;&#106;&#x6f;&#x6e;&#104;&#110;&#x6e;&#121;&#119;&#101;&#115;&#108;&#108;&#x65;&#x79;&#46;&#x6e;&#101;&#116;" data-bare-link="true">&#x6a;&#x77;&#x40;&#x6a;&#x6f;&#110;&#104;&#x6e;&#110;&#x79;&#119;&#x65;&#115;&#108;&#108;&#x65;&#121;&#x2e;&#110;&#101;&#x74;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>August 2015</li>
+    <li class='tr'>git-alias(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-alias.md
+++ b/man/git-alias.md
@@ -4,7 +4,7 @@ git-alias(1) -- Define, search and show aliases
 ## SYNOPSIS
 
 `git-alias`  
-`git-alias` &lt;search-term&gt;  
+`git-alias` &lt;search-pattern&gt;  
 `git-alias` &lt;alias-name&gt; &lt;command&gt;  
 
 ## DESCRIPTION
@@ -13,7 +13,7 @@ git-alias(1) -- Define, search and show aliases
 
 ## OPTIONS
 
-  &lt;search-term&gt;
+  &lt;search-pattern&gt;
 
   The pattern used to search aliases.
 


### PR DESCRIPTION
Avoid incorrect usage probably because of the missing quotes, like "git
alias cm checkout master"