### PR TITLE
merge-into: change --ff option to --ff-only

### DIFF
--- a/bin/git-merge-into
+++ b/bin/git-merge-into
@@ -5,11 +5,11 @@ current_branch() {
 }
 
 usage() {
-    echo "Usage: git merge-into [src] dest [--ff]"
+    echo "Usage: git merge-into [src] dest [--ff-only]"
 }
 
 cur_branch=$(current_branch)
-if [ "${!#}" == '--ff' ]; then
+if [ "${!#}" == '--ff-only' ]; then
     case $# in
         2 ) # dest --ff
             git push "$(git rev-parse --show-toplevel)" "$cur_branch":"$1";;

--- a/man/git-merge-into.1
+++ b/man/git-merge-into.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-MERGE\-INTO" "1" "April 2015" "" ""
+.TH "GIT\-MERGE\-INTO" "1" "August 2015" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-merge\-into\fR \- Merge one branch into another
 .
 .SH "SYNOPSIS"
-\fBgit merge\-into\fR [src] <dest> [\-\-ff]
+\fBgit merge\-into\fR [src] <dest> [\-\-ff\-only]
 .
 .SH "DESCRIPTION"
 Merge one branch into another, and keep yourself on current branch\. If src branch not given, it will merge current one to dest\.
@@ -25,10 +25,10 @@ The name of the branch will be merged into\. If this not given, use current bran
 The name of the branch to merge into\.
 .
 .P
-\-\-ff
+\-\-ff\-only
 .
 .P
-Try to use \fBgit push\fR instead of \fBgit merge\fR\. Only work on fast\-forward mode\.
+Refuse to merge and exit with a non\-zero status unless the current HEAD is already up\-to\-date or the merge can be resolved as a fast\-forward\.
 .
 .SH "EXAMPLES"
 Assume the following history exists and the current branch is src:
@@ -64,7 +64,7 @@ After running \fBgit merge\-into dest\fR, it will look like this:
 The \fBH\fR commit will record the merge result, just like what \fBgit merge\fR does\. And \fBsrc\fR is still the current branch\.
 .
 .P
-The default implementation of \fBmerge\-into\fR use \fBgit checkout\fR and \fBgit merge\fR, which may cause temporary change in the working tree\. If you make sure your branch can be merged fast\-forward, add \fB\-\-ff\fR to avoid files change\.
+The default implementation of \fBmerge\-into\fR use \fBgit checkout\fR and \fBgit merge\fR, which may cause temporary change in the working tree\. If you make sure your branch can be merged fast\-forward, add \fB\-\-ff\-only\fR to avoid files change\.
 .
 .SH "AUTHOR"
 Written by spacewander <\fIspacewanderlzx@gmail\.com\fR>

--- a/man/git-merge-into.html
+++ b/man/git-merge-into.html
@@ -65,7 +65,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-merge-into(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-merge-into(1)</li>
   </ol>
 
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git merge-into</code> [src] &lt;dest&gt; [--ff]</p>
+<p><code>git merge-into</code> [src] &lt;dest&gt; [--ff-only]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -92,9 +92,10 @@
 
 <p>  The name of the branch to merge into.</p>
 
-<p>  --ff</p>
+<p>  --ff-only</p>
 
-<p>  Try to use <code>git push</code> instead of <code>git merge</code>. Only work on fast-forward mode.</p>
+<p>  Refuse to merge and exit with a non-zero status unless the current HEAD is
+  already up-to-date or the merge can be resolved as a fast-forward.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -117,11 +118,11 @@ And <code>src</code> is still the current branch.</p>
 
 <p>The default implementation of <code>merge-into</code> use <code>git checkout</code> and <code>git merge</code>,
 which may cause temporary change in the working tree. If you make sure your
-branch can be merged fast-forward, add <code>--ff</code> to avoid files change.</p>
+branch can be merged fast-forward, add <code>--ff-only</code> to avoid files change.</p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by spacewander &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#116;&#x6f;&#x3a;&#115;&#112;&#x61;&#99;&#x65;&#119;&#x61;&#110;&#x64;&#x65;&#114;&#108;&#x7a;&#120;&#x40;&#103;&#x6d;&#97;&#x69;&#108;&#x2e;&#x63;&#111;&#109;" data-bare-link="true">&#115;&#x70;&#x61;&#x63;&#x65;&#119;&#97;&#x6e;&#x64;&#x65;&#114;&#108;&#x7a;&#x78;&#64;&#103;&#109;&#97;&#105;&#108;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
+<p>Written by spacewander &lt;<a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#58;&#115;&#112;&#97;&#99;&#x65;&#x77;&#97;&#x6e;&#100;&#101;&#114;&#108;&#x7a;&#120;&#x40;&#x67;&#109;&#x61;&#x69;&#108;&#x2e;&#99;&#111;&#109;" data-bare-link="true">&#x73;&#x70;&#x61;&#x63;&#101;&#119;&#x61;&#x6e;&#x64;&#x65;&#x72;&#108;&#x7a;&#120;&#64;&#x67;&#109;&#97;&#x69;&#x6c;&#x2e;&#99;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -134,7 +135,7 @@ branch can be merged fast-forward, add <code>--ff</code> to avoid files change.<
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2015</li>
+    <li class='tc'>August 2015</li>
     <li class='tr'>git-merge-into(1)</li>
   </ol>
 

--- a/man/git-merge-into.md
+++ b/man/git-merge-into.md
@@ -3,7 +3,7 @@ git-merge-into(1) -- Merge one branch into another
 
 ## SYNOPSIS
 
-`git merge-into` [src] &lt;dest&gt; [--ff]
+`git merge-into` [src] &lt;dest&gt; [--ff-only]
 
 ## DESCRIPTION
 
@@ -19,9 +19,11 @@ Merge one branch into another, and keep yourself on current branch. If src branc
 
   The name of the branch to merge into.
 
-  --ff
+  --ff-only
 
-  Try to use `git push` instead of `git merge`. Only work on fast-forward mode.
+  Refuse to merge and exit with a non-zero status unless the current HEAD is
+  already up-to-date or the merge can be resolved as a fast-forward.
+
 
 ## EXAMPLES
 
@@ -42,7 +44,7 @@ And `src` is still the current branch.
 
 The default implementation of `merge-into` use `git checkout` and `git merge`, 
 which may cause temporary change in the working tree. If you make sure your 
-branch can be merged fast-forward, add `--ff` to avoid files change.
+branch can be merged fast-forward, add `--ff-only` to avoid files change.
 
 ## AUTHOR
 


### PR DESCRIPTION
Before you merge this: Should we have a special error message for `--ff`? Currently, we print usage if you pass `--ff` to `git merge-into` **with** this patch.

The best would be if we could accept it silently, as it is the default for `git merge`. But that could confuse users who have adapted to use `--ff` with `git merge-into`.

What do you think?