### PR TITLE
remove duplicate checkout

### DIFF
--- a/bin/git-bug
+++ b/bin/git-bug
@@ -10,6 +10,5 @@ else
     echo "too many arguments; if not finishing a bug, only <name> of new bug is expected" && exit 1
   fi
   branch=bug/$1
-  git checkout -b $branch &> /dev/null
-  test -n $? && git checkout $branch &> /dev/null
+  git checkout -b $branch
 fi

--- a/bin/git-chore
+++ b/bin/git-chore
@@ -10,6 +10,5 @@ else
     echo "too many arguments; if not finishing a chore, only <name> of new chore is expected" && exit 1
   fi
   branch=chore/$1
-  git checkout -b $branch &> /dev/null
-  test -n $? && git checkout $branch &> /dev/null
+  git checkout -b $branch
 fi

--- a/bin/git-feature
+++ b/bin/git-feature
@@ -20,6 +20,5 @@ else
   else 
     branch=feature/$1
   fi
-  git checkout -b $branch &> /dev/null
-  test -n $? && git checkout $branch &> /dev/null
+  git checkout -b $branch
 fi

--- a/bin/git-refactor
+++ b/bin/git-refactor
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Removed unnecessary git checkout for bug, feature and refactor
 
 if test "$1" = "finish"; then
   test -z $2 && echo "refactor <name> required." 1>&2 && exit 1
@@ -11,6 +10,5 @@ else
     echo "too many arguments; if not finishing a refactor, only <name> of new refactoring is expected" && exit 1
   fi
   branch=refactor/$1
-  git checkout -b $branch &> /dev/null
-  test -n $? && git checkout $branch &> /dev/null
+  git checkout -b $branch
 fi


### PR DESCRIPTION
And also print checkout info to user.
I think it is no need to conceal checkout message. The message is not unexpected. And when `checkout` is failed(as uncommited change, existed branch, etc.), people can know what happened.