### PR TITLE
effort, summary: Correctly estimate the number of active days

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -42,7 +42,7 @@ show_cursor_and_cleanup() {
 #
 
 active_days() {
-  echo "$1" | uniq | wc -l
+  echo "$1" | sort -r | uniq | wc -l
 }
 
 #

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -21,7 +21,7 @@ date() {
 #
 
 active_days() {
-  date $1 | uniq | awk '
+  date $1 | sort -r | uniq | awk '
     { sum += 1 }
     END { print sum }
   '


### PR DESCRIPTION
The output of `git log` is not exactly in chronological order. The
default sort option (--date-order) is described in the man page as
follows:

    Show no parents before all of its children are shown, but otherwise
    show commits in the commit timestamp order.

The `uniq` program will only remove duplicate lines if they follow each
other. In order for this to work correctly, we need to ensure that the
list of dates is exactly in chronological order. There doesn't seem to
be a `git log` option to achieve this, but we can use the `sort`
program. I used reverse sort (`sort -r`) since the output will be roughly
reverse-sorted already.

It's also worth noting that the default --date-order option sorts by
commit date, but git-summary uses *author* date (%ai). Passing
--author-date-order doesn't fix this issue, though, so I didn't change
that.

At the time of writing, this change reduces the number of 'active days'
for git-extras.git from 367 to 331.