### PR TITLE
Makefile: escape $ used inside eval as shell variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install:
 	@mkdir -p $(DESTDIR)$(BINPREFIX)
 	@echo "... installing bins to $(DESTDIR)$(BINPREFIX)"
 	@echo "... installing man pages to $(DESTDIR)$(MANPREFIX)"
-	$(eval TEMPFILE := $(shell mktemp -q ${TMPDIR:-/tmp}/git-extras.XXXXXX 2>/dev/null || mktemp -q))
+	$(eval TEMPFILE := $(shell mktemp -q $${TMPDIR:-/tmp}/git-extras.XXXXXX 2>/dev/null || mktemp -q))
 	@# chmod from rw-------(default) to rwxrwxr-x, so that users can exec the scripts
 	@chmod 775 $(TEMPFILE)
 	$(eval EXISTED_ALIASES := $(shell \


### PR DESCRIPTION
Follows up on #383, which introduced a build problem on OS X.

In an `eval` in a `Makefile`, shell variables need to have their `$` escaped as `$$` so they're expanded by the called shell instead of by `make`.

Currently, the build is breaking for me like this.

```
[~/local/opp/git/git-extras on ⇄ master]
$ make PREFIX=/tmp/git-extras install
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix
... installing bins to /tmp/git-extras/bin
... installing man pages to /tmp/git-extras/share/man/man1
usage:	chmod [-fhv] [-R [-H | -L | -P]] [-a | +a | =a  [i][# [ n]]] mode|entry file ...
	chmod [-fhv] [-R [-H | -L | -P]] [-E | -C | -N | -i | -I] file ...
make: *** [install] Error 1
[✘ ~/local/opp/git/git-extras on ⇄ master]
$
```