### PR TITLE
Makefile: refactor is-git-repo inclusion logic

### DIFF
--- a/need_git_repo
+++ b/need_git_repo
@@ -1,0 +1,6 @@
+# A list of the commands that use is_git_repo, and should have
+# it included in the "built" version of the command
+git-alias
+git-extras
+git-fork
+git-setup


### PR DESCRIPTION
Here's a suggestion for refactoring the Makefile to simplify it. This avoids the need for a big repeated block of code for the command-construction logic, where the two blocks differ by only one line.