### PR TITLE
git-summary: protect against character encoding issues with LC_ALL=C

### DIFF
--- a/bin/git-line-summary
+++ b/bin/git-line-summary
@@ -9,7 +9,7 @@ single_file() {
   while read data
   do
     if [[ $(file "$data") = *text* ]]; then
-      git blame --line-porcelain "$data" 2>/dev/null | grep "^author\ " | sed -n 's/^author //p';
+      git blame --line-porcelain "$data" 2>/dev/null | grep "^author\ " | LC_ALL=C sed -n 's/^author //p';
     fi
   done
 }

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+
 SUBDIRECTORY_OK=Yes
 source "$(git --exec-path)/git-sh-setup"
 cd_to_toplevel
@@ -63,7 +64,7 @@ authors() {
 #
 
 repository_age() {
-  git log --reverse --pretty=oneline --format="%ar" | head -n 1 | sed 's/ago//'
+  git log --reverse --pretty=oneline --format="%ar" | head -n 1 | LC_ALL=C sed 's/ago//'
 }
 
 # summary


### PR DESCRIPTION
On OS X 10.9.5, I get a couple sed errors in `git-summary-line`.

These look like character encoding issues.

```
[~/local/opp/omz/oh-my-zsh on ⇄ git-extras-compatibility]
$ git-summary --line

 project  : oh-my-zsh
sed: RE error: illegal byte sequence
sed: RE error: illegal byte sequence
 lines    : 34168
 authors  :
 3938 Andrew Janke              11.5%
 3374 Felipe Contreras          9.9%
```

Running `sed` under `LC_ALL=C` makes the errors go away. This PR does that.