### PR TITLE
Use the default installation path in install.cmd

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -1,5 +1,9 @@
 @ECHO OFF
 SET PREFIX=C:\SCM\PortableGit\mingw64
+:: default for Git for Windows 2.x
+@if exist "%ProgramFiles%\Git" (
+    set PREFIX="%ProgramFiles%\Git\mingw64"
+)
 IF NOT "%~1"=="" SET PREFIX="%~1"
 SET HTMLDIR=%PREFIX%\share\doc\git-doc
 SET GITEXTRAS=%~dp0


### PR DESCRIPTION
That's the same path as cmdr checks when starting up: https://github.com/cmderdev/cmder/blob/master/vendor/init.bat#L31

With this patch you can run `install.cmd` without any arguments. Adding arguments still overwrites the path.