### PR TITLE
Makefile: allow customizing of SYSCONFDIR (/etc) location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PREFIX ?= /usr/local
 BINPREFIX ?= "$(PREFIX)/bin"
 MANPREFIX ?= "$(PREFIX)/share/man/man1"
+SYSCONFDIR ?= /etc
 BINS = $(wildcard bin/git-*)
 MANS = $(wildcard man/git-*.md)
 MAN_HTML = $(MANS:.md=.html)
@@ -47,8 +48,8 @@ install:
 		cp -f man/git-*.1 $(DESTDIR)$(MANPREFIX); \
 		echo "cp -f man/git-*.1 $(DESTDIR)$(MANPREFIX)"; \
 	fi
-	@mkdir -p $(DESTDIR)/etc/bash_completion.d
-	cp -f etc/bash_completion.sh $(DESTDIR)/etc/bash_completion.d/git-extras
+	@mkdir -p $(DESTDIR)$(SYSCONFDIR)/bash_completion.d
+	cp -f etc/bash_completion.sh $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/git-extras
 
 man/%.html: man/%.md
 	ronn \
@@ -72,7 +73,7 @@ uninstall:
 		echo "... uninstalling $(DESTDIR)$(MANPREFIX)/$(notdir $(MAN))"; \
 		rm -f $(DESTDIR)$(MANPREFIX)/$(notdir $(MAN)); \
 	)
-	rm -f $(DESTDIR)/etc/bash_completion.d/git-extras
+	rm -f $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/git-extras
 
 clean: docclean
 


### PR DESCRIPTION
The current Makefile hardcodes the `/etc` installation location. Users might want to install `etc` files to other places, like `/usr/local/etc` for non-root installs or `brew --prefix` for Homebrew. GNU software and Homebrew locate `SYSCONFDIR` (the conventional Makefile variable for the `/etc` dir location) under `PREFIX` by default, even.

This PR introduces a `SYSCONFDIR` variable to the Makefile to allow the user to customize the `/etc` location. It leaves the default as `/etc`, not changing it to `$(PREFIX)/etc`, so the current default behavior is preserved. I think it's worth discussing whether to change to locate `etc` under `$(PREFIX)` by default; that would allow non-root or fully-relocated installs by just specifying `PREFIX`, and would match the behavior of a lot of other software.

This will help users installing as non-root (as in #237), and remove the need for [one of the patches](https://github.com/Homebrew/homebrew/blob/41025fb70fcab7a8d379cc41558bc1133869c3d7/Library/Formula/git-extras.rb#L23) in the Homebrew `git-extras` installation formula.

I've tested this on OS X.