### PR TITLE
Makefile: fix inverted list of commands that use is_git_repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install:
 			echo "... installing $(COMMAND)"; \
 			head -1 bin/$(COMMAND) > $(TEMPFILE); \
 			cat $(LIB) >> $(TEMPFILE); \
-			if grep "$(COMMAND)" need_git_repo >/dev/null; then \
+			if ! grep "$(COMMAND)" not_need_git_repo >/dev/null; then \
 				cat ./helper/is-git-repo >> $(TEMPFILE); \
 			fi; \
 			tail -n +2 bin/$(COMMAND) >> $(TEMPFILE); \

--- a/not_need_git_repo
+++ b/not_need_git_repo
@@ -1,4 +1,4 @@
-# A list of the commands that use is_git_repo, and should have
+# A list of the commands that do not use is_git_repo(), and should not have
 # it included in the "built" version of the command
 git-alias
 git-extras


### PR DESCRIPTION
PR #458 inverted the sense of the test for whether is-git-repo should be included in a file. This fixes it.

Fixes #493 
