### PR TITLE
Make the win installer more robust

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -25,21 +25,21 @@ git clone https://github.com/tj/git-extras.git
 git checkout $(git describe --tags $(git rev-list --tags --max-count=1))
 ```
 
-After that, execute the `install.cmd` in the command prompt, with the path your
-`Git for Windows 2.x` is installed. If you installed git as admin, you need to 
-run this promt as admin, too. Per default, it finds a `Git for Windows 2.x` in
-`%ProgramFiles%\Git`, which is the default install location. The fallback is
-`C:\SCM\PortableGit`. If you didn't install git into one of these dirs, you have 
-to supply the `mingw64` path for the install location, e.g. if git is installed 
-in `c:\git\`:
+After that, execute the `install.cmd` in the command prompt. If you installed
+git as admin, you need to run this prompt as admin, too. Per default, it finds
+a `Git for Windows 2.x` if it's in the path (first path in `where git.exe` wins)
+or installed in the default location `%ProgramFiles%\Git`. The fallback is
+`C:\SCM\PortableGit`. If you didn't install git into one of these dirs, you have
+to supply the path for the install location, e.g. if git is installed
+in `c:\git`:
 
 ```batch
-install.cmd "C:\git\mingw64"
+install.cmd "C:\git"
 ```
 
-Last, to use `git-line-summary`, `git-summary` and `git-ignore-io`, you need to copy 
+Last, to use `git line-summary`, `git summary` and `git ignore-io`, you need to copy
 `column.exe` from a [msys2][1] installation from `folder-your-msys2-installed/usr/bin`
-to `folder-your-git-installed/usr/bin` .
+to `folder-your-git-installed/usr/bin`.
 
 ## Building from source
 

--- a/install.cmd
+++ b/install.cmd
@@ -1,32 +1,127 @@
 @ECHO OFF
-SET PREFIX=C:\SCM\PortableGit\mingw64
-:: default for Git for Windows 2.x
-@if exist "%ProgramFiles%\Git" (
-    set PREFIX="%ProgramFiles%\Git\mingw64"
+:: don't leak env variables into the calling interperter...
+setlocal
+:: better defaults for dealing with quotes...
+SETLOCAL enabledelayedexpansion
+
+:: A comment on quotes around file path variables:
+:: only add quotes around the variable when you use the variable
+:: as a file path (exists, type, pipe,...) and teh parenthesis of a 
+:: for, not when used as a string (-> setting variables)
+
+:: more does not work if the codepage is set to unicode 65001
+for /F "tokens=*" %%F in ('chcp') do (
+	for %%A in (%%F) do (set _last=%%A)
 )
-IF NOT "%~1"=="" SET PREFIX="%~1"
+SET CP=%_last:~0,-1%
+chcp 850 > NUL
+:: echo %CP%
+
+:: not so sane default...
+SET PREFIX=C:\SCM\PortableGit\mingw64
+
+:: find a git.exe in path and use that as a default dir
+where /Q git.exe
+if errorlevel 1 goto :defaultpath
+
+for /F "delims=" %%F in ('where git.exe') do (
+	set bindir=%%~dpF
+	rem break after the first, so that we get the first in path
+	goto :break
+)
+goto :defaultpath
+
+:break
+rem remove the last slash
+SET bindir=%bindir:~0,-1%
+for %%G in ("%bindir%") do set installdir=%%~dpG
+set PREFIX=%installdir%mingw64
+goto :foundprefix
+
+:defaultpath
+:: default for Git for Windows 2.x
+if exist "%ProgramFiles%\Git" (
+    set PREFIX=%ProgramFiles%\Git\mingw64
+)
+
+:foundprefix
+:: overwrite with whatever the user supplied...
+IF NOT "%~1"=="" (
+	REM make it easier for the user to specify a prefix:
+	REM just supplying the git dir is enough...
+	if exist "%~1\mingw64" (
+		set PREFIX=%~1\mingw64
+	) else (
+		echo Using git install path "%~1" as PREFIX, please make sure it's really a
+		echo path to the mingw64 directory...
+		echo.
+		SET PREFIX=%~1
+	)
+)
+:: remove a trailing slash, but only after removing quotes...
+set PREFIX=!PREFIX:"=!
+IF %PREFIX:~-1%==\ SET PREFIX=%PREFIX:~0,-1%
+
+for %%H in ("%PREFIX%") do set GIT_INSTALL_DIR=%%~dpH
+
+set GIT_INSTALL_DIR=!GIT_INSTALL_DIR:"=!
+IF %GIT_INSTALL_DIR:~-1%==\ SET GIT_INSTALL_DIR=%GIT_INSTALL_DIR:~0,-1%
+
+if not exist "%GIT_INSTALL_DIR%\mingw64" (
+	echo No mingw64 folder found in %GIT_INSTALL_DIR%. 
+	echo.
+	echo Please supply a proper "Git for Windows 2.x" install path:
+	echo "install.cmd c:\[git-install-path]"
+	set ERROR=1
+	goto :exit
+)
+
+echo Installing to %PREFIX%
 SET HTMLDIR=%PREFIX%\share\doc\git-doc
 SET GITEXTRAS=%~dp0
 
-IF NOT EXIST %PREFIX%\bin MKDIR %PREFIX%\bin
+IF NOT EXIST "%PREFIX%\bin" MKDIR "%PREFIX%\bin"
 
 SET COMMANDS_WITHOUT_REPO=git-alias git-extras git-fork git-setup
 
-FOR /R %GITEXTRAS%\bin %%i in (*.*) DO (
-	ECHO #!/usr/bin/env bash > %PREFIX%\bin\%%~ni
-	TYPE %GITEXTRAS%\helper\reset-env >> %PREFIX%\bin\%%~ni
-	TYPE %GITEXTRAS%\helper\git-extra-utility >> %PREFIX%\bin\%%~ni
-	TYPE %GITEXTRAS%\helper\is-git-repo >> %PREFIX%\bin\%%~ni
-	MORE +2 %GITEXTRAS%\bin\%%~ni >> %PREFIX%\bin\%%~ni
+echo Installing binaries...
+FOR /R "%GITEXTRAS%\bin" %%i in (*.*) DO (
+	ECHO #!/usr/bin/env bash > "%PREFIX%\bin\%%~ni"
+	TYPE "%GITEXTRAS%\helper\reset-env" >> "%PREFIX%\bin\%%~ni"
+	TYPE "%GITEXTRAS%\helper\git-extra-utility" >> "%PREFIX%\bin\%%~ni"
+	TYPE "%GITEXTRAS%\helper\is-git-repo" >> "%PREFIX%\bin\%%~ni"
+	MORE +2 "%GITEXTRAS%\bin\%%~ni" >> "%PREFIX%\bin\%%~ni"
 )
 
 FOR %%i in (%COMMANDS_WITHOUT_REPO%) DO (
-	ECHO #!/usr/bin/env bash > %PREFIX%\bin\%%i
-	TYPE %GITEXTRAS%\helper\reset-env >> %PREFIX%\bin\%%i
-	TYPE %GITEXTRAS%\helper\git-extra-utility >> %PREFIX%\bin\%%i
-	MORE +2 %GITEXTRAS%\bin\%%i >> %PREFIX%\bin\%%i
+	ECHO #!/usr/bin/env bash > "%PREFIX%\bin\%%i"
+	TYPE "%GITEXTRAS%\helper\reset-env" >> "%PREFIX%\bin\%%i"
+	TYPE "%GITEXTRAS%\helper\git-extra-utility" >> "%PREFIX%\bin\%%i"
+	MORE +2 "%GITEXTRAS%\bin\%%i" >> "%PREFIX%\bin\%%i"
 )
 
-ROBOCOPY /IS %GITEXTRAS%\man %HTMLDIR% *.html
+echo Installing man pages...
+set _QUIET=/NP /NFL /NDL /NJS /NJH
+ROBOCOPY %_QUIET% /IS "%GITEXTRAS%\man" "%HTMLDIR%" *.html
+echo done
 
-@ECHO ON
+if not exist "%GIT_INSTALL_DIR%\usr\bin\column.exe" (
+	where /Q column.exe
+	if errorlevel 1 (
+		echo.
+		echo column.exe is missing: Not in "%GIT_INSTALL_DIR%\usr\bin" or in PATH!
+		echo.
+		echo "git summary", "git summary-line" and "git ignore-io" do not work
+		echo without. If you need these commands, please install msys2 and 
+		echo make column.exe available by copying it into the path or into 
+		echo "%GIT_INSTALL_DIR%\usr\bin".
+		echo.
+	)
+)
+
+
+:exit
+@chcp %CP% > NUL
+@endlocal enabledelayedexpansion
+@endlocal
+@exit /b %ERROR%


### PR DESCRIPTION
User visible:
* Also accept the git install path (and not the mingw64 subdir) as a user
  supplied install location. Make it the new default and warn the user if
  a mingw64 dir is supplied (=this dir is not checked, so it might be
  anywhere...)
* Find git.exe in path and use that as an install location
* Add error|status messages and output less noise (robocopy)
* do some check if column.exe is not found...
* adjust the installation text for windows...

not user visible:
* more.exe does not work when used in a cmd which has a unicode codepage
  -> save the current codepage and set a sane default during the install
* do some "magic" with quotes around path variables -> makes it work with
  pathes with spaces in it (both final git dir and the git-extra checkout)
* Do not leak variables to the sourounding interpreter