### PR TITLE
Mention initial copyright year and add contributors to copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2015 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2010 TJ Holowaychuk <tj@vision-media.ca> and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
I am not a lawyer but according to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below), mentioning the first year of publication in the copyright is a good thing

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)

Mentioning 2010 as the first release happened at that time - https://github.com/tj/git-extras/releases/tag/0.0.1

Also adding `Contributors` to copyright because TJ Holowaychuk is not the only person owning copyright for the whole project. The copyright is collectively owned by all contributors, or more precisely: every contributor owns a copyright on the code he or she has contributed.

The only way to retain full copyright over code is to ask for signing contributor's agreement before merging in changes. This is, in fact, what some companies who license commercially their free software do.