### PR TITLE
Add Fedora package-manager installation instruction

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -9,6 +9,12 @@ $ sudo $apt_pref update
 $ sudo $apt_pref install git-extras
 ```
 
+### Fedora
+
+```bash
+$ sudo dnf install git-extras
+```
+
 ### Mac OS X with Homebrew
 
 ```bash


### PR DESCRIPTION
git-extras is available in the official fedora repository: [https://admin.fedoraproject.org/pkgdb/package/rpms/git-extras/](https://admin.fedoraproject.org/pkgdb/package/rpms/git-extras/).