### PR TITLE
add git standup

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -41,6 +41,7 @@
  - [`git scp`](#git-scp)
  - [`git sed`](#git-sed)
  - [`git setup`](#git-setup)
+ - [`git standup`](#git-standup)
  - [`git squash`](#git-squash)
  - [`git summary`](#git-summary)
  - [`git sync`](#git-sync)
@@ -793,6 +794,13 @@ Internally this script uses `rsync` and not `scp` as the name suggests.
 
     $ git scp staging js/vendor/
 
+## git standup
+
+Recall what you did or find what someone else did in a given range of time.
+For instance, recall John's commits since last week:
+```
+git standup John "last week"
+```
 
 ## git touch
 

--- a/bin/git-standup
+++ b/bin/git-standup
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Code modified from https://github.com/kamranahmedse/git-standup,
+# under the MIT LICENSE.
+if [[ $# -gt 3 ]] ; then
+  >&2 printf "Usage: $0 [fullname] [since] [until]\nExample: $0 \"John Doe\" \"last Mon\" yesterday\n"
+  exit 1
+fi
+
+git rev-parse --show-toplevel > /dev/null 2>&1
+in_git_repo=$?
+
+# Use colors, but only if connected to a terminal, and that terminal
+# supports them.
+if which tput >/dev/null 2>&1; then
+  ncolors=$(tput colors)
+fi
+if [[ -t 1 ]] && [[ -n "$ncolors" ]] && [[ "$ncolors" -ge 8 ]] ; then
+  RED="$(tput setaf 1)"
+  GREEN="$(tput setaf 2)"
+  YELLOW="$(tput setaf 3)"
+  BLUE="$(tput setaf 4)"
+  BOLD="$(tput bold)"
+  NORMAL="$(tput sgr0)"
+  BOLD=$(tput bold)
+  UNDERLINE=$(tput smul)
+  NORMAL=$(tput sgr0)
+else
+  RED=""
+  GREEN=""
+  YELLOW=""
+  BLUE=""
+  BOLD=""
+  NORMAL=""
+  BOLD=""
+  UNDERLINE=""
+  NORMAL=""
+fi
+
+# Only enable exit-on-error after the non-critical colorization stuff,
+# which may fail on systems lacking tput or terminfo
+set -e
+
+AUTHOR=${1:-"$(git config user.name)"}
+SINCE=${2:-yesterday}
+UNTIL=${3:-today}
+
+
+## In case it is the start of week, we need to
+## show the commits since the last weekend
+shopt -s nocasematch
+
+GIT_LOG_COMMAND="git --no-pager log \
+    --all
+    --no-merges
+    --since \"$SINCE\"
+    --until \"$UNTIL\"
+    --author=\"$AUTHOR\"
+    --abbrev-commit
+    --oneline
+    --pretty=format:'%Cred%h%Creset - %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'"
+
+## For when the command has been run in a non-repo directory
+if [[ $in_git_repo != 0 ]]; then
+
+    ## Iterate through all the top level directories inside
+    ## and look for any git repositories.
+    for DIR in */ ; do
+
+        cd "$DIR"
+
+        ## Show the detail only if it is a git repository
+        if [[ -d ".git" ]] ; then
+            if GITOUT=$(eval ${GIT_LOG_COMMAND}); then
+                ## Only output if there is some activity
+                if [[ ! -z "$GITOUT" ]] ;  then
+                    echo "${BOLD}${UNDERLINE}${YELLOW}$DIR${NORMAL}"
+                    echo "$GITOUT"
+                fi
+            else
+                echo "Repository under $DIR could not be queried. Missing initial commit?" >&2
+            fi
+        fi
+
+        cd ..
+    done
+else
+    eval ${GIT_LOG_COMMAND}
+    echo "" ## To avoid that ugly # icon representing the end of line
+fi

--- a/man/git-standup.1
+++ b/man/git-standup.1
@@ -1,0 +1,94 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-STANDUP" "1" "April 2016" "" ""
+.
+.SH "NAME"
+\fBgit\-standup\fR \- Recall the commit history
+.
+.SH "SYNOPSIS"
+\fBgit\-standup\fR [<full name>] [<since>] [<until>]
+.
+.SH "DESCRIPTION"
+Recall what you did on the last working day \.\.or be nosy and find what someone else did\.
+.
+.SH "OPTIONS"
+<full name>
+.
+.P
+The author of commits\. Defaults to \fB$(git config user\.name)\fR\.
+.
+.P
+<since>
+.
+.P
+The start of commit history\. Defaults to \fByesterday\fR\.
+.
+.P
+<until>
+.
+.P
+The end of commit history\. Defaults to \fBtoday\fR\.
+.
+.SH "EXAMPLES"
+This shows your commits since yesterday:
+.
+.IP "" 4
+.
+.nf
+
+$ git standup
+
+a26d1f9 \- add profile hook (69 minutes ago) <spacewander>
+.
+.fi
+.
+.IP "" 0
+.
+.P
+This shows the author\'s commits since last week:
+.
+.IP "" 4
+.
+.nf
+
+$ git standup spacewander "last week"
+
+a26d1f9 \- add profile hook (70 minutes ago) <spacewander>
+4e19859 \- fix getTotalSize return value error (6 days ago) <spacewander>
+36da84e \- fix rename over bound (7 days ago) <spacewander>
+8e4182a \- add watermark\.png (7 days ago) <spacewander>
+46fef1d \- use tinyXML to configure (7 days ago) <spacewander>
+.
+.fi
+.
+.IP "" 0
+.
+.P
+If current directory is not a git repo, git\-standup will fetch data from all top\-level git repos under it:
+.
+.IP "" 4
+.
+.nf
+
+$ cd \.\.
+$ git standup spacewander "last week" yesterday
+
+someProject/
+4e19859 \- fix getTotalSize return value error (6 days ago) <spacewander>
+36da84e \- fix rename over bound (7 days ago) <spacewander>
+8e4182a \- add watermark\.png (7 days ago) <spacewander>
+46fef1d \- use tinyXML to configure (7 days ago) <spacewander>
+.
+.fi
+.
+.IP "" 0
+.
+.SH "AUTHOR"
+Originally from https://github\.com/kamranahmedse/git\-standup
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-standup.html
+++ b/man/git-standup.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-standup(1) - Recall the commit history</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-standup(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-standup(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-standup</code> - <span class="man-whatis">Recall the commit history</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-standup</code> [&lt;full name&gt;] [&lt;since&gt;] [&lt;until&gt;]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>Recall what you did on the last working day ..or be nosy and find what someone else did.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>&lt;full name&gt;</p>
+
+<p>The author of commits. Defaults to <code>$(git config user.name)</code>.</p>
+
+<p>&lt;since&gt;</p>
+
+<p>The start of commit history. Defaults to <code>yesterday</code>.</p>
+
+<p>&lt;until&gt;</p>
+
+<p>The end of commit history. Defaults to <code>today</code>.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>This shows your commits since yesterday:</p>
+
+<pre><code>$ git standup
+
+a26d1f9 - add profile hook (69 minutes ago) &lt;spacewander>
+</code></pre>
+
+<p>This shows the author's commits since last week:</p>
+
+<pre><code>$ git standup spacewander "last week"
+
+a26d1f9 - add profile hook (70 minutes ago) &lt;spacewander>
+4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander>
+36da84e - fix rename over bound (7 days ago) &lt;spacewander>
+8e4182a - add watermark.png (7 days ago) &lt;spacewander>
+46fef1d - use tinyXML to configure (7 days ago) &lt;spacewander>
+</code></pre>
+
+<p>If current directory is not a git repo, git-standup will fetch data from all top-level git repos under it:</p>
+
+<pre><code>$ cd ..
+$ git standup spacewander "last week" yesterday
+
+someProject/
+4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander>
+36da84e - fix rename over bound (7 days ago) &lt;spacewander>
+8e4182a - add watermark.png (7 days ago) &lt;spacewander>
+46fef1d - use tinyXML to configure (7 days ago) &lt;spacewander>
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Originally from https://github.com/kamranahmedse/git-standup</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>April 2016</li>
+    <li class='tr'>git-standup(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-standup.md
+++ b/man/git-standup.md
@@ -1,0 +1,66 @@
+git-standup(1) -- Recall the commit history
+=================================
+
+## SYNOPSIS
+
+`git-standup` [&lt;full name&gt;] [&lt;since&gt;] [&lt;until&gt;]
+
+## DESCRIPTION
+
+Recall what you did on the last working day ..or be nosy and find what someone else did.
+
+## OPTIONS
+
+&lt;full name&gt;
+
+The author of commits. Defaults to `$(git config user.name)`.
+
+&lt;since&gt;
+
+The start of commit history. Defaults to `yesterday`.
+
+&lt;until&gt;
+
+The end of commit history. Defaults to `today`.
+
+## EXAMPLES
+
+This shows your commits since yesterday:
+
+    $ git standup
+
+    a26d1f9 - add profile hook (69 minutes ago) <spacewander>
+
+This shows the author's commits since last week:
+
+    $ git standup spacewander "last week"
+
+    a26d1f9 - add profile hook (70 minutes ago) <spacewander>
+    4e19859 - fix getTotalSize return value error (6 days ago) <spacewander>
+    36da84e - fix rename over bound (7 days ago) <spacewander>
+    8e4182a - add watermark.png (7 days ago) <spacewander>
+    46fef1d - use tinyXML to configure (7 days ago) <spacewander>
+
+If current directory is not a git repo, git-standup will fetch data from all top-level git repos under it:
+
+    $ cd ..
+    $ git standup spacewander "last week" yesterday
+
+    someProject/
+    4e19859 - fix getTotalSize return value error (6 days ago) <spacewander>
+    36da84e - fix rename over bound (7 days ago) <spacewander>
+    8e4182a - add watermark.png (7 days ago) <spacewander>
+    46fef1d - use tinyXML to configure (7 days ago) <spacewander>
+
+
+## AUTHOR
+
+Originally from https://github.com/kamranahmedse/git-standup
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;

--- a/not_need_git_repo
+++ b/not_need_git_repo
@@ -4,3 +4,4 @@ git-alias
 git-extras
 git-fork
 git-setup
+git-standup


### PR DESCRIPTION
For #523
A notable change from the original one: The third argument of the original `git-standup` is `weekstart-weekend`. It is a litttle confusing in my opinion, so I divide it into two seperate arguments: `since` and `until`. 