### PR TITLE
Add git clear-soft, modify git clear to indicate explicit removal of files

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -4,6 +4,7 @@
  - [`git authors`](#git-authors)
  - [`git changelog`](#git-changelog)
  - [`git clear`](#git-clear)
+ - [`git clear-soft`](#git-clear-soft)
  - [`git commits-since`](#git-commits-since)
  - [`git contrib`](#git-contrib)
  - [`git count`](#git-count)
@@ -956,7 +957,11 @@ README.md
 
 ## git clear
 
-Does a hard reset and deletes all untracked files from the working directory
+Does a hard reset and deletes all untracked files from the working directory, including those in .gitignore.
+
+## git clear-soft
+
+Does a soft reset and deletes all untracked files from the working directory, excluding those in .gitignore.
 
 ## git merge-repo
 

--- a/Commands.md
+++ b/Commands.md
@@ -961,7 +961,7 @@ Does a hard reset and deletes all untracked files from the working directory, in
 
 ## git clear-soft
 
-Does a soft reset and deletes all untracked files from the working directory, excluding those in .gitignore.
+Does a hard reset and deletes all untracked files from the working directory, excluding those in .gitignore.
 
 ## git merge-repo
 

--- a/bin/git-clear
+++ b/bin/git-clear
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo "Sure? - This command may delete files that cannot be recovered. [Y/n]"
+echo "Sure? - This command may delete files that cannot be recovered, including those in .gitignore [Y/n]"
 read ans
 if [ "$ans" != "n" ] 
     then git clean -d -f -x && git reset --hard

--- a/bin/git-clear-soft
+++ b/bin/git-clear-soft
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "Sure? - This command may delete files that cannot be recovered. Files and directories in .gitignore will be preserved [Y/n]"
+read ans
+if [ "$ans" != "n" ] 
+    then git clean -d -f && git reset --hard
+fi

--- a/man/git-clear-soft.1
+++ b/man/git-clear-soft.1
@@ -1,0 +1,35 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-CLEAR\-SOFT" "1" "May 2016" "" ""
+.
+.SH "NAME"
+\fBgit\-clear\-soft\fR \- Soft clean up of a repository
+.
+.SH "SYNOPSIS"
+\fBgit\-clear\-soft\fR
+.
+.SH "DESCRIPTION"
+Clears the repository to a state that it looks as if it was freshly cloned with the current HEAD, however, preserving all changes that are located in files and directories listed in \.gitignore\. It is a git\-reset \-\-hard together with deletion of all untracked files that reside inside the working directory, excluding those in \.gitignore\.
+.
+.SH "EXAMPLES"
+Clears the repo\.
+.
+.IP "" 4
+.
+.nf
+
+$ git clear\-soft
+.
+.fi
+.
+.IP "" 0
+.
+.SH "AUTHOR"
+Modified version of script written by Daniel \'grindhold\' Brendle <\fIgrindhold@gmx\.net\fR> by Matiss Treinis <\fImrtreinis@gmail\.com\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-clear-soft.html
+++ b/man/git-clear-soft.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
   <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
-  <title>git-clear(1) - Rigorously clean up a repository </title>
+  <title>git-clear-soft(1) - Soft clean up of a repository</title>
   <style type='text/css' media='all'>
   /* style: man */
   body#manpage {margin:0}
@@ -63,36 +63,36 @@
   </div>
 
   <ol class='man-decor man-head man head'>
-    <li class='tl'>git-clear(1)</li>
+    <li class='tl'>git-clear-soft(1)</li>
     <li class='tc'></li>
-    <li class='tr'>git-clear(1)</li>
+    <li class='tr'>git-clear-soft(1)</li>
   </ol>
 
   <h2 id="NAME">NAME</h2>
 <p class="man-name">
-  <code>git-clear</code> - <span class="man-whatis">Rigorously clean up a repository </span>
+  <code>git-clear-soft</code> - <span class="man-whatis">Soft clean up of a repository</span>
 </p>
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-clear</code></p>
+<p><code>git-clear-soft</code></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
 <p>  Clears the repository to a state that it looks as if it was freshly cloned
-  with the current HEAD. Basically it is a git-reset --hard together with
-  deletion of all untracked files that reside inside the working directory, including those in .gitignore.</p>
+  with the current HEAD, however, preserving all changes that are located in files and directories listed in .gitignore. It is a git-reset --hard together with
+  deletion of all untracked files that reside inside the working directory, excluding those in .gitignore.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <p>  Clears the repo.</p>
 
-<pre><code>$ git clear
+<pre><code>$ git clear-soft
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Daniel 'grindhold' Brendle &lt;<a href="&#x6d;&#x61;&#105;&#108;&#x74;&#x6f;&#58;&#103;&#114;&#x69;&#x6e;&#x64;&#x68;&#111;&#x6c;&#100;&#x40;&#x67;&#x6d;&#120;&#46;&#x6e;&#101;&#116;" data-bare-link="true">&#103;&#114;&#x69;&#110;&#100;&#104;&#111;&#x6c;&#x64;&#64;&#x67;&#x6d;&#x78;&#x2e;&#x6e;&#101;&#116;</a>&gt;</p>
+<p>Modified version of script written by Daniel 'grindhold' Brendle &lt;<a href="&#109;&#97;&#x69;&#108;&#116;&#111;&#58;&#x67;&#114;&#x69;&#110;&#x64;&#x68;&#111;&#x6c;&#x64;&#64;&#103;&#x6d;&#120;&#x2e;&#110;&#x65;&#x74;" data-bare-link="true">&#103;&#x72;&#x69;&#x6e;&#x64;&#x68;&#111;&#x6c;&#x64;&#x40;&#x67;&#x6d;&#x78;&#x2e;&#110;&#101;&#x74;</a>&gt; by Matiss Treinis &lt;<a href="&#109;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#x6d;&#x72;&#x74;&#114;&#101;&#105;&#x6e;&#105;&#x73;&#64;&#103;&#109;&#x61;&#105;&#108;&#46;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#109;&#x72;&#x74;&#114;&#101;&#105;&#110;&#105;&#x73;&#64;&#103;&#109;&#x61;&#105;&#108;&#x2e;&#99;&#111;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -106,7 +106,7 @@
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
     <li class='tc'>May 2016</li>
-    <li class='tr'>git-clear(1)</li>
+    <li class='tr'>git-clear-soft(1)</li>
   </ol>
 
   </div>

--- a/man/git-clear-soft.md
+++ b/man/git-clear-soft.md
@@ -1,0 +1,30 @@
+git-clear-soft(1) -- Soft clean up of a repository
+================================================
+
+## SYNOPSIS
+
+`git-clear-soft`
+
+## DESCRIPTION
+
+  Clears the repository to a state that it looks as if it was freshly cloned
+  with the current HEAD, however, preserving all changes that are located in files and directories listed in .gitignore. It is a git-reset --hard together with
+  deletion of all untracked files that reside inside the working directory, excluding those in .gitignore.
+
+## EXAMPLES
+
+  Clears the repo.
+
+    $ git clear-soft
+
+## AUTHOR
+
+Modified version of script written by Daniel 'grindhold' Brendle &lt;<grindhold@gmx.net>&gt; by Matiss Treinis &lt;<mrtreinis@gmail.com>&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;

--- a/man/git-clear.1
+++ b/man/git-clear.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-CLEAR" "1" "December 2015" "" ""
+.TH "GIT\-CLEAR" "1" "May 2016" "" ""
 .
 .SH "NAME"
 \fBgit\-clear\fR \- Rigorously clean up a repository
@@ -10,7 +10,7 @@
 \fBgit\-clear\fR
 .
 .SH "DESCRIPTION"
-Clears the repository to a state that it looks as if it was freshly cloned with the current HEAD\. Basically it is a git\-reset \-\-hard together with deletion of all untracked files that reside inside the working directory\.
+Clears the repository to a state that it looks as if it was freshly cloned with the current HEAD\. Basically it is a git\-reset \-\-hard together with deletion of all untracked files that reside inside the working directory, including those in \.gitignore\.
 .
 .SH "EXAMPLES"
 Clears the repo\.

--- a/man/git-clear.md
+++ b/man/git-clear.md
@@ -9,7 +9,7 @@ git-clear(1) -- Rigorously clean up a repository
 
   Clears the repository to a state that it looks as if it was freshly cloned
   with the current HEAD. Basically it is a git-reset --hard together with
-  deletion of all untracked files that reside inside the working directory.
+  deletion of all untracked files that reside inside the working directory, including those in .gitignore.
 
 ## EXAMPLES
 


### PR DESCRIPTION
This could be one potential solution to issue #531 - a separate command that allows for "soft" cleanup of the repository honoring `.gitignore`.

This PR also includes modified description and notice on `git clear` about that it does not honor `.gitignore`.

I was swinging between this and modifying the existing command with a flag, but this somehow seemed a cleaner solution. 