### PR TITLE
Add note about overwriting git aliases

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -27,6 +27,8 @@ $ sudo apt-get install git-extras
 $ brew install git-extras
 ```
 
+Installing from Homebrow will not give you the option omit certain `git-extras` if they conflict with existing git aliases. To have this option, build from source.
+
 ### Windows
 
 First, please install `Git for Windows 2.x` from 'https://github.com/git-for-windows/git/releases'.


### PR DESCRIPTION
This bit me on OSX so I've added the note there, but it could also be applied to the whole package manager section if it's also true on other platforms.