### PR TITLE
Improve forking `origin` repo

### DIFF
--- a/bin/git-fork
+++ b/bin/git-fork
@@ -37,6 +37,7 @@ curl -X POST -u "$user" "https://api.github.com/repos/$owner/$project/forks"
 if [ "$origin" = true ]; then
     git remote rename origin upstream
     git remote add origin "https://github.com/$user/$project"
+    git fetch origin
 else
     # clone forked repo into current dir
     git clone "https://github.com/$user/$project" "$project"

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -19,7 +19,7 @@ forks the repo on github
 clones the repo into the current dir
 .
 .IP "3." 4
-adds the original repo as a remote called upstream
+adds the original repo as a remote called \fBupstream\fR
 .
 .IP "" 0
 .
@@ -30,10 +30,10 @@ If a url is not given and the current dir is a github repo, fork the repo\.
 forks the current repo
 .
 .IP "2." 4
-rename the \'origin\' remote repo to \'upstream\'
+rename the \fBorigin\fR remote repo to \fBupstream\fR
 .
 .IP "3." 4
-adds the forked repo as a remote called origin
+adds the forked repo as a remote called \fBorigin\fR
 .
 .IP "" 0
 .

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -84,7 +84,7 @@
 <ol>
 <li>forks the repo on github</li>
 <li>clones the repo into the current dir</li>
-<li>adds the original repo as a remote called upstream</li>
+<li>adds the original repo as a remote called <code>upstream</code></li>
 </ol>
 
 
@@ -92,8 +92,8 @@
 
 <ol>
 <li>forks the current repo</li>
-<li>rename the 'origin' remote repo to 'upstream'</li>
-<li>adds the forked repo as a remote called origin</li>
+<li>rename the <code>origin</code> remote repo to <code>upstream</code></li>
+<li>adds the forked repo as a remote called <code>origin</code></li>
 </ol>
 
 
@@ -128,7 +128,7 @@ $ cd expect.js &amp;&amp; git remote -v
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Andrew Griffiths &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#x6f;&#58;&#109;&#x61;&#x69;&#x6c;&#64;&#x61;&#x6e;&#x64;&#114;&#101;&#x77;&#103;&#x72;&#x69;&#102;&#102;&#105;&#116;&#x68;&#x73;&#x6f;&#x6e;&#108;&#105;&#110;&#101;&#x2e;&#99;&#111;&#109;" data-bare-link="true">&#x6d;&#97;&#x69;&#108;&#x40;&#97;&#x6e;&#x64;&#x72;&#x65;&#x77;&#103;&#x72;&#x69;&#102;&#102;&#x69;&#116;&#104;&#x73;&#x6f;&#110;&#108;&#x69;&#110;&#101;&#x2e;&#x63;&#111;&#x6d;</a>&gt;</p>
+<p>Written by Andrew Griffiths &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#x6d;&#x61;&#x69;&#x6c;&#64;&#97;&#x6e;&#100;&#x72;&#101;&#x77;&#x67;&#x72;&#105;&#x66;&#x66;&#x69;&#x74;&#x68;&#x73;&#x6f;&#110;&#108;&#105;&#x6e;&#101;&#46;&#x63;&#111;&#109;" data-bare-link="true">&#x6d;&#x61;&#105;&#108;&#64;&#97;&#110;&#100;&#114;&#x65;&#119;&#x67;&#x72;&#x69;&#x66;&#102;&#105;&#116;&#x68;&#115;&#111;&#x6e;&#108;&#105;&#x6e;&#x65;&#x2e;&#x63;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-fork(1) - Fork a repo on github</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#EXAMPLE">EXAMPLE</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-fork(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-fork(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-fork</code> - <span class="man-whatis">Fork a repo on github</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-fork</code> [&lt;github-repo-url&gt;]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>  If a github repo url is given, fork the repo. Like clone but forks first.</p>
+
+<ol>
+<li>forks the repo on github</li>
+<li>clones the repo into the current dir</li>
+<li>adds the original repo as a remote called upstream</li>
+</ol>
+
+
+<p>  If a url is not given and the current dir is a github repo, fork the repo.</p>
+
+<ol>
+<li>forks the current repo</li>
+<li>rename the 'origin' remote repo to 'upstream'</li>
+<li>adds the forked repo as a remote called origin</li>
+</ol>
+
+
+<h2 id="EXAMPLE">EXAMPLE</h2>
+
+<p>  Fork expect.js:</p>
+
+<pre><code>$ git fork https://github.com/LearnBoost/expect.js
+</code></pre>
+
+<p>  or just:</p>
+
+<pre><code>$ git fork LearnBoost/expect.js
+</code></pre>
+
+<p>  Then:</p>
+
+<pre><code>$ ..&lt;forks into your github profile and clones repo locally to expect.js dir&gt;...
+
+$ cd expect.js &amp;&amp; git remote -v
+
+  origin          https://github.com/&lt;user>/expect.js (fetch)
+  origin          https://github.com/&lt;user>/expect.js (push)
+  upstream        https://github.com/LearnBoost/expect.js (fetch)
+  upstream        https://github.com/LearnBoost/expect.js (push)
+</code></pre>
+
+<p>  If the current dir is a clone of expect.js, this has the same effect:</p>
+
+<pre><code>$ git fork
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Andrew Griffiths &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#x6f;&#58;&#109;&#x61;&#x69;&#x6c;&#64;&#x61;&#x6e;&#x64;&#114;&#101;&#x77;&#103;&#x72;&#x69;&#102;&#102;&#105;&#116;&#x68;&#x73;&#x6f;&#x6e;&#108;&#105;&#110;&#101;&#x2e;&#99;&#111;&#109;" data-bare-link="true">&#x6d;&#97;&#x69;&#108;&#x40;&#97;&#x6e;&#x64;&#x72;&#x65;&#x77;&#103;&#x72;&#x69;&#102;&#102;&#x69;&#116;&#104;&#x73;&#x6f;&#110;&#108;&#x69;&#110;&#101;&#x2e;&#x63;&#111;&#x6d;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>July 2016</li>
+    <li class='tr'>git-fork(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -11,13 +11,13 @@ git-fork(1) -- Fork a repo on github
 
   1. forks the repo on github
   2. clones the repo into the current dir
-  3. adds the original repo as a remote called upstream
+  3. adds the original repo as a remote called `upstream`
 
   If a url is not given and the current dir is a github repo, fork the repo.
 
   1. forks the current repo
-  3. rename the 'origin' remote repo to 'upstream'
-  3. adds the forked repo as a remote called origin
+  3. rename the `origin` remote repo to `upstream`
+  3. adds the forked repo as a remote called `origin`
 
 ## EXAMPLE
 


### PR DESCRIPTION
Update #552 and #553 

* Add git-fork.html removed by accident
* Quote refs by backtick rather than single quote
* Fetch origin after forking