### PR TITLE
Set fork remotes using ssh instead of https

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -196,7 +196,7 @@ project  : git-extras
 
 ## git line-summary
 
-  WARNING: git line-summary has been replaced by git summary --line and will be removed in a future release. 
+  WARNING: git line-summary has been replaced by git summary --line and will be removed in a future release.
 
 ## git effort
 
@@ -215,7 +215,7 @@ $ git effort --above 5
 ```
 
   If you wish to see only the commits in the last month you may use `--since` (it supports the same syntax like `git log --since`):
-  
+
 ```
  $ git effort --since='last month'
 ```
@@ -319,7 +319,7 @@ Does the following:
 - forks the repo (prompts for github username and pass)
 - clones the repo into the current directory
 - adds the original repo as a remote so can track upstream changes
-- all remotes refs use git over ssh
+- all remotes refs use git over ssh if configured, otherwise https will be used
 
 
 ```Shell
@@ -427,7 +427,7 @@ To show just the global or just the local file's contents, you can use the follo
 
 * `-g` or `--global` to show just the global file
 * `-l` or `--local` to show just the local file
- 
+
 ```bash
 $ git ignore -g
 Global gitignore: /Users/foo/.gitignore_global
@@ -462,7 +462,7 @@ $ git ignore-io vim
     .netrwhist
     *~
 ```
-  
+
 To export it to `.gitignore` file you can use the following options:  
 
 * `-a` or `--append` to append the result to `.gitignore`
@@ -476,7 +476,7 @@ For efficiency, `git ignore-io` store all available types at `~/.gi_list`.
 To list all the available types:
 
 * `-l` or `-L` : These two options will show the list in different format. Just try it.
-  
+
 You can also search type from the list by:
 
 * `-s <word>` or `--search <word>`
@@ -804,7 +804,7 @@ Set up a git repository (if one doesn't exist), add all files, and make an initi
 
 A convenient way to copy files from the current working tree to the working directory of a remote repository. If a `<commits>...` is provided, only files that has changed within the commit range will be copied.
 
-Internally this script uses `rsync` and not `scp` as the name suggests. 
+Internally this script uses `rsync` and not `scp` as the name suggests.
 
 `git-rscp` - The reverse of `git-scp`. Copies specific files from the working directory of a remote repository to the current working directory.
 
@@ -1078,7 +1078,7 @@ Create pull request via commandline.
 
 ## git rebase-patch
 
-Given  you have a patch that doesn´t apply to the current HEAD, but you know it applied to some commit in the past, 
+Given  you have a patch that doesn´t apply to the current HEAD, but you know it applied to some commit in the past,
 `git rebase-patch` will help you find that commit and do a rebase.
 
 For example,
@@ -1108,4 +1108,3 @@ Sync local branch with origin/master
 ```bash
 $ git sync origin master
 ```
-

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -34,16 +34,25 @@ fi
 curl -X POST -u "$user" "https://api.github.com/repos/$owner/$project/forks"
 [ $? = 0 ] || abort "fork failed"
 
+# Check if user has ssh configured with GitHub
+ssh -o BatchMode=yes git@github.com exit >/dev/null 2>&1
+ssh_exit_code=$?
+if [[ "$ssh_exit_code" = 0 ]] || [[ "$ssh_exit_code" = 1 ]]; then
+  remote_prefix="git@github.com:"
+else
+  remote_prefix="https://github.com/"
+fi
+
 if [ "$origin" = true ]; then
     git remote rename origin upstream
-    git remote add origin "https://github.com/$user/$project"
+    git remote add origin "$remote_prefix$user/$project"
     git fetch origin
 else
     # clone forked repo into current dir
-    git clone "https://github.com/$user/$project" "$project"
+    git clone "$remote_prefix$user/$project" "$project"
 
     # add reference to origin fork so can merge in upstream changes
     cd "$project"
-    git remote add upstream "https://github.com/$owner/$project"
+    git remote add upstream "$remote_prefix$owner/$project"
     git fetch upstream
 fi

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-FORK" "1" "July 2016" "" "Git Extras"
+.TH "GIT\-FORK" "1" "August 2016" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-fork\fR \- Fork a repo on github
@@ -36,6 +36,9 @@ rename the \fBorigin\fR remote repo to \fBupstream\fR
 adds the forked repo as a remote called \fBorigin\fR
 .
 .IP "" 0
+.
+.P
+Remotes will use ssh if you have it configured with GitHub, if not, https will be used\.
 .
 .SH "EXAMPLE"
 Fork expect\.js:
@@ -74,10 +77,10 @@ $ \.\.<forks into your github profile and clones repo locally to expect\.js dir>
 
 $ cd expect\.js && git remote \-v
 
-  origin          https://github\.com/<user>/expect\.js (fetch)
-  origin          https://github\.com/<user>/expect\.js (push)
-  upstream        https://github\.com/LearnBoost/expect\.js (fetch)
-  upstream        https://github\.com/LearnBoost/expect\.js (push)
+  origin          git@github\.com:<user>/expect\.js (fetch)
+  origin          git@github\.com:<user>/expect\.js (push)
+  upstream        git@github\.com:LearnBoost/expect\.js (fetch)
+  upstream        git@github\.com:LearnBoost/expect\.js (push)
 .
 .fi
 .

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -97,6 +97,8 @@
 </ol>
 
 
+<p>  Remotes will use ssh if you have it configured with GitHub, if not, https will be used.</p>
+
 <h2 id="EXAMPLE">EXAMPLE</h2>
 
 <p>  Fork expect.js:</p>
@@ -115,10 +117,10 @@
 
 $ cd expect.js &amp;&amp; git remote -v
 
-  origin          https://github.com/&lt;user>/expect.js (fetch)
-  origin          https://github.com/&lt;user>/expect.js (push)
-  upstream        https://github.com/LearnBoost/expect.js (fetch)
-  upstream        https://github.com/LearnBoost/expect.js (push)
+  origin          git@github.com:&lt;user>/expect.js (fetch)
+  origin          git@github.com:&lt;user>/expect.js (push)
+  upstream        git@github.com:LearnBoost/expect.js (fetch)
+  upstream        git@github.com:LearnBoost/expect.js (push)
 </code></pre>
 
 <p>  If the current dir is a clone of expect.js, this has the same effect:</p>
@@ -128,7 +130,7 @@ $ cd expect.js &amp;&amp; git remote -v
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Andrew Griffiths &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#x6d;&#x61;&#x69;&#x6c;&#64;&#97;&#x6e;&#100;&#x72;&#101;&#x77;&#x67;&#x72;&#105;&#x66;&#x66;&#x69;&#x74;&#x68;&#x73;&#x6f;&#110;&#108;&#105;&#x6e;&#101;&#46;&#x63;&#111;&#109;" data-bare-link="true">&#x6d;&#x61;&#105;&#108;&#64;&#97;&#110;&#100;&#114;&#x65;&#119;&#x67;&#x72;&#x69;&#x66;&#102;&#105;&#116;&#x68;&#115;&#111;&#x6e;&#108;&#105;&#x6e;&#x65;&#x2e;&#x63;&#111;&#x6d;</a>&gt;</p>
+<p>Written by Andrew Griffiths &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#x6f;&#58;&#109;&#97;&#x69;&#x6c;&#64;&#x61;&#x6e;&#x64;&#x72;&#101;&#x77;&#103;&#114;&#x69;&#x66;&#102;&#105;&#116;&#x68;&#115;&#111;&#110;&#108;&#105;&#110;&#101;&#46;&#x63;&#111;&#x6d;" data-bare-link="true">&#109;&#97;&#105;&#x6c;&#x40;&#97;&#110;&#x64;&#114;&#101;&#x77;&#x67;&#114;&#x69;&#102;&#102;&#x69;&#x74;&#104;&#115;&#x6f;&#110;&#x6c;&#x69;&#110;&#x65;&#46;&#99;&#x6f;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -141,7 +143,7 @@ $ cd expect.js &amp;&amp; git remote -v
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2016</li>
+    <li class='tc'>August 2016</li>
     <li class='tr'>git-fork(1)</li>
   </ol>
 

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -16,8 +16,10 @@ git-fork(1) -- Fork a repo on github
   If a url is not given and the current dir is a github repo, fork the repo.
 
   1. forks the current repo
-  3. rename the `origin` remote repo to `upstream`
+  2. rename the `origin` remote repo to `upstream`
   3. adds the forked repo as a remote called `origin`
+
+  Remotes will use ssh if you have it configured with GitHub, if not, https will be used.
 
 ## EXAMPLE
 
@@ -35,10 +37,10 @@ git-fork(1) -- Fork a repo on github
 
     $ cd expect.js && git remote -v
 
-      origin          https://github.com/<user>/expect.js (fetch)
-      origin          https://github.com/<user>/expect.js (push)
-      upstream        https://github.com/LearnBoost/expect.js (fetch)
-      upstream        https://github.com/LearnBoost/expect.js (push)
+      origin          git@github.com:<user>/expect.js (fetch)
+      origin          git@github.com:<user>/expect.js (push)
+      upstream        git@github.com:LearnBoost/expect.js (fetch)
+      upstream        git@github.com:LearnBoost/expect.js (push)
 
   If the current dir is a clone of expect.js, this has the same effect:
 


### PR DESCRIPTION
Proposed in https://github.com/tj/git-extras/issues/540

This allows you to push changes to your fork without being prompted for your GitHub credentials every time.

Previous behaviour:

```
$ git fork tj/commander.js
Enter your github username
lukechilds
Enter host password for user 'lukechilds':
{
  ...
}
Cloning into 'commander.js'...
remote: Counting objects: 1791, done.
remote: Total 1791 (delta 0), reused 0 (delta 0), pack-reused 1791
Receiving objects: 100% (1791/1791), 381.24 KiB | 677.00 KiB/s, done.
Resolving deltas: 100% (977/977), done.
Checking connectivity... done.
From https://github.com/tj/commander.js
 * [new branch]      gh-pages   -> upstream/gh-pages
 * [new branch]      master     -> upstream/master

$ cd commander.js && git push
Username for 'https://github.com':
```

New behaviour:

```
$ git fork tj/commander.js
Enter your github username
lukechilds
Enter host password for user 'lukechilds':
{
  ...
}
Cloning into 'commander.js'...
remote: Counting objects: 1791, done.
remote: Total 1791 (delta 0), reused 0 (delta 0), pack-reused 1791
Receiving objects: 100% (1791/1791), 381.24 KiB | 309.00 KiB/s, done.
Resolving deltas: 100% (977/977), done.
Checking connectivity... done.
From github.com:tj/commander.js
 * [new branch]      gh-pages   -> upstream/gh-pages
 * [new branch]      master     -> upstream/master

$ cd commander.js && git push
Everything up-to-date
```