### PR TITLE
Remove a non-contributor from AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,7 +85,6 @@ Patches and Suggestions
 - ☃ pitr <pitr.vern@gmail.com>
 - Akim Demaille <akim@lrde.epita.fr>
 - Alex McHale <alexmchale@gmail.com>
-- Allan Odgaard <github@simplit.com>
 - Amir Tocker <tocker.signup@gmail.com>
 - Andrei Petcu <andreicristianpetcu@gmail.com>
 - Andrew Starr-Bochicchio <a.starr.b@gmail.com>


### PR DESCRIPTION
Since there is hesitation about PR #544 this is a quick fix to at least remove my email from the master (google the email in question and you’ll find this repository is the only hit).