### PR TITLE
git-missing: do proper argument parsing. Fix #562

### DIFF
--- a/bin/git-missing
+++ b/bin/git-missing
@@ -1,21 +1,41 @@
 #!/usr/bin/env bash
 
-# grab first two non-option arguments
-for arg in $*; do
-    if [ -n "${arg}" ]; then
-        test -z "$firstbranch" && firstbranch="${arg}" && continue
-        test -z "$secondbranch" && secondbranch="${arg}" && continue
-    else
-        # add anything else to a passthrough
-        passthrough="$passthrough $arg"
-    fi
-done
+usage() {
+    echo 1>&2 "usage: git missing [<first branch>] <second branch> [<git log options>]"
+}
 
-test -z "$firstbranch" && echo "at least one branch required" && exit 1
-
-if test -z "$secondbranch"; then
-    secondbranch=$firstbranch
-    firstbranch=
+if [ "${#}" -lt 1 ]
+then
+    usage
+    exit 1
 fi
 
-git log $passthrough $firstbranch...$secondbranch --format="%m %h %s" --left-right
+declare -a git_log_args=()
+declare -a branches=()
+for arg in "$@" ; do
+
+    case "$arg" in
+        --*)
+            git_log_args+=( "$arg" )
+            ;;
+        *)
+            branches+=( "$arg" )
+            ;;
+    esac
+done
+
+firstbranch=
+secondbranch=
+if [ ${#branches[@]} -eq 2 ]
+then
+    firstbranch="${branches[0]}"
+    secondbranch="${branches[1]}"
+elif [ ${#branches[@]} -eq 1 ]
+then
+    secondbranch="${branches[0]}"
+else
+    echo >&2 "error: at least one branch required"
+    exit 1
+fi
+
+git log "${git_log_args[@]}" "$firstbranch"..."$secondbranch" --format="%m %h %s" --left-right


### PR DESCRIPTION
Ref #562

This is a rewrite of `git-missing` to make it behave like the docs says it will.

I have tested by running these commands, which should be enough:
```sh
$ git missing feature
$ git missing master feature
$ git missing --no-merges feature
$ git missing --no-merges master feature
$ git missing --no-merges master feature --no-merges
```

That last one may seem stupid, but argument parsing, and especially passing arguments along to other commands in bash can be very tricky, so that one is important. `git log` doesn't care about duplicate arguments, so that's alright.

Only tested on OSX, with bash 4.3.46(1)-release.
I don't think there is anything that would make this crash on other systems, but I will test it on FreeBsd and Arch tomorrow.

___________
Possible future enhancements:

`git-missing` will get confused with a call looking like this: `git missing --option value firstbranch secondbranch`.  I don't know if `git log` accepts any argument on the form `--arg value`. I scanned `man git-log` and it doesn't look like it, but `git log` understands hundreds of different arguments it looks like, so I may be wrong.

