### PR TITLE
git-release: fix typo in documentation

### DIFF
--- a/man/git-release.1
+++ b/man/git-release.1
@@ -10,7 +10,7 @@
 \fBgit\-release\fR <tagname> [\-r <remote>] [\-m <commit info%gt;] [\-c]
 .
 .SH "DESCRIPTION"
-Commits changes with message "Release <tagname>" or custom commit infomation, tags with the given <tagname> and pushes the branch / tags\. Optionally it generates a changelog (see git\-changelog) and a remote can be defined\. The order of first \-c or \-r does not matter\.
+Commits changes with message "Release <tagname>" or custom commit information, tags with the given <tagname> and pushes the branch / tags\. Optionally it generates a changelog (see git\-changelog) and a remote can be defined\. The order of first \-c or \-r does not matter\.
 .
 .SH "OPTIONS"
 <tagname>
@@ -28,7 +28,7 @@ The "remote" repository that is destination of a push operation: it is passed to
 \-m <commit info>
 .
 .P
-use the custom commit infomation instead of the default message "Release <tagname>" \.
+use the custom commit information instead of the default message "Release <tagname>" \.
 .
 .P
 \-c

--- a/man/git-release.html
+++ b/man/git-release.html
@@ -80,7 +80,7 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Commits changes with message "Release &lt;tagname&gt;" or custom commit infomation, tags with the given &lt;tagname&gt; and pushes the branch / tags.
+<p>  Commits changes with message "Release &lt;tagname&gt;" or custom commit information, tags with the given &lt;tagname&gt; and pushes the branch / tags.
   Optionally it generates a changelog (see git-changelog) and a remote can be defined. The order of first -c or -r does not matter.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
@@ -95,7 +95,7 @@
 
 <p>  -m &lt;commit info&gt;</p>
 
-<p>  use the custom commit infomation instead of the default message "Release &lt;tagname&gt;" .</p>
+<p>  use the custom commit information instead of the default message "Release &lt;tagname&gt;" .</p>
 
 <p>  -c</p>
 

--- a/man/git-release.md
+++ b/man/git-release.md
@@ -7,7 +7,7 @@ git-release(1) -- Commit, tag and push changes to the repository
 
 ## DESCRIPTION
 
-  Commits changes with message "Release &lt;tagname&gt;" or custom commit infomation, tags with the given &lt;tagname&gt; and pushes the branch / tags.
+  Commits changes with message "Release &lt;tagname&gt;" or custom commit information, tags with the given &lt;tagname&gt; and pushes the branch / tags.
   Optionally it generates a changelog (see git-changelog) and a remote can be defined. The order of first -c or -r does not matter.
 
 ## OPTIONS
@@ -22,7 +22,7 @@ git-release(1) -- Commit, tag and push changes to the repository
   
   -m &lt;commit info&gt;
 
-  use the custom commit infomation instead of the default message "Release &lt;tagname&gt;" .
+  use the custom commit information instead of the default message "Release &lt;tagname&gt;" .
 
   -c
   


### PR DESCRIPTION
"infomation" -> "information"