### PR TITLE
pull-request: should read local config if present

### DIFF
--- a/bin/git-pull-request
+++ b/bin/git-pull-request
@@ -30,7 +30,7 @@ EOF
 
 # user
 
-user=$(git config --global user.email)
+user=$(git config user.email)
 test -z "$user" && abort "git config user.email required"
 
 # branch

--- a/man/git-pull-request.1
+++ b/man/git-pull-request.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-PULL\-REQUEST" "1" "July 2016" "" ""
+.TH "GIT\-PULL\-REQUEST" "1" "August 2016" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-pull\-request\fR \- Create pull request for GitHub project
@@ -11,6 +11,9 @@
 .
 .SH "DESCRIPTION"
 Create pull request for a project on GitHub via commandline\.
+.
+.P
+Uses the email from \fBgit config user\.email\fR to open the pull request\.
 .
 .SH "OPTIONS"
 <target branch>

--- a/man/git-pull-request.html
+++ b/man/git-pull-request.html
@@ -65,7 +65,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-pull-request(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-pull-request(1)</li>
   </ol>
 
@@ -81,6 +81,8 @@
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
 <p>Create pull request for a project on GitHub via commandline.</p>
+
+<p>Uses the email from <code>git config user.email</code> to open the pull request.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -105,7 +107,7 @@ Enter host password for user 'spacewanderlzx@gmail.com':
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#105;&#108;&#116;&#x6f;&#x3a;&#116;&#106;&#x40;&#118;&#105;&#115;&#105;&#x6f;&#110;&#45;&#x6d;&#101;&#100;&#105;&#x61;&#x2e;&#99;&#x61;" data-bare-link="true">&#116;&#106;&#x40;&#x76;&#105;&#x73;&#105;&#111;&#110;&#45;&#x6d;&#x65;&#x64;&#x69;&#x61;&#46;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#x61;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x74;&#106;&#x40;&#x76;&#105;&#115;&#105;&#x6f;&#110;&#x2d;&#109;&#x65;&#x64;&#105;&#97;&#46;&#x63;&#97;" data-bare-link="true">&#116;&#106;&#x40;&#118;&#105;&#115;&#105;&#x6f;&#x6e;&#45;&#x6d;&#101;&#100;&#105;&#x61;&#x2e;&#99;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -118,7 +120,7 @@ Enter host password for user 'spacewanderlzx@gmail.com':
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2016</li>
+    <li class='tc'>August 2016</li>
     <li class='tr'>git-pull-request(1)</li>
   </ol>
 

--- a/man/git-pull-request.md
+++ b/man/git-pull-request.md
@@ -9,6 +9,8 @@ git-pull-request(1) -- Create pull request for GitHub project
 
 Create pull request for a project on GitHub via commandline.
 
+Uses the email from `git config user.email` to open the pull request.
+
 ## OPTIONS
 
 &lt;target branch&gt;


### PR DESCRIPTION
Ref: #546 

Removes the `--global` option to `git config user.email`. This is a saner and more predictable approach.