### PR TITLE
Add built in 'exit' command to git-repl

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -248,6 +248,8 @@ bin/git-release
 git> quit
 ```
 
+You can use `exit` instead of `quit`.
+
 ## git commits-since
 
 List commits since `date` (defaults to "last week"):

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -28,7 +28,7 @@ while true; do
   case $cmd in
     ls) cmd=ls-files;;
     "") continue;;
-    quit) break;;
+    quit|exit) break;;
   esac
 
   if [[ $cmd == !*  ]]; then

--- a/man/git-repl.1
+++ b/man/git-repl.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-REPL" "1" "December 2015" "" ""
+.TH "GIT\-REPL" "1" "August 2016" "" ""
 .
 .SH "NAME"
 \fBgit\-repl\fR \- git read\-eval\-print\-loop
@@ -36,6 +36,9 @@ git> quit
 .fi
 .
 .IP "" 0
+.
+.P
+You can use \fBexit\fR instead of \fBquit\fR\.
 .
 .SH "EXAMPLES"
 .

--- a/man/git-repl.html
+++ b/man/git-repl.html
@@ -100,11 +100,13 @@ bin/git-release
 git&gt; quit
 </code></pre>
 
+<p>  You can use <code>exit</code> instead of <code>quit</code>.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#105;&#x6c;&#116;&#111;&#58;&#116;&#106;&#64;&#x76;&#105;&#x73;&#x69;&#x6f;&#110;&#x2d;&#109;&#101;&#100;&#x69;&#x61;&#x2e;&#99;&#x61;" data-bare-link="true">&#x74;&#106;&#x40;&#x76;&#x69;&#115;&#x69;&#x6f;&#x6e;&#45;&#x6d;&#x65;&#x64;&#x69;&#97;&#x2e;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#x61;&#x69;&#x6c;&#116;&#x6f;&#58;&#116;&#x6a;&#x40;&#118;&#x69;&#115;&#x69;&#x6f;&#x6e;&#45;&#x6d;&#x65;&#x64;&#x69;&#97;&#46;&#x63;&#x61;" data-bare-link="true">&#116;&#106;&#x40;&#118;&#x69;&#115;&#x69;&#111;&#x6e;&#45;&#109;&#x65;&#100;&#105;&#97;&#46;&#x63;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -117,7 +119,7 @@ git&gt; quit
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2015</li>
+    <li class='tc'>August 2016</li>
     <li class='tr'>git-repl(1)</li>
   </ol>
 

--- a/man/git-repl.md
+++ b/man/git-repl.md
@@ -26,6 +26,8 @@ git-repl(1) -- git read-eval-print-loop
  
     git> quit
 
+  You can use `exit` instead of `quit`.
+
 ## EXAMPLES
 
 ## AUTHOR


### PR DESCRIPTION
This just adds the ability to use `exit` to quit git-repl, in addition to the built-in `quit`.