### PR TITLE
Update git-delete-branch

### DIFF
--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -1,16 +1,94 @@
 #!/usr/bin/env bash
 
-# Assert there is at least one branch provided
-test -z $1 && echo "branch required." 1>&2 && exit 1
+set -u
 
-for branch in "$@"
-do
-  remote=$(git config branch.$branch.remote)
-  test -z $remote && remote="origin"
-  ref=$(git config branch.$branch.merge)
-  test -z $ref && ref="refs/heads/$branch"
+usage()
+{
+    local command="git delete-branch"
+    cat << EOF
+Usage:
+    ${command} [-r <remote[:remote branch name]>] <branch>
+    ${command} -h
 
-  git branch -D $branch
-  git branch -d -r $remote/$branch
-  git push $remote :$ref
+Delete local and remote branches. If the remote switch (-r) is provided, then
+use the given remote and remote branch. Otherwise, the remote branch is found
+by first trying the upstream tracking branch. If there is no tracking branch
+configured, then deletion will not succeed unless provided explicitly. If the
+remote branch and local branch do not share a name, the remote branch name can
+be included with the remote switch.
+EOF
+}
+
+remote=
+remote_branch=
+
+while getopts "r:h" opt; do
+    case "$opt" in
+        r)
+            remote="$(echo ${OPTARG} | cut -d ':' -f 1)"
+            remote_branch="$(echo ${OPTARG} | cut -s -d ':' -f 2)"
+
+            # Remote must not be empty string, or anything of that sort. The
+            # remote branch need not be provided here.
+            if [[ -z "$remote" ]]; then
+                echo "error: Provided empty remote name"
+                usage
+                exit 1
+            fi
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        \?)
+            usage
+            exit 1
+            ;;
+    esac
 done
+
+shift $((OPTIND-1))
+
+if [[ $# -ne 1 ]]; then
+    echo "error: Need a single branch as a positional argument"
+    usage
+    exit 1
+fi
+
+branch="$1"
+
+# If the -r option was not passed, then both the remote and the remote branch
+# have to be assumed using the tracking configuration. Need to make sure that
+# these values are set as both can be set/unset and both are necessary in this
+# case.
+if [[ -z "$remote" ]]; then
+    remote="$(git config --get branch.${branch}.remote)"
+    if [[ $? -ne 0 ]]; then
+            echo "error: $branch not tracking a repository"
+            usage
+            exit 1
+    fi
+
+    remote_branch="$(git config --get branch.${branch}.merge)"
+    if [[ $? -ne 0 ]]; then
+            echo "error: $branch not tracking a remote branch"
+            usage
+            exit 1
+    fi
+elif [[ -z "$remote_branch" ]]; then
+    # In the event that a remote is specified but no remote branch is
+    # specified, then assume the branch name is the same as the local branch.
+    remote_branch="$branch"
+fi
+
+git branch -d "$branch"
+ret=$?
+if [[ $ret -ne 0 ]]; then
+    exit $ret
+fi
+
+git push "${remote}" ":${remote_branch}"
+ret=$?
+if [[ $ret -ne 0 ]]; then
+    exit $ret
+fi

--- a/man/git-delete-branch.1
+++ b/man/git-delete-branch.1
@@ -1,34 +1,43 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-DELETE\-BRANCH" "1" "December 2015" "" ""
+.TH "GIT\-DELETE\-BRANCH" "1" "September 2016" "" ""
 .
 .SH "NAME"
 \fBgit\-delete\-branch\fR \- Delete branches
 .
 .SH "SYNOPSIS"
-\fBgit\-delete\-branch\fR <branchname>
+\fBgit\-delete\-branch\fR [\-r <remote[:remote branch name]>] <branchname>
 .
 .SH "DESCRIPTION"
-Deletes local and remote branch named <branchname>\. Note that local deletion fails if the branch is checked out\.
-.
-.SH "OPTIONS"
-<branchname>
+Delete local and remote branches\. If the remote switch (\-r) is provided, then use the given remote and remote branch\. Otherwise, the remote branch is found by first trying the upstream tracking branch\. If there is no tracking branch configured, then deletion will not succeed unless provided explicitly\. If the remote branch and local branch do not share a name, the remote branch name can be included with the remote switch\.
 .
 .P
-The name of the branch to delete\. If multiple branches are provided, then they will all be deleted\.
+Local deletion will fail if the branch is currently checked out\. If the local operation fails, then the remote operation will not run\.
+.
+.SH "OPTIONS"
+\-r
+.
+.P
+Specify a remote name and a remote branch name to use during the remote branch deletion\.
 .
 .SH "EXAMPLES"
+Delete the branch "ex1", the upstream tracking information is used\.
 .
-.nf
-
-$ git delete\-branch integration
-$ git delete\-branch integration bug/1234
+.P
+$ git delete\-branch ex1
 .
-.fi
+.P
+Delete the local branch "ex2", and the remote branch "ex2\-1" at remote "upstream"\.
+.
+.P
+$ git delete\-branch \-r upstream:ext2\-1 ex2
 .
 .SH "AUTHOR"
 Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>
+.
+.P
+Extended by Ben Turrubiates <ben@turrubiat\.es>
 .
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>

--- a/man/git-delete-branch.html
+++ b/man/git-delete-branch.html
@@ -76,29 +76,43 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-delete-branch</code> &lt;branchname&gt;</p>
+<p><code>git-delete-branch</code> [-r &lt;remote[:remote branch name]&gt;] &lt;branchname&gt;</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Deletes local and remote branch named &lt;branchname&gt;.
-  Note that local deletion fails if the branch is checked out.</p>
+<p>Delete local and remote branches. If the remote switch (-r) is provided, then
+use the given remote and remote branch. Otherwise, the remote branch is found
+by first trying the upstream tracking branch. If there is no tracking branch
+configured, then deletion will not succeed unless provided explicitly. If the
+remote branch and local branch do not share a name, the remote branch name can
+be included with the remote switch.</p>
+
+<p>Local deletion will fail if the branch is currently checked out. If the local
+operation fails, then the remote operation will not run.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  &lt;branchname&gt;</p>
+<p>-r</p>
 
-<p>  The name of the branch to delete.
-  If multiple branches are provided, then they will all be deleted.</p>
+<p>Specify a remote name and a remote branch name to use during the remote
+branch deletion.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<pre><code>$ git delete-branch integration
-$ git delete-branch integration bug/1234
-</code></pre>
+<p>Delete the branch "ex1", the upstream tracking information is used.</p>
+
+<p>$ git delete-branch ex1</p>
+
+<p>Delete the local branch "ex2", and the remote branch "ex2-1" at remote
+"upstream".</p>
+
+<p>$ git delete-branch -r upstream:ext2-1 ex2</p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#x61;&#x69;&#x6c;&#116;&#111;&#x3a;&#x74;&#106;&#64;&#x76;&#x69;&#x73;&#x69;&#111;&#x6e;&#45;&#x6d;&#x65;&#x64;&#105;&#x61;&#46;&#x63;&#x61;" data-bare-link="true">&#x74;&#106;&#x40;&#118;&#x69;&#x73;&#x69;&#x6f;&#110;&#45;&#x6d;&#101;&#100;&#x69;&#97;&#46;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#x61;&#x69;&#x6c;&#x74;&#111;&#x3a;&#116;&#x6a;&#64;&#118;&#105;&#x73;&#x69;&#x6f;&#x6e;&#45;&#109;&#x65;&#x64;&#x69;&#x61;&#x2e;&#x63;&#x61;" data-bare-link="true">&#116;&#x6a;&#x40;&#x76;&#x69;&#115;&#105;&#111;&#110;&#45;&#x6d;&#101;&#x64;&#x69;&#97;&#x2e;&#x63;&#97;</a>&gt;</p>
+
+<p>Extended by Ben Turrubiates &lt;ben@turrubiat.es&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -111,7 +125,7 @@ $ git delete-branch integration bug/1234
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2015</li>
+    <li class='tc'>September 2016</li>
     <li class='tr'>git-delete-branch(1)</li>
   </ol>
 

--- a/man/git-delete-branch.md
+++ b/man/git-delete-branch.md
@@ -3,28 +3,43 @@ git-delete-branch(1) -- Delete branches
 
 ## SYNOPSIS
 
-`git-delete-branch` &lt;branchname&gt;
+`git-delete-branch` [-r &lt;remote[:remote branch name]&gt;] &lt;branchname&gt;
 
 ## DESCRIPTION
 
-  Deletes local and remote branch named &lt;branchname&gt;.
-  Note that local deletion fails if the branch is checked out.
+Delete local and remote branches. If the remote switch (-r) is provided, then
+use the given remote and remote branch. Otherwise, the remote branch is found
+by first trying the upstream tracking branch. If there is no tracking branch
+configured, then deletion will not succeed unless provided explicitly. If the
+remote branch and local branch do not share a name, the remote branch name can
+be included with the remote switch.
+
+Local deletion will fail if the branch is currently checked out. If the local
+operation fails, then the remote operation will not run.
 
 ## OPTIONS
 
-  &lt;branchname&gt;
+-r
 
-  The name of the branch to delete.
-  If multiple branches are provided, then they will all be deleted.
+Specify a remote name and a remote branch name to use during the remote
+branch deletion.
 
 ## EXAMPLES
 
-    $ git delete-branch integration
-    $ git delete-branch integration bug/1234
+Delete the branch "ex1", the upstream tracking information is used.
+
+$ git delete-branch ex1
+
+Delete the local branch "ex2", and the remote branch "ex2-1" at remote
+"upstream".
+
+$ git delete-branch -r upstream:ext2-1 ex2
 
 ## AUTHOR
 
 Written by Tj Holowaychuk &lt;<tj@vision-media.ca>&gt;
+
+Extended by Ben Turrubiates &lt;ben@turrubiat.es&gt;
 
 ## REPORTING BUGS
 


### PR DESCRIPTION
Instead of assuming 'origin' as the remote, default to using the remote
tracking configuration. This can be overridden by using the `-r` option to
provide a remote name and a remote branch name. This also removes the ability
to delete multiple branches at once.

Closes #514.

@hemanth, apologies this took so long. I haven't updated the completions file yet,
need to figure that out.

Thoughts?
