### PR TITLE
count: remove usage of extra arguments for detailed display

### DIFF
--- a/bin/git-count
+++ b/bin/git-count
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if test "$1" = "--all"; then
-  git shortlog -n -s $@ | awk '{print substr($0,index($0,$2)) " (" $1 ")"}'
+  git shortlog -n -s | awk '{print substr($0,index($0,$2)) " (" $1 ")"}'
   echo
 fi
 


### PR DESCRIPTION
When viewing detailed count information through the usage of the
--all argument, extra arguments would be also passed to the
git shortlog command (probably to be used as revisions list)
This behaviour was introduced in commit 7a60cd1.

Unfortunately the --all argument itself is passed along and results
in the counts of all refs to be displayed
This commit removed the usage of extra arguments and thus only
display the counts of the current branch
