### PR TITLE
Add git stamp

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -997,16 +997,17 @@ Issue FOO-456 #close
 Review https://reviews.foo.org/r/4567/
 ```
 
-Replace previous issues with a new one
+Replace previous issues with a new one  
+(Note that the identifier is case insensitive)
 
 ```bash
-$ git stamp --replace Issue BAR-123
+$ git stamp --replace issue BAR-123
 
 Fix timezone bug
 
 Review https://reviews.foo.org/r/4567/
 
-Issue BAR-123
+issue BAR-123
 ```
 
 

--- a/Commands.md
+++ b/Commands.md
@@ -974,13 +974,26 @@ Reference the issues numbers from your bug tracker
 
 ```bash
 $ git stamp Issue FOO-123
+
+commit 787590e42c9bacd249f3b79faee7aecdc9de28ec
+Author: Jack <jack@work.com>
+Commit: Jack <jack@work.com>
+
+    Fix timezone bug
+
+    Issue FOO-123
+
 $ git stamp Issue FOO-456 \#close
 
-Fix timezone bug
+commit f8d920511e052bea39ce2088d1d723b475aeff87
+Author: Jack <jack@work.com>
+Commit: Jack <jack@work.com>
 
-Issue FOO-123
+    Fix timezone bug
 
-Issue FOO-456 #close
+    Issue FOO-123
+
+    Issue FOO-456 #close
 ```
 
 Link to its review page
@@ -988,13 +1001,17 @@ Link to its review page
 ```bash
 $ git stamp Review https://reviews.foo.org/r/4567/
 
-Fix timezone bug
+commit 6c6bcf43bd32a76e37b6fc9708d3ff0ae723c7da
+Author: Jack <jack@work.com>
+Commit: Jack <jack@work.com>
 
-Issue FOO-123
+    Fix timezone bug
 
-Issue FOO-456 #close
+    Issue FOO-123
 
-Review https://reviews.foo.org/r/4567/
+    Issue FOO-456 #close
+
+    Review https://reviews.foo.org/r/4567/
 ```
 
 Replace previous issues with a new one  
@@ -1003,11 +1020,15 @@ Replace previous issues with a new one
 ```bash
 $ git stamp --replace issue BAR-123
 
-Fix timezone bug
+commit 2b93c56b2340578cc3478008e2cadb05a7bcccfa
+Author: Jack <jack@work.com>
+Commit: Jack <jack@work.com>
 
-Review https://reviews.foo.org/r/4567/
+    Fix timezone bug
 
-issue BAR-123
+    Review https://reviews.foo.org/r/4567/
+
+    issue BAR-123
 ```
 
 

--- a/Commands.md
+++ b/Commands.md
@@ -974,7 +974,7 @@ Reference the issues numbers from your bug tracker
 
 ```bash
 $ git stamp Issue FOO-123
-$ git stamp Issue "FOO-456 #close"
+$ git stamp Issue FOO-456 \#close
 
 Fix timezone bug
 

--- a/Commands.md
+++ b/Commands.md
@@ -56,6 +56,7 @@
  - [`git show-merged-branches`](#git-show-merged-branches)
  - [`git show-tree`](#git-show-tree)
  - [`git show-unmerged-branches`](#git-show-unmerged-branches)
+ - [`git stamp`](#git-stamp)
  - [`git squash`](#git-squash)
  - [`git standup`](#git-standup)
  - [`git summary`](#git-summary)
@@ -957,6 +958,57 @@ For example, running `git show-tree` will display:
 ```
 
 Be free to try it for yourself!
+
+
+## git stamp
+
+Stamp the last commit message
+
+Commit message is
+
+```bash
+Fix timezone bug
+```
+
+Reference the issues numbers from your bug tracker
+
+```bash
+$ git stamp Issue FOO-123
+$ git stamp Issue "FOO-456 #close"
+
+Fix timezone bug
+
+Issue FOO-123
+
+Issue FOO-456 #close
+```
+
+Link to its review page
+
+```bash
+$ git stamp Review https://reviews.foo.org/r/4567/
+
+Fix timezone bug
+
+Issue FOO-123
+
+Issue FOO-456 #close
+
+Review https://reviews.foo.org/r/4567/
+```
+
+Replace previous issues with a new one
+
+```bash
+$ git stamp --replace Issue BAR-123
+
+Fix timezone bug
+
+Review https://reviews.foo.org/r/4567/
+
+Issue BAR-123
+```
+
 
 ## git standup
 

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -39,7 +39,7 @@ stamp() {
     # remove previous stamps with same ID from the commit message
     commit_msg=$(
       echo "${commit_msg}" \
-        | grep --invert-match "^${ID}\b" \
+        | grep --ignore-case --invert-match "^${ID}\b" \
         | cat --squeeze-blank
     )
   fi

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -12,7 +12,7 @@ init_variables() {
 
 usage() {
   cat << EOF
-usage: git ${COMMAND} [<options>] <id> [<message>]
+usage: git ${COMMAND} [<options>] <id> [<messages>]
 
 Options:
     -r, --replace    replace all previous stamps with same id
@@ -73,7 +73,7 @@ parse_options() {
   done
   
   ID="$1"
-  MSG="$2"
+  MSG="${@:2}"
 }
 
 

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+
+init_variables() {
+  COMMAND=${0#*-}
+
+  unset ID
+}
+
+
+usage() {
+  cat << EOF
+usage: git ${COMMAND} [<options>] <id>
+EOF
+}
+
+
+error() {
+  if [[ -n "$1" ]]; then
+    local msg=$( echo "error: $1" | sed 's/\\n/\\n       /g' )
+    echo -e "${msg}" >&2
+  fi
+  usage
+  exit 1
+}
+
+
+stamp() {
+  local commit_msg=$( git log -1 --pretty=%B )
+  
+  git commit --amend \
+    --message "${commit_msg}" \
+    --message "${ID}"
+}
+
+
+parse_options() {
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -h)
+        usage
+        exit 0
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  
+  ID="$1"
+}
+
+
+validate_options() {
+  # ID should be set to non-empty string
+  if [[ -z "${ID}" ]]; then
+    error "missing stamp identifier"
+  fi
+}
+
+
+init_variables
+parse_options "$@"
+validate_options
+
+stamp

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -5,12 +5,13 @@ init_variables() {
   COMMAND=${0#*-}
 
   unset ID
+  unset MSG
 }
 
 
 usage() {
   cat << EOF
-usage: git ${COMMAND} [<options>] <id>
+usage: git ${COMMAND} [<options>] <id> [<message>]
 EOF
 }
 
@@ -27,10 +28,12 @@ error() {
 
 stamp() {
   local commit_msg=$( git log -1 --pretty=%B )
+  local stamp_msg
+  [[ -n "${MSG}" ]] && stamp_msg="${ID} ${MSG}" || stamp_msg="${ID}"
   
   git commit --amend \
     --message "${commit_msg}" \
-    --message "${ID}"
+    --message "${stamp_msg}"
 }
 
 
@@ -48,6 +51,7 @@ parse_options() {
   done
   
   ID="$1"
+  MSG="$2"
 }
 
 

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -22,7 +22,7 @@ EOF
 
 error() {
   if [[ -n "$1" ]]; then
-    local msg=$( echo "error: $1" | sed 's/\\n/\\n       /g' )
+    local msg=$( echo "error: $1" )
     echo -e "${msg}" >&2
   fi
   usage

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -4,6 +4,7 @@
 init_variables() {
   COMMAND=${0#*-}
 
+  REPLACE=false
   unset ID
   unset MSG
 }
@@ -12,6 +13,9 @@ init_variables() {
 usage() {
   cat << EOF
 usage: git ${COMMAND} [<options>] <id> [<message>]
+
+Options:
+    -r, --replace    replace all previous stamps with same id
 EOF
 }
 
@@ -31,6 +35,16 @@ stamp() {
   local stamp_msg
   [[ -n "${MSG}" ]] && stamp_msg="${ID} ${MSG}" || stamp_msg="${ID}"
   
+  if ${REPLACE}; then
+    # remove previous stamps with same ID from the commit message
+    commit_msg=$(
+      echo "${commit_msg}" \
+        | grep --invert-match "^${ID}\b" \
+        | cat --squeeze-blank
+    )
+  fi
+
+  # append the stamp to the commit message in a new paragraph
   git commit --amend \
     --message "${commit_msg}" \
     --message "${stamp_msg}" \
@@ -47,6 +61,10 @@ parse_options() {
       -h)
         usage
         exit 0
+        ;;
+      --replace|-r)
+        REPLACE=true
+        shift
         ;;
       *)
         break

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -33,7 +33,11 @@ stamp() {
   
   git commit --amend \
     --message "${commit_msg}" \
-    --message "${stamp_msg}"
+    --message "${stamp_msg}" \
+    > /dev/null
+
+  # show result
+  git log -1 --pretty=full
 }
 
 

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -134,6 +134,10 @@ _git_scp(){
   __git_complete_remote_or_refspec
 }
 
+_git_stamp(){
+  __gitcomp '--replace -r'
+}
+
 _git_rscp(){
   __git_complete_remote_or_refspec
 }

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -337,6 +337,10 @@ _git-squash() {
         ':branch-name:__gitex_branch_names'
 }
 
+_git-stamp() {
+    _arguments  -C \
+         '(--replace -r)'{--replace,-r}'[replace stamps with same id]'
+}
 
 _git-summary() {
     _arguments '--line[summarize with lines rather than commits]'
@@ -407,6 +411,7 @@ zstyle ':completion:*:*:git:*' user-commands \
     show-tree:'show branch tree of commit history' \
     show-unmerged-branches:'show unmerged branches' \
     squash:'import changes from a branch' \
+    stamp:'stamp the last commit message' \
     standup:'recall the commit history' \
     summary:'show repository summary' \
     sync:'sync local branch with remote branch' \

--- a/man/git-stamp.1
+++ b/man/git-stamp.1
@@ -32,6 +32,7 @@ With this flag, all the related stamps with the same identifier will be removed 
 .nf
 
 Replace all previous stamps in the last commit message that have the same identifier
+The identifier is case insensitive for this replacement
 .
 .fi
 .
@@ -94,17 +95,20 @@ $ git stamp Review https://reviews\.foo\.org/r/4567/
 .P
 Replace previous issues with a new one
 .
+.br
+(Note that the identifier is case insensitive)
+.
 .IP "" 4
 .
 .nf
 
-$ git stamp \-\-replace Issue BAR\-123
+$ git stamp \-\-replace issue BAR\-123
 
 | Fix timezone bug
 |
 | Review https://reviews\.foo\.org/r/4567/
 |
-| Issue BAR\-123
+| issue BAR\-123
 .
 .fi
 .

--- a/man/git-stamp.1
+++ b/man/git-stamp.1
@@ -24,6 +24,9 @@ You can change this behavior by using the \-\-replace flag\.
 .br
 With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended\.
 .
+.P
+\fBWARNING!\fR If a commit message without stamp have a line starting with the same identifier, it will be interpreted as a stamp
+.
 .SH "OPTIONS"
 \-r, \-\-replace
 .

--- a/man/git-stamp.1
+++ b/man/git-stamp.1
@@ -7,7 +7,7 @@
 \fBgit\-stamp\fR \- Stamp the last commit message
 .
 .SH "SYNOPSIS"
-\fBgit stamp [<options>] <id> [<message>]\fR
+\fBgit stamp [<options>] <id> [<messages>]\fR
 .
 .SH "DESCRIPTION"
 Lets you amend the last commit with a stamp message\.
@@ -59,7 +59,7 @@ Reference the issues numbers from your bug tracker
 .nf
 
 $ git stamp Issue FOO\-123
-$ git stamp Issue "FOO\-456 #close"
+$ git stamp Issue FOO\-456 \e#close
 
 | Fix timezone bug
 |

--- a/man/git-stamp.1
+++ b/man/git-stamp.1
@@ -1,0 +1,120 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-STAMP" "1" "October 2016" "" ""
+.
+.SH "NAME"
+\fBgit\-stamp\fR \- Stamp the last commit message
+.
+.SH "SYNOPSIS"
+\fBgit stamp [<options>] <id> [<message>]\fR
+.
+.SH "DESCRIPTION"
+Lets you amend the last commit with a stamp message\.
+.
+.P
+The command appends a message with its identifier to the last commit message\.
+.
+.br
+By default all stamps are appended as a new paragraph to the commit message\.
+.
+.br
+You can change this behavior by using the \-\-replace flag\.
+.
+.br
+With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended\.
+.
+.SH "OPTIONS"
+\-r, \-\-replace
+.
+.IP "" 4
+.
+.nf
+
+Replace all previous stamps in the last commit message that have the same identifier
+.
+.fi
+.
+.IP "" 0
+.
+.SH "EXAMPLES"
+Commit message is
+.
+.IP "" 4
+.
+.nf
+
+| Fix timezone bug
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Reference the issues numbers from your bug tracker
+.
+.IP "" 4
+.
+.nf
+
+$ git stamp Issue FOO\-123
+$ git stamp Issue "FOO\-456 #close"
+
+| Fix timezone bug
+|
+| Issue FOO\-123
+|
+| Issue FOO\-456 #close
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Link to its review page
+.
+.IP "" 4
+.
+.nf
+
+$ git stamp Review https://reviews\.foo\.org/r/4567/
+
+| Fix timezone bug
+|
+| Issue FOO\-123
+|
+| Issue FOO\-456 #close
+|
+| Review https://reviews\.foo\.org/r/4567/
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Replace previous issues with a new one
+.
+.IP "" 4
+.
+.nf
+
+$ git stamp \-\-replace Issue BAR\-123
+
+| Fix timezone bug
+|
+| Review https://reviews\.foo\.org/r/4567/
+|
+| Issue BAR\-123
+.
+.fi
+.
+.IP "" 0
+.
+.SH "AUTHOR"
+Written by Damien Tardy\-Panis <\fIdamien@tardypad\.me\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttp://github\.com/tj/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-stamp.html
+++ b/man/git-stamp.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-stamp(1) - Stamp the last commit message</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-stamp(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-stamp(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-stamp</code> - <span class="man-whatis">Stamp the last commit message</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git stamp [&lt;options>] &lt;id> [&lt;message>]</code></p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>Lets you amend the last commit with a stamp message.</p>
+
+<p>The command appends a message with its identifier to the last commit message.<br />
+By default all stamps are appended as a new paragraph to the commit message.<br />
+You can change this behavior by using the --replace flag.<br />
+With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -r, --replace</p>
+
+<pre><code>Replace all previous stamps in the last commit message that have the same identifier
+</code></pre>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>Commit message is</p>
+
+<pre><code>| Fix timezone bug
+</code></pre>
+
+<p>Reference the issues numbers from your bug tracker</p>
+
+<pre><code>$ git stamp Issue FOO-123
+$ git stamp Issue "FOO-456 #close"
+
+| Fix timezone bug
+| 
+| Issue FOO-123
+| 
+| Issue FOO-456 #close
+</code></pre>
+
+<p>Link to its review page</p>
+
+<pre><code>$ git stamp Review https://reviews.foo.org/r/4567/
+
+| Fix timezone bug
+|
+| Issue FOO-123
+|
+| Issue FOO-456 #close
+| 
+| Review https://reviews.foo.org/r/4567/
+</code></pre>
+
+<p>Replace previous issues with a new one</p>
+
+<pre><code>$ git stamp --replace Issue BAR-123
+
+| Fix timezone bug
+|
+| Review https://reviews.foo.org/r/4567/
+|
+| Issue BAR-123
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Damien Tardy-Panis &lt;<a href="&#109;&#x61;&#105;&#108;&#116;&#111;&#58;&#x64;&#x61;&#109;&#x69;&#x65;&#110;&#x40;&#116;&#x61;&#114;&#100;&#x79;&#x70;&#x61;&#x64;&#x2e;&#109;&#101;" data-bare-link="true">&#x64;&#97;&#x6d;&#x69;&#101;&#x6e;&#x40;&#x74;&#x61;&#x72;&#100;&#121;&#x70;&#x61;&#x64;&#46;&#109;&#101;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="http://github.com/tj/git-extras/issues" data-bare-link="true">http://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>October 2016</li>
+    <li class='tr'>git-stamp(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-stamp.html
+++ b/man/git-stamp.html
@@ -87,6 +87,8 @@ By default all stamps are appended as a new paragraph to the commit message.<br 
 You can change this behavior by using the --replace flag.<br />
 With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended.</p>
 
+<p><code>WARNING!</code> If a commit message without stamp have a line starting with the same identifier, it will be interpreted as a stamp</p>
+
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <p>  -r, --replace</p>
@@ -141,7 +143,7 @@ $ git stamp Issue FOO-456 \#close
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Damien Tardy-Panis &lt;<a href="&#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#58;&#100;&#x61;&#x6d;&#x69;&#101;&#x6e;&#64;&#116;&#x61;&#114;&#100;&#121;&#x70;&#x61;&#x64;&#x2e;&#x6d;&#x65;" data-bare-link="true">&#x64;&#x61;&#x6d;&#x69;&#101;&#110;&#x40;&#116;&#97;&#x72;&#100;&#x79;&#x70;&#97;&#x64;&#x2e;&#x6d;&#x65;</a>&gt;</p>
+<p>Written by Damien Tardy-Panis &lt;<a href="&#x6d;&#97;&#x69;&#x6c;&#116;&#111;&#58;&#x64;&#97;&#x6d;&#105;&#x65;&#x6e;&#64;&#x74;&#97;&#x72;&#100;&#x79;&#112;&#97;&#x64;&#46;&#x6d;&#x65;" data-bare-link="true">&#100;&#x61;&#109;&#x69;&#101;&#x6e;&#64;&#x74;&#97;&#x72;&#x64;&#121;&#112;&#97;&#x64;&#x2e;&#x6d;&#101;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-stamp.html
+++ b/man/git-stamp.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git stamp [&lt;options>] &lt;id> [&lt;message>]</code></p>
+<p><code>git stamp [&lt;options>] &lt;id> [&lt;messages>]</code></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -105,7 +105,7 @@ The identifier is case insensitive for this replacement
 <p>Reference the issues numbers from your bug tracker</p>
 
 <pre><code>$ git stamp Issue FOO-123
-$ git stamp Issue "FOO-456 #close"
+$ git stamp Issue FOO-456 \#close
 
 | Fix timezone bug
 |
@@ -141,7 +141,7 @@ $ git stamp Issue "FOO-456 #close"
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Damien Tardy-Panis &lt;<a href="&#109;&#97;&#105;&#108;&#116;&#x6f;&#x3a;&#100;&#97;&#x6d;&#105;&#x65;&#110;&#x40;&#116;&#x61;&#114;&#100;&#121;&#x70;&#97;&#x64;&#46;&#109;&#x65;" data-bare-link="true">&#100;&#97;&#109;&#105;&#x65;&#x6e;&#64;&#x74;&#97;&#x72;&#x64;&#x79;&#112;&#97;&#100;&#46;&#109;&#x65;</a>&gt;</p>
+<p>Written by Damien Tardy-Panis &lt;<a href="&#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#58;&#100;&#x61;&#x6d;&#x69;&#101;&#x6e;&#64;&#116;&#x61;&#114;&#100;&#121;&#x70;&#x61;&#x64;&#x2e;&#x6d;&#x65;" data-bare-link="true">&#x64;&#x61;&#x6d;&#x69;&#101;&#110;&#x40;&#116;&#97;&#x72;&#100;&#x79;&#x70;&#97;&#x64;&#x2e;&#x6d;&#x65;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-stamp.html
+++ b/man/git-stamp.html
@@ -91,7 +91,8 @@ With this flag, all the related stamps with the same identifier will be removed 
 
 <p>  -r, --replace</p>
 
-<pre><code>Replace all previous stamps in the last commit message that have the same identifier
+<pre><code>Replace all previous stamps in the last commit message that have the same identifier  
+The identifier is case insensitive for this replacement
 </code></pre>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
@@ -107,9 +108,9 @@ With this flag, all the related stamps with the same identifier will be removed 
 $ git stamp Issue "FOO-456 #close"
 
 | Fix timezone bug
-| 
+|
 | Issue FOO-123
-| 
+|
 | Issue FOO-456 #close
 </code></pre>
 
@@ -122,24 +123,25 @@ $ git stamp Issue "FOO-456 #close"
 | Issue FOO-123
 |
 | Issue FOO-456 #close
-| 
+|
 | Review https://reviews.foo.org/r/4567/
 </code></pre>
 
-<p>Replace previous issues with a new one</p>
+<p>Replace previous issues with a new one<br />
+(Note that the identifier is case insensitive)</p>
 
-<pre><code>$ git stamp --replace Issue BAR-123
+<pre><code>$ git stamp --replace issue BAR-123
 
 | Fix timezone bug
 |
 | Review https://reviews.foo.org/r/4567/
 |
-| Issue BAR-123
+| issue BAR-123
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Damien Tardy-Panis &lt;<a href="&#109;&#x61;&#105;&#108;&#116;&#111;&#58;&#x64;&#x61;&#109;&#x69;&#x65;&#110;&#x40;&#116;&#x61;&#114;&#100;&#x79;&#x70;&#x61;&#x64;&#x2e;&#109;&#101;" data-bare-link="true">&#x64;&#97;&#x6d;&#x69;&#101;&#x6e;&#x40;&#x74;&#x61;&#x72;&#100;&#121;&#x70;&#x61;&#x64;&#46;&#109;&#101;</a>&gt;</p>
+<p>Written by Damien Tardy-Panis &lt;<a href="&#109;&#97;&#105;&#108;&#116;&#x6f;&#x3a;&#100;&#97;&#x6d;&#105;&#x65;&#110;&#x40;&#116;&#x61;&#114;&#100;&#121;&#x70;&#97;&#x64;&#46;&#109;&#x65;" data-bare-link="true">&#100;&#97;&#109;&#105;&#x65;&#x6e;&#64;&#x74;&#97;&#x72;&#x64;&#x79;&#112;&#97;&#100;&#46;&#109;&#x65;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-stamp.md
+++ b/man/git-stamp.md
@@ -3,7 +3,7 @@ git-stamp(1) -- Stamp the last commit message
 
 ## SYNOPSIS
 
-`git stamp [<options>] <id> [<message>]`
+`git stamp [<options>] <id> [<messages>]`
 
 ## DESCRIPTION
 
@@ -30,7 +30,7 @@ Commit message is
 Reference the issues numbers from your bug tracker
 
     $ git stamp Issue FOO-123
-    $ git stamp Issue "FOO-456 #close"
+    $ git stamp Issue FOO-456 \#close
 
     | Fix timezone bug
     |

--- a/man/git-stamp.md
+++ b/man/git-stamp.md
@@ -1,0 +1,72 @@
+git-stamp(1) -- Stamp the last commit message
+=============================================
+
+## SYNOPSIS
+
+`git stamp [<options>] <id> [<message>]`
+
+## DESCRIPTION
+
+Lets you amend the last commit with a stamp message.
+
+The command appends a message with its identifier to the last commit message.  
+By default all stamps are appended as a new paragraph to the commit message.  
+You can change this behavior by using the --replace flag.  
+With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended.
+
+## OPTIONS
+
+  -r, --replace
+
+    Replace all previous stamps in the last commit message that have the same identifier
+
+## EXAMPLES
+
+Commit message is
+
+    | Fix timezone bug
+
+Reference the issues numbers from your bug tracker
+
+    $ git stamp Issue FOO-123
+    $ git stamp Issue "FOO-456 #close"
+
+    | Fix timezone bug
+    |
+    | Issue FOO-123
+    |
+    | Issue FOO-456 #close
+
+Link to its review page
+
+    $ git stamp Review https://reviews.foo.org/r/4567/
+
+    | Fix timezone bug
+    |
+    | Issue FOO-123
+    |
+    | Issue FOO-456 #close
+    |
+    | Review https://reviews.foo.org/r/4567/
+
+Replace previous issues with a new one
+
+    $ git stamp --replace Issue BAR-123
+
+    | Fix timezone bug
+    |
+    | Review https://reviews.foo.org/r/4567/
+    |
+    | Issue BAR-123
+
+## AUTHOR
+
+Written by Damien Tardy-Panis &lt;<damien@tardypad.me>&gt;
+
+## REPORTING BUGS
+
+&lt;<http://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;

--- a/man/git-stamp.md
+++ b/man/git-stamp.md
@@ -14,6 +14,8 @@ By default all stamps are appended as a new paragraph to the commit message.
 You can change this behavior by using the --replace flag.  
 With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended.
 
+`WARNING!` If a commit message without stamp have a line starting with the same identifier, it will be interpreted as a stamp
+
 ## OPTIONS
 
   -r, --replace

--- a/man/git-stamp.md
+++ b/man/git-stamp.md
@@ -18,7 +18,8 @@ With this flag, all the related stamps with the same identifier will be removed 
 
   -r, --replace
 
-    Replace all previous stamps in the last commit message that have the same identifier
+    Replace all previous stamps in the last commit message that have the same identifier  
+    The identifier is case insensitive for this replacement
 
 ## EXAMPLES
 
@@ -49,15 +50,16 @@ Link to its review page
     |
     | Review https://reviews.foo.org/r/4567/
 
-Replace previous issues with a new one
+Replace previous issues with a new one  
+(Note that the identifier is case insensitive)
 
-    $ git stamp --replace Issue BAR-123
+    $ git stamp --replace issue BAR-123
 
     | Fix timezone bug
     |
     | Review https://reviews.foo.org/r/4567/
     |
-    | Issue BAR-123
+    | issue BAR-123
 
 ## AUTHOR
 

--- a/man/index.txt
+++ b/man/index.txt
@@ -51,6 +51,7 @@ git-show-merged-branches(1)   git-show-merged-branches
 git-show-tree(1)              git-show-tree
 git-show-unmerged-branches(1) git-show-unmerged-branches
 git-squash(1)                 git-squash
+git-stamp(1)                  git-stamp
 git-summary(1)                git-summary
 git-touch(1)                  git-touch
 git-undo(1)                   git-undo


### PR DESCRIPTION
Continuing the moving of some of my local git aliases and functions
in order to make them more maintainable and so that other people can use them too :grin:

This adds a new stamp command: Stamp the last commit message
See the [manual](https://github.com/tardypad/git-extras/blob/stamp/man/git-stamp.md) for the use cases and examples

The command is best used afterwards with personal aliases such as `issue = stamp -r Issue`
The usage is then `git issue FOO-142` to stamp the commit with an issue number
