### PR TITLE
Add --no-email to git-author

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -726,7 +726,6 @@ Updating AUTHORS file:
 $ git authors && cat AUTHORS
 
 TJ Holowaychuk <tj@vision-media.ca>
-Tj Holowaychuk <tj@vision-media.ca>
 hemanth.hm <hemanth.hm@gmail.com>
 Jonhnny Weslley <jw@jonhnnyweslley.net>
 nickl- <github@jigsoft.co.za>
@@ -739,11 +738,22 @@ Listing authors:
 $ git authors --list
 
 TJ Holowaychuk <tj@vision-media.ca>
-Tj Holowaychuk <tj@vision-media.ca>
 hemanth.hm <hemanth.hm@gmail.com>
 Jonhnny Weslley <jw@jonhnnyweslley.net>
 nickl- <github@jigsoft.co.za>
 Leila Muhtasib <muhtasib@gmail.com>
+```
+
+Listing authors without email:
+
+```bash
+$ git authors --list --no-email
+
+TJ Holowaychuk
+hemanth.hm
+Jonhnny Weslley
+nickl-
+Leila Muhtasib
 ```
 
 ## git back

--- a/bin/git-authors
+++ b/bin/git-authors
@@ -1,15 +1,29 @@
 #!/usr/bin/env bash
 
 LIST=false
+NO_EMAIL=false
 FILE=""
 EDITOR=$(git var GIT_EDITOR)
 
-if test "$1" = "-l" || test "$1" = "--list"; then
-  LIST=true
-else
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -l|--list )
+      LIST=true
+      shift
+      ;;
+    --no-email )
+      NO_EMAIL=true
+      shift
+      ;;
+    * )
+      break
+  esac
+done
+
+if ! $LIST; then
   FILE=$1
   if test "$FILE" = ""; then
-    FILE=`ls | egrep 'authors|contributors' -i|head -n1`
+    FILE=$(ls | egrep 'authors|contributors' -i|head -n1)
     if test "$FILE" = ""; then
       FILE='AUTHORS'
     fi
@@ -21,7 +35,13 @@ fi
 #
 
 authors() {
-  git shortlog -sne | awk '{$1=""; sub(" ", ""); print}' | awk -F'<' '!x[$1]++' | awk -F'<' '!x[$2]++'
+  if $NO_EMAIL; then
+    # eamil will be used to uniq authors.
+    git shortlog -sne | awk '{$1=""; sub(" ", ""); print}' | awk -F'<' '!x[$1]++' | awk -F'<' '!x[$2]++' \
+      | awk -F'<' '{print $1}'
+  else
+    git shortlog -sne | awk '{$1=""; sub(" ", ""); print}' | awk -F'<' '!x[$1]++' | awk -F'<' '!x[$2]++'
+  fi
 }
 
 #
@@ -29,7 +49,7 @@ authors() {
 #
 
 if $LIST; then
-  echo "$(authors)"
+  authors
 else
   authors >> $FILE
   test -n "$EDITOR" && $EDITOR $FILE

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -29,7 +29,7 @@ _git_chore(){
 }
 
 _git_authors(){
-  __gitcomp "-l --list"
+  __gitcomp "-l --list --no-email"
 }
 
 _git_contrib(){

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -109,6 +109,7 @@ __gitex_author_names() {
 _git-authors() {
     _arguments  -C \
         '(--list -l)'{--list,-l}'[show authors]' \
+        '--no-email[without email]' \
 }
 
 _git-bug() {

--- a/man/git-authors.1
+++ b/man/git-authors.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-AUTHORS" "1" "December 2015" "" ""
+.TH "GIT\-AUTHORS" "1" "October 2016" "" ""
 .
 .SH "NAME"
 \fBgit\-authors\fR \- Generate authors report
 .
 .SH "SYNOPSIS"
-\fBgit\-authors\fR [\-l, \-\-list]
+\fBgit\-authors\fR [\-l, \-\-list] [\-\-no\-email]
 .
 .SH "DESCRIPTION"
 Populates the file matching \fIauthors|contributors \-i\fR with the authors of commits, according to the number of commits per author\. Opens the file in \fB$EDITOR\fR when set\.
@@ -20,6 +20,12 @@ See the "MAPPING AUTHORS" section of \fBgit\-shortlog\fR(1) to coalesce together
 .
 .P
 Show authors\.
+.
+.P
+\-\-no\-email
+.
+.P
+Don\'t show authors\' email\.
 .
 .SH "EXAMPLES"
 .
@@ -40,11 +46,31 @@ $ git authors \-\-list
 .nf
 
 TJ Holowaychuk <tj@vision\-media\.ca>
-Tj Holowaychuk <tj@vision\-media\.ca>
 hemanth\.hm <hemanth\.hm@gmail\.com>
 Jonhnny Weslley <jw@jonhnnyweslley\.net>
 nickl\- <github@jigsoft\.co\.za>
 Leila Muhtasib <muhtasib@gmail\.com>
+.
+.fi
+.
+.IP "" 0
+
+.
+.TP
+Listing authors without email:
+.
+.IP
+$ git authors \-\-list \-\-no\-email
+.
+.IP "" 4
+.
+.nf
+
+TJ Holowaychuk
+hemanth\.hm
+Jonhnny Weslley
+nickl\-
+Leila Muhtasib
 .
 .fi
 .

--- a/man/git-authors.html
+++ b/man/git-authors.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-authors</code> [-l, --list]</p>
+<p><code>git-authors</code> [-l, --list] [--no-email]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -91,6 +91,10 @@
 
 <p>  Show authors.</p>
 
+<p>  --no-email</p>
+
+<p>  Don't show authors' email.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <dl>
@@ -102,18 +106,27 @@
 <p>$ git authors --list</p>
 
 <pre><code>TJ Holowaychuk &lt;tj@vision-media.ca&gt;
-Tj Holowaychuk &lt;tj@vision-media.ca&gt;
 hemanth.hm &lt;hemanth.hm@gmail.com&gt;
 Jonhnny Weslley &lt;jw@jonhnnyweslley.net&gt;
 nickl- &lt;github@jigsoft.co.za&gt;
 Leila Muhtasib &lt;muhtasib@gmail.com&gt;
+</code></pre></dd>
+<dt>Listing authors without email:</dt><dd><p></p>
+
+<p>$ git authors --list --no-email</p>
+
+<pre><code>TJ Holowaychuk
+hemanth.hm
+Jonhnny Weslley
+nickl-
+Leila Muhtasib
 </code></pre></dd>
 </dl>
 
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Titus Wormer &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#116;&#x69;&#x74;&#117;&#115;&#x77;&#x6f;&#x72;&#x6d;&#x65;&#114;&#64;&#x67;&#x6d;&#97;&#x69;&#x6c;&#46;&#99;&#x6f;&#x6d;" data-bare-link="true">&#x74;&#105;&#x74;&#x75;&#115;&#119;&#x6f;&#114;&#109;&#101;&#114;&#x40;&#x67;&#109;&#x61;&#x69;&#108;&#46;&#99;&#x6f;&#x6d;</a>&gt;</p>
+<p>Written by Titus Wormer &lt;<a href="&#x6d;&#x61;&#x69;&#x6c;&#116;&#111;&#58;&#x74;&#105;&#116;&#x75;&#x73;&#x77;&#x6f;&#x72;&#x6d;&#x65;&#114;&#64;&#103;&#109;&#97;&#x69;&#108;&#46;&#99;&#111;&#x6d;" data-bare-link="true">&#x74;&#105;&#116;&#x75;&#x73;&#x77;&#111;&#114;&#109;&#101;&#x72;&#64;&#103;&#x6d;&#x61;&#x69;&#108;&#x2e;&#99;&#x6f;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -126,7 +139,7 @@ Leila Muhtasib &lt;muhtasib@gmail.com&gt;
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2015</li>
+    <li class='tc'>October 2016</li>
     <li class='tr'>git-authors(1)</li>
   </ol>
 

--- a/man/git-authors.md
+++ b/man/git-authors.md
@@ -3,7 +3,7 @@ git-authors(1) -- Generate authors report
 
 ## SYNOPSIS
 
-`git-authors` [-l, --list]
+`git-authors` [-l, --list] [--no-email]
 
 ## DESCRIPTION
 
@@ -18,6 +18,10 @@ git-authors(1) -- Generate authors report
 
   Show authors.
 
+  --no-email
+
+  Don't show authors' email.
+
 ## EXAMPLES
 
   * Updating AUTHORS file:
@@ -30,11 +34,22 @@ git-authors(1) -- Generate authors report
 
     ```
     TJ Holowaychuk <tj@vision-media.ca>
-    Tj Holowaychuk <tj@vision-media.ca>
     hemanth.hm <hemanth.hm@gmail.com>
     Jonhnny Weslley <jw@jonhnnyweslley.net>
     nickl- <github@jigsoft.co.za>
     Leila Muhtasib <muhtasib@gmail.com>
+    ```
+
+  * Listing authors without email:
+
+    $ git authors --list --no-email
+
+    ```
+    TJ Holowaychuk
+    hemanth.hm
+    Jonhnny Weslley
+    nickl-
+    Leila Muhtasib
     ```
 
 ## AUTHOR


### PR DESCRIPTION
This feature is used to generate AUTHORS in 4.2.0 release.