### PR TITLE
Be sure to remove tempfile in git-changelog

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -478,6 +478,7 @@ main() {
     rm -f "$tmpfile"
   else
     cp -f "$tmpfile" "$changelog"
+    rm -f "$tmpfile"
     # Use `eval` to handle GIT_EDITOR which contains space and options,
     # like ""C:\Program Files (x86)\Notepad++\notepad++.exe" -multiInst ".
     # Thanks @JanSchulz to inspire me this solution


### PR DESCRIPTION
The tempfile was only getting removed if the `-x` parameter was getting set.

This is proved by the following:

````
╰─ ls /tmp/git-changelog.*
/tmp/git-changelog.6HZ  /tmp/git-changelog.Fqc  /tmp/git-changelog.NkI  /tmp/git-changelog.S52  /tmp/git-changelog.xnI
/tmp/git-changelog.dLh  /tmp/git-changelog.Izo  /tmp/git-changelog.nrQ  /tmp/git-changelog.uDx  /tmp/git-changelog.yk5
/tmp/git-changelog.ezr  /tmp/git-changelog.KsF  /tmp/git-changelog.OOO  /tmp/git-changelog.WyK
````