### PR TITLE
fix: git-squash docs. Replaced 'actual' with 'current'

### DIFF
--- a/man/git-squash.1
+++ b/man/git-squash.1
@@ -16,7 +16,7 @@ Produce the working tree and index state as if a real merge happened without the
 <source\-branch>
 .
 .P
-Branch to squash on the actual branch\.
+Branch to squash on the current branch\.
 .
 .P
 <commit reference> A commit reference (has to be from the current branch) can also be used as the first argument\. A range of commits \fIsha\fR\.\.HEAD will be squashed\.

--- a/man/git-squash.html
+++ b/man/git-squash.html
@@ -87,7 +87,7 @@
 
 <p>  &lt;source-branch&gt;</p>
 
-<p>  Branch to squash on the actual branch.</p>
+<p>  Branch to squash on the current branch.</p>
 
 <p>  &lt;commit reference&gt;
   A commit reference (has to be from the current branch) can also be used as the

--- a/man/git-squash.md
+++ b/man/git-squash.md
@@ -14,7 +14,7 @@ git-squash(1) -- Import changes from a branch
 
   &lt;source-branch&gt;
 
-  Branch to squash on the actual branch.
+  Branch to squash on the current branch.
 
   &lt;commit reference&gt;
   A commit reference (has to be from the current branch) can also be used as the


### PR DESCRIPTION
Fixed a small typo in git-squash documentation.