### PR TITLE
git-fresh-branch: fix handling of 'yes' response when there are changes

### DIFF
--- a/bin/git-fresh-branch
+++ b/bin/git-fresh-branch
@@ -16,7 +16,7 @@ clean()
 if [ ! -z "$changes" ]; then
     read -p "All untracked changes will be lost. Continue [y/N]? " res
     case $res in
-        [Yy]* ) clean; break;;
+        [Yy]* ) ;;
         * ) exit 0;;
     esac
 fi


### PR DESCRIPTION
`break` isn't valid in its current location in the script, resulting in an error like:

    /usr/bin/git-fresh-branch: line 42: break: only meaningful in a `for', `while', or `until' loop

Since there's a call to `clean` right at the end of the script, do nothing if anything beginning `Y` or `y` is entered; execution will continue to the end of the script, and `clean` will be called.