### PR TITLE
git-sed: use "grep -z" and "xargs -0" to cope with spaces in filenames

### DIFF
--- a/bin/git-sed
+++ b/bin/git-sed
@@ -64,6 +64,6 @@ actual command:
     shift
 done
 
-command="git grep -l '$search' | xargs sed -i 's/$search/$replacement/$flags'"
-git grep -l "$search" | xargs sed -i "s/$search/$replacement/$flags"
+command="git grep -lz '$search' | xargs -0 sed -i 's/$search/$replacement/$flags'"
+git grep -lz "$search" | xargs -0 sed -i "s/$search/$replacement/$flags"
 do_commit


### PR DESCRIPTION
Otherwise filenames with spaces result in errors:

    $ cat "file with spaces in name"
    old

    $ git sed old new
    sed: can't read file: No such file or directory
    sed: can't read with: No such file or directory
    sed: can't read spaces: No such file or directory
    sed: can't read in: No such file or directory
    sed: can't read name: No such file or directory