### PR TITLE
git-delete-merged-branches: use "xargs -r" to prevent error when there are no branches to delete

### DIFF
--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-git branch --no-color --merged | grep -v "\*" | grep -v master | grep -v svn | xargs -n 1 git branch -d
+git branch --no-color --merged | grep -v "\*" | grep -v master | grep -v svn | xargs -r -n 1 git branch -d


### PR DESCRIPTION
Prevents this error:

    $ git delete-merged-branches
    fatal: branch name required