### PR TITLE
git-clear-soft: change default yes/no option to "no" (as with git-clear)

### DIFF
--- a/bin/git-clear-soft
+++ b/bin/git-clear-soft
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-echo -n "Sure? - This command may delete files that cannot be recovered. Files and directories in .gitignore will be preserved [Y/n]: "
+echo -n "Sure? - This command may delete files that cannot be recovered. Files and directories in .gitignore will be preserved [y/N]: "
 read ans
-if [ "$ans" != "n" ] 
+if [ "$ans" == "y" ] 
     then git clean -d -f && git reset --hard
 fi


### PR DESCRIPTION
6d49449 changed the `git-clear` default option to "no" (see #583).

Make the `git-clear-soft` default the same - it's safer.