### PR TITLE
fix git-extras update and tweak Windows detection

### DIFF
--- a/bin/git-extras
+++ b/bin/git-extras
@@ -4,7 +4,7 @@ VERSION="4.3.0-dev"
 INSTALL_SCRIPT="https://raw.githubusercontent.com/tj/git-extras/master/install.sh"
 
 update() {
-  local bin=$(which git-extras)
+  local bin="$(which git-extras)"
   local prefix=${bin%/*/*}
   local orig=$PWD
 
@@ -14,7 +14,7 @@ update() {
 }
 
 updateForWindows() {
-  local bin=$(which git-extras)
+  local bin="$(which git-extras)"
   local prefix=${bin%/*/*}
   local orig=$PWD
   
@@ -39,9 +39,9 @@ case "$1" in
     ;;
   update)
     platform=$(uname -s)
-    if [ $(expr substr "$platform" 1 9) = "CYGWIN_NT" ] || \
-      [ $(expr substr "$platform" 1 10) = "MINGW32_NT" ] || \
-      [ $(expr substr "$platform" 1 10) = "MINGW64_NT" ]
+    if [ "${platform::9}" = "CYGWIN_NT" ] || \
+      [ "${platform::5}" = "MINGW" ] || \
+      [ "${platform::7}" = "MSYS_NT" ]
     then
       updateForWindows
     else


### PR DESCRIPTION
Replace expr with bash substring expansion, which fixes some syntax error.
Tested under:
GNU bash, version 4.3.42(5)-release (x86_64-pc-msys)
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin16)