### PR TITLE
spelling: {a,an} archive

### DIFF
--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -356,7 +356,7 @@ _git-undo(){
 
 zstyle ':completion:*:*:git:*' user-commands \
     alias:'define, search and show aliases' \
-    archive-file:'export the current head of the git repository to a archive' \
+    archive-file:'export the current head of the git repository to an archive' \
     authors:'generate authors report' \
     back:'undo and stage latest commits' \
     bug:'create bug branch' \

--- a/man/git-archive-file.1
+++ b/man/git-archive-file.1
@@ -1,16 +1,16 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-ARCHIVE\-FILE" "1" "December 2015" "" ""
+.TH "GIT\-ARCHIVE\-FILE" "1" "December 2016" "" "Git Extras"
 .
 .SH "NAME"
-\fBgit\-archive\-file\fR \- Export the current HEAD of the git repository to a archive
+\fBgit\-archive\-file\fR \- Export the current HEAD of the git repository to an archive
 .
 .SH "SYNOPSIS"
 \fBgit\-archive\-file\fR
 .
 .SH "DESCRIPTION"
-Export the current HEAD of the repository into a archive with a identifiable and unique name\.
+Export the current HEAD of the repository into an archive with an identifiable and unique name\.
 .
 .SH "OPTIONS"
 This command does not take any options\.

--- a/man/git-archive-file.html
+++ b/man/git-archive-file.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
   <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
-  <title>git-archive-file(1) - Export the current HEAD of the git repository to a archive</title>
+  <title>git-archive-file(1) - Export the current HEAD of the git repository to an archive</title>
   <style type='text/css' media='all'>
   /* style: man */
   body#manpage {margin:0}
@@ -65,13 +65,13 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-archive-file(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-archive-file(1)</li>
   </ol>
 
   <h2 id="NAME">NAME</h2>
 <p class="man-name">
-  <code>git-archive-file</code> - <span class="man-whatis">Export the current HEAD of the git repository to a archive</span>
+  <code>git-archive-file</code> - <span class="man-whatis">Export the current HEAD of the git repository to an archive</span>
 </p>
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
@@ -80,7 +80,7 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>Export the current HEAD of the repository into a archive with a identifiable and unique name.</p>
+<p>Export the current HEAD of the repository into an archive with an identifiable and unique name.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -98,7 +98,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Philipp Klose &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#109;&#x65;&#x40;&#116;&#104;&#x65;&#x68;&#x69;&#x70;&#x70;&#111;&#46;&#x64;&#x65;" data-bare-link="true">&#109;&#x65;&#x40;&#116;&#104;&#x65;&#x68;&#x69;&#112;&#x70;&#x6f;&#46;&#100;&#x65;</a>&gt;</p>
+<p>Written by Philipp Klose &lt;<a href="&#x6d;&#x61;&#105;&#108;&#116;&#111;&#58;&#109;&#x65;&#64;&#x74;&#104;&#x65;&#104;&#x69;&#112;&#x70;&#x6f;&#x2e;&#100;&#x65;" data-bare-link="true">&#x6d;&#x65;&#64;&#x74;&#x68;&#101;&#x68;&#x69;&#x70;&#112;&#111;&#46;&#x64;&#x65;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -111,7 +111,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2015</li>
+    <li class='tc'>December 2016</li>
     <li class='tr'>git-archive-file(1)</li>
   </ol>
 

--- a/man/git-archive-file.md
+++ b/man/git-archive-file.md
@@ -1,4 +1,4 @@
-git-archive-file(1) -- Export the current HEAD of the git repository to a archive
+git-archive-file(1) -- Export the current HEAD of the git repository to an archive
 ===============================================
 
 ## SYNOPSIS
@@ -7,7 +7,7 @@ git-archive-file(1) -- Export the current HEAD of the git repository to a archiv
 
 ## DESCRIPTION
 
-Export the current HEAD of the repository into a archive with a identifiable and unique name.
+Export the current HEAD of the repository into an archive with an identifiable and unique name.
 
 ## OPTIONS
 

--- a/man/git-extras.1
+++ b/man/git-extras.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-EXTRAS" "1" "December 2015" "" ""
+.TH "GIT\-EXTRAS" "1" "December 2016" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-extras\fR \- Awesome GIT utilities
@@ -33,7 +33,7 @@ Self update\.
 \fBgit\-alias(1)\fR Define, search and show aliases
 .
 .IP "\(bu" 4
-\fBgit\-archive\-file(1)\fR Export the current HEAD of the git repository to a archive
+\fBgit\-archive\-file(1)\fR Export the current HEAD of the git repository to an archive
 .
 .IP "\(bu" 4
 \fBgit\-authors(1)\fR Generate authors report
@@ -136,6 +136,9 @@ Self update\.
 .
 .IP "\(bu" 4
 \fBgit\-psykorebase(1)\fR Rebase a branch with a merge commit
+.
+.IP "\(bu" 4
+\fBgit\-reauthor(1)\fR Rewrite history to change author\'s identity
 .
 .IP "\(bu" 4
 \fBgit\-rebase\-patch(1)\fR Rebases a patch

--- a/man/git-extras.html
+++ b/man/git-extras.html
@@ -64,7 +64,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-extras(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-extras(1)</li>
   </ol>
 
@@ -95,7 +95,7 @@
 
 <ul>
 <li> <strong><a class="man-ref" href="git-alias.html">git-alias<span class="s">(1)</span></a></strong> Define, search and show aliases</li>
-<li> <strong><a class="man-ref" href="git-archive-file.html">git-archive-file<span class="s">(1)</span></a></strong> Export the current HEAD of the git repository to a archive</li>
+<li> <strong><a class="man-ref" href="git-archive-file.html">git-archive-file<span class="s">(1)</span></a></strong> Export the current HEAD of the git repository to an archive</li>
 <li> <strong><a class="man-ref" href="git-authors.html">git-authors<span class="s">(1)</span></a></strong> Generate authors report</li>
 <li> <strong><a class="man-ref" href="git-back.html">git-back<span class="s">(1)</span></a></strong> Undo and Stage latest commits</li>
 <li> <strong><a class="man-ref" href="git-bug.html">git-bug<span class="s">(1)</span></a></strong> Create bug branch</li>
@@ -130,6 +130,7 @@
 <li> <strong><a class="man-ref" href="git-missing.html">git-missing<span class="s">(1)</span></a></strong> Show commits missing from another branch</li>
 <li> <strong><a class="man-ref" href="git-pr.html">git-pr<span class="s">(1)</span></a></strong> Checks out a pull request locally</li>
 <li> <strong><a class="man-ref" href="git-psykorebase.html">git-psykorebase<span class="s">(1)</span></a></strong> Rebase a branch with a merge commit</li>
+<li> <strong><a class="man-ref" href="git-reauthor.html">git-reauthor<span class="s">(1)</span></a></strong> Rewrite history to change author's identity</li>
 <li> <strong><a class="man-ref" href="git-rebase-patch.html">git-rebase-patch<span class="s">(1)</span></a></strong> Rebases a patch</li>
 <li> <strong><a class="man-ref" href="git-refactor.html">git-refactor<span class="s">(1)</span></a></strong> Create refactor branch</li>
 <li> <strong><a class="man-ref" href="git-release.html">git-release<span class="s">(1)</span></a></strong> Commit, tag and push changes to the repository</li>
@@ -153,7 +154,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#x69;&#108;&#x74;&#x6f;&#58;&#x74;&#x6a;&#x40;&#x76;&#x69;&#x73;&#x69;&#111;&#x6e;&#45;&#x6d;&#101;&#100;&#x69;&#x61;&#46;&#x63;&#97;" data-bare-link="true">&#116;&#x6a;&#64;&#x76;&#105;&#x73;&#x69;&#111;&#110;&#45;&#x6d;&#101;&#100;&#x69;&#x61;&#x2e;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#x61;&#x69;&#x6c;&#116;&#x6f;&#58;&#116;&#106;&#64;&#x76;&#105;&#x73;&#105;&#x6f;&#x6e;&#45;&#109;&#101;&#x64;&#x69;&#x61;&#x2e;&#99;&#x61;" data-bare-link="true">&#x74;&#x6a;&#64;&#118;&#105;&#115;&#105;&#x6f;&#x6e;&#45;&#x6d;&#101;&#100;&#x69;&#x61;&#x2e;&#99;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -166,7 +167,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2015</li>
+    <li class='tc'>December 2016</li>
     <li class='tr'>git-extras(1)</li>
   </ol>
 

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -22,7 +22,7 @@ git-extras(1) -- Awesome GIT utilities
 ## COMMANDS
 
    - **git-alias(1)** Define, search and show aliases
-   - **git-archive-file(1)** Export the current HEAD of the git repository to a archive
+   - **git-archive-file(1)** Export the current HEAD of the git repository to an archive
    - **git-authors(1)** Generate authors report
    - **git-back(1)** Undo and Stage latest commits
    - **git-bug(1)** Create bug branch


### PR DESCRIPTION
#609 and an occurence of `a identifiable`. 

The `git extras` man page also got updated with an entry for `git reauthor` which probably just was forgotten when it was added.