### PR TITLE
effort: handling of $'s and \n's, plus make shellcheck happy

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -17,7 +17,10 @@ usage() {
 # get dates for the given <commit>
 #
 dates() {
-  eval "git log $args_to_git_log --pretty='format: %ad' --date=short \"$1\""
+  path="$1"
+  # Escape dollars so they aren't interpreted in eval
+  path="${1/\$/\\$}"
+  eval "git log $args_to_git_log --pretty='format: %ad' --date=short \"${path}\""
 }
 
 # tput, being quiet about unknown capabilities
@@ -80,6 +83,15 @@ color_for() {
 
 effort() {
     path=$1
+
+    # Exit if path == ""
+    # This is not an error
+    # shellcheck disable=SC2116
+    if [ -z "$(head -c 1 <<<"$(echo "$path")")" ]
+    then
+      exit 0
+    fi
+
     local commit_dates
     local color reset_color commits len dot f_dot i msg active
     reset_color=""
@@ -98,6 +110,12 @@ effort() {
 
     # ignore <= --above
     test $commits -le $above && exit 0
+
+    # Replace actual newlines with a textual representation.
+    # We need to print everything in one line, else we get
+    # a race condition because this function runs in
+    # parallell. Also, the sorting at the end messes things up.
+    path="${path/$'\n'/\\n}"
 
     # commits
     color_for $(( $commits - $above ))
@@ -213,7 +231,11 @@ fi
 
 heading
 # send paths to effort
-printf "%s\0" "${paths[@]}" | xargs -0 -n 1 -P 4 -I % bash $bash_params -c "effort \"%\"" | tee $tmp
+printf "%s\0" "${paths[@]}" \
+    | sed 's/\$/\\\$/g' \
+    | sed "s/\\\n/\\\$\'\\\n\'/g" \
+    | xargs -0 -n 1 -P 4 -I % bash $bash_params -c "effort \"%\"" \
+    | tee "$tmp"
 
 # if more than one path, sort and print
 test "$(wc -l $tmp | awk '{print $1}')" -gt 1 && sort_effort

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -117,21 +117,20 @@ effort() {
     # parallell. Also, the sorting at the end messes things up.
     path="${path/$'\n'/\\n}"
 
-    # commits
-    color_for $(( $commits - $above ))
+    color_for $(( commits - above ))
     len=${#path}
     dot="."
     f_dot="$path"
-    i=0 ; while test $i -lt $((45-$len)) ; do
+    i=0 ; while test $i -lt $((45 - len)) ; do
       f_dot=$f_dot$dot
-      i=$(($i+1))
+      i=$((i + 1))
     done
 
     msg=$(printf "  ${color}%s %-10d" "$f_dot" $commits)
 
     # active days
     active=`active_days "$commit_dates"`
-    color_for $(( $active - $above ))
+    color_for $(( active - above ))
     msg="$msg $(printf "${color} %d${reset_color}\n" $active)"
     echo "$msg"
 }

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -62,14 +62,14 @@ active_days() {
 
 color_for() {
   if [ "$to_tty" = true ]; then
-    if   [ $1 -gt 200 ]; then color="$(tputq setaf 1)$(tputq bold)"
-    elif [ $1 -gt 150 ]; then color="$(tputq setaf 1)"  # red
-    elif [ $1 -gt 125 ]; then color="$(tputq setaf 2)$(tputq bold)"
-    elif [ $1 -gt 100 ]; then color="$(tputq setaf 2)"  # green
-    elif [ $1 -gt 75 ]; then color="$(tputq setaf 5)$(tputq bold)"
-    elif [ $1 -gt 50 ]; then color="$(tputq setaf 5)"  # purplish
-    elif [ $1 -gt 25 ]; then color="$(tputq setaf 3)$(tputq bold)"
-    elif [ $1 -gt 10 ]; then color="$(tputq setaf 3)"  # yellow
+    if   [ "$1" -gt 200 ]; then color="$(tputq setaf 1)$(tputq bold)"
+    elif [ "$1" -gt 150 ]; then color="$(tputq setaf 1)"  # red
+    elif [ "$1" -gt 125 ]; then color="$(tputq setaf 2)$(tputq bold)"
+    elif [ "$1" -gt 100 ]; then color="$(tputq setaf 2)"  # green
+    elif [ "$1" -gt 75 ]; then color="$(tputq setaf 5)$(tputq bold)"
+    elif [ "$1" -gt 50 ]; then color="$(tputq setaf 5)"  # purplish
+    elif [ "$1" -gt 25 ]; then color="$(tputq setaf 3)$(tputq bold)"
+    elif [ "$1" -gt 10 ]; then color="$(tputq setaf 3)"  # yellow
     else color="$(tputq sgr0)" # default color
     fi
   else
@@ -96,20 +96,27 @@ effort() {
     local color reset_color commits len dot f_dot i msg active
     reset_color=""
     test "$to_tty" = true && reset_color="$(tputq sgr0)"
-    commit_dates=`dates "$path"`
-    [ $? -gt 0 ] && exit 255
 
-    # Ensure it's not just an empty line
-    if [ -z "`head -c 1 <<<$(echo $commit_dates)`" ]
+    if ! commit_dates=$(dates "$path")
+    then
+        # 255 should terminate xargs (which runs the effort() function)
+        exit 255
+    fi
+
+    # If `git log ...` returns nothing, return
+    # This is not an error
+    # shellcheck disable=SC2116
+    if [ -z "$(head -c 1 <<<"$(echo "$commit_dates")")" ]
     then
       exit 0
     fi
 
-    commits=`wc -l <<<"$(echo "$commit_dates")"`
-    color='90'
+    # shellcheck disable=SC2116
+    commits=$(wc -l <<<"$(echo "$commit_dates")")
+    color="$(tputq sgr0)" # default color
 
     # ignore <= --above
-    test $commits -le $above && exit 0
+    test "$commits" -le "$above" && exit 0
 
     # Replace actual newlines with a textual representation.
     # We need to print everything in one line, else we get
@@ -126,12 +133,13 @@ effort() {
       i=$((i + 1))
     done
 
-    msg=$(printf "  ${color}%s %-10d" "$f_dot" $commits)
+
+    msg=$(printf "  ${color}%s %-10d" "$f_dot" "$commits")
 
     # active days
-    active=`active_days "$commit_dates"`
+    active=$(active_days "$commit_dates")
     color_for $(( active - above ))
-    msg="$msg $(printf "${color} %d${reset_color}\n" $active)"
+    msg="$msg $(printf "${color} %d${reset_color}\n" "$active")"
     echo "$msg"
 }
 
@@ -153,7 +161,7 @@ sort_effort() {
   clear
   echo " "
   heading
-  < $tmp sort -rn -k 2
+  < "$tmp" sort -rn -k 2
 }
 
 declare -a paths=()
@@ -198,8 +206,8 @@ export args_to_git_log
 
 if test "${#paths}" -eq 0; then
   save_ifs=$IFS
-  IFS=`echo -en "\n\b"`
-  paths=(`git ls-files`)
+  IFS=$(echo -en "\n\b")
+  paths=($(git ls-files))
   IFS=$save_ifs
   unset save_ifs
 fi
@@ -223,8 +231,8 @@ export log_args
 bash_params=
 # If bash exits sucessfully with --import-functions,
 # then we need to pass it (FreeBSD probably)
-bash --import-functions -c ":" 1>/dev/null 2>&1
-if [ $? -eq 0 ] ; then
+if bash --import-functions -c ":" 1>/dev/null 2>&1
+then
   bash_params="--import-functions"
 fi
 
@@ -237,7 +245,7 @@ printf "%s\0" "${paths[@]}" \
     | tee "$tmp"
 
 # if more than one path, sort and print
-test "$(wc -l $tmp | awk '{print $1}')" -gt 1 && sort_effort
+test "$(wc -l "$tmp" | awk '{print $1}')" -gt 1 && sort_effort
 echo
 
 show_cursor_and_cleanup

--- a/man/git-effort.1
+++ b/man/git-effort.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-EFFORT" "1" "December 2015" "" ""
+.TH "GIT\-EFFORT" "1" "January 2017" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-effort\fR \- Show effort statistics on file(s)
@@ -20,6 +20,9 @@ Display includes:
 .
 .br
 \- Active days: total number of days which contributed modifications to this file\.
+.
+.P
+Because statistics are displayed in a linewise manner, filenames with newlines in them will be displayed with the newline replaced by \fB\en\fR\.
 .
 .SH "OPTIONS"
 \-\-above <value>

--- a/man/git-effort.1
+++ b/man/git-effort.1
@@ -37,13 +37,22 @@ Ignore files with commits <= a value\.
 Only count commits that touches the given paths\.
 .
 .P
+\fBgit effort folder_name\fR gives one entry, showing statistics for files in that folder\. \fBgit effort folder_name/*\fR on the other hand, gives an entry for each file in that folder\.
+.
+.P
 Note: \fBgit\-effort\fR does not accept revision ranges, but the underlying \fBgit log\fR does (See the examples)\.
 .
 .P
 <log options>\.\.\.
 .
 .P
-Options for \fBgit log\fR\. Note that you must use \fB\-\-\fR to separate options to \fBgit log\fR from options to \fBgit effort\fR\. This makes it possible to only count commits you are interested in\. Not all options are relevant in the context of \fBgit\-effort\fR, but those that are is listed under the "Commit Limiting" section on the \fBgit\-log\fR manpages\.
+Options for \fBgit log\fR\.
+.
+.br
+This makes it possible to limit which commits to count\. Not all options are relevant in the context of \fBgit\-effort\fR, but those that are is listed under the "Commit Limiting" section on the \fBgit\-log\fR manpages\.
+.
+.P
+\fBNote\fR that you probably want to use \fB\-\-\fR to separate options to \fBgit log\fR from options to \fBgit effort\fR\. There are interesting usages of leaving \fB\-\-\fR out, if you understand what happens\. See examples for more on this\.
 .
 .SH "EXAMPLES"
 Note: Output will first appear unsorted, then the screen is cleared and the sorted list is output\. The initial unsorted list is not shown in the examples for brevity\.
@@ -68,7 +77,17 @@ $ git effort \-\-above 5
   git\-summary                                   8          6
   git\-delete\-branch                             8          6
   git\-repl                                      7          5
-
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Note the \fB\-\-\fR for separating options to \fBgit log\fR\. This example only counts commits from the past year, and only commits authored by Leila Muhtasib\.
+.
+.IP "" 4
+.
+.nf
 
 $ git effort \-\-above 5 bin/* \-\- \-\-after="one year ago" \-\-author="Leila Muhtasib"
 
@@ -106,17 +125,34 @@ $ git effort bin man \-\- \-\-after="one year ago"
 .P
 Only count commits in the specified revision range:
 .
-.P
-$ git effort \-\- master\.\.feature
-.
 .IP "" 4
 .
 .nf
+
+$ git effort \-\- master\.\.feature
 
   file                                          commits    active days
 
   bin/git\-effort\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\. 3          2
   man/git\-effort\.md\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\. 1          1
+.
+.fi
+.
+.IP "" 0
+.
+.P
+You can "trick" \fBgit effort\fR into thinking that a \fBrevision\fR is a path, to give a summarised view of that revision\. Remember: arguments before the \fB\-\-\fR separator is interpreted as paths\.
+.
+.IP "" 4
+.
+.nf
+
+$ git effort master\.\.feature master\.\.hotfix
+
+  file                                          commits    active days
+
+  master\.\.feature\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.4          2
+  master\.\.hotfix\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.\.1          1
 .
 .fi
 .

--- a/man/git-effort.html
+++ b/man/git-effort.html
@@ -65,7 +65,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-effort(1)</li>
-    <li class='tc'></li>
+    <li class='tc'>Git Extras</li>
     <li class='tr'>git-effort(1)</li>
   </ol>
 
@@ -85,6 +85,9 @@
 <p>  Display includes:<br />
   - Commits: number of commits per file - highlighting files with most activity.<br />
   - Active days: total number of days which contributed modifications to this file.</p>
+
+<p>  Because statistics are displayed in a linewise manner, filenames with newlines in them
+  will be displayed with the newline replaced by <code>\n</code>.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -161,7 +164,7 @@ $ git effort --above 5 bin/* -- --after="one year ago" --author="Leila Muhtasib"
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#109;&#97;&#x69;&#108;&#x74;&#x6f;&#58;&#109;&#x75;&#x68;&#x74;&#x61;&#115;&#x69;&#x62;&#x40;&#x67;&#x6d;&#97;&#105;&#x6c;&#x2e;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#x6d;&#117;&#x68;&#x74;&#97;&#x73;&#x69;&#x62;&#64;&#103;&#109;&#x61;&#105;&#108;&#46;&#x63;&#x6f;&#x6d;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#x74;&#x6f;&#58;&#109;&#x75;&#104;&#116;&#x61;&#x73;&#105;&#x62;&#x40;&#x67;&#x6d;&#97;&#x69;&#108;&#46;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#109;&#117;&#x68;&#116;&#x61;&#115;&#105;&#98;&#64;&#103;&#109;&#x61;&#105;&#108;&#x2e;&#x63;&#111;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -174,7 +177,7 @@ $ git effort --above 5 bin/* -- --after="one year ago" --author="Leila Muhtasib"
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2015</li>
+    <li class='tc'>January 2017</li>
     <li class='tr'>git-effort(1)</li>
   </ol>
 

--- a/man/git-effort.html
+++ b/man/git-effort.html
@@ -99,14 +99,20 @@
 
 <p>  Only count commits that touches the given paths.</p>
 
+<p>  <code>git effort folder_name</code> gives one entry, showing statistics for files in that folder.
+  <code>git effort folder_name/*</code> on the other hand, gives an entry for each file in that folder.</p>
+
 <p>  Note: <code>git-effort</code> does not accept revision ranges, but the underlying <code>git log</code> does (See the examples).</p>
 
 <p>  &lt;log options&gt;...</p>
 
-<p>  Options for <code>git log</code>. Note that you must use <code>--</code> to separate options to <code>git log</code>
-  from options to <code>git effort</code>.
-  This makes it possible to only count commits you are interested in.
+<p>  Options for <code>git log</code>.<br />
+  This makes it possible to limit which commits to count.
   Not all options are relevant in the context of <code>git-effort</code>, but those that are is listed under the "Commit Limiting" section on the <code>git-log</code> manpages.</p>
+
+<p>  <strong>Note</strong> that you probably want to use <code>--</code> to separate options to <code>git log</code>
+  from options to <code>git effort</code>. There are interesting usages of leaving <code>--</code> out,
+  if you understand what happens. See examples for more on this.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -128,9 +134,12 @@
   git-summary                                   8          6
   git-delete-branch                             8          6
   git-repl                                      7          5
+</code></pre>
 
+<p>  Note the <code>--</code> for separating options to <code>git log</code>. This example only counts
+  commits from the past year, and only commits authored by Leila Muhtasib.</p>
 
-$ git effort --above 5 bin/* -- --after="one year ago" --author="Leila Muhtasib"
+<pre><code>$ git effort --above 5 bin/* -- --after="one year ago" --author="Leila Muhtasib"
 
   file                                          commits    active days
 
@@ -154,17 +163,29 @@ $ git effort --above 5 bin/* -- --after="one year ago" --author="Leila Muhtasib"
 
 <p> Only count commits in the specified revision range:</p>
 
-<p>   $ git effort -- master..feature</p>
+<pre><code>$ git effort -- master..feature
 
-<pre><code>  file                                          commits    active days
+  file                                          commits    active days
 
   bin/git-effort............................... 3          2
   man/git-effort.md............................ 1          1
 </code></pre>
 
+<p>  You can "trick" <code>git effort</code> into thinking that a <code>revision</code> is a path,
+  to give a summarised view of that revision. Remember: arguments
+  before the <code>--</code> separator is interpreted as paths.</p>
+
+<pre><code>$ git effort master..feature master..hotfix
+
+  file                                          commits    active days
+
+  master..feature...............................4          2
+  master..hotfix................................1          1
+</code></pre>
+
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#x74;&#x6f;&#58;&#109;&#x75;&#104;&#116;&#x61;&#x73;&#105;&#x62;&#x40;&#x67;&#x6d;&#97;&#x69;&#108;&#46;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#109;&#117;&#x68;&#116;&#x61;&#115;&#105;&#98;&#64;&#103;&#109;&#x61;&#105;&#108;&#x2e;&#x63;&#111;&#109;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#x61;&#105;&#x6c;&#x74;&#111;&#x3a;&#x6d;&#x75;&#104;&#116;&#x61;&#x73;&#x69;&#x62;&#64;&#103;&#x6d;&#x61;&#105;&#x6c;&#46;&#99;&#111;&#x6d;" data-bare-link="true">&#109;&#x75;&#104;&#x74;&#x61;&#115;&#105;&#98;&#64;&#x67;&#x6d;&#x61;&#105;&#108;&#46;&#99;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-effort.md
+++ b/man/git-effort.md
@@ -26,15 +26,20 @@ git-effort(1) -- Show effort statistics on file(s)
 
   Only count commits that touches the given paths.
 
+  `git effort folder_name` gives one entry, showing statistics for files in that folder.
+  `git effort folder_name/*` on the other hand, gives an entry for each file in that folder.
+
   Note: `git-effort` does not accept revision ranges, but the underlying `git log` does (See the examples).  
 
   &lt;log options&gt;...
 
-  Options for `git log`. Note that you must use `--` to separate options to `git log`
-  from options to `git effort`.
-  This makes it possible to only count commits you are interested in.
+  Options for `git log`.  
+  This makes it possible to limit which commits to count.
   Not all options are relevant in the context of `git-effort`, but those that are is listed under the "Commit Limiting" section on the `git-log` manpages.
 
+  **Note** that you probably want to use `--` to separate options to `git log`
+  from options to `git effort`. There are interesting usages of leaving `--` out,
+  if you understand what happens. See examples for more on this.
 ## EXAMPLES
 
  Note: Output will first appear unsorted, then the screen is cleared and the sorted
@@ -56,6 +61,8 @@ git-effort(1) -- Show effort statistics on file(s)
       git-delete-branch                             8          6
       git-repl                                      7          5
 
+  Note the `--` for separating options to `git log`. This example only counts
+  commits from the past year, and only commits authored by Leila Muhtasib.
 
     $ git effort --above 5 bin/* -- --after="one year ago" --author="Leila Muhtasib"
 
@@ -79,12 +86,23 @@ git-effort(1) -- Show effort statistics on file(s)
 
  Only count commits in the specified revision range:
 
-   $ git effort -- master..feature
+    $ git effort -- master..feature
 
       file                                          commits    active days
 
       bin/git-effort............................... 3          2
       man/git-effort.md............................ 1          1
+
+  You can "trick" `git effort` into thinking that a `revision` is a path,
+  to give a summarised view of that revision. Remember: arguments
+  before the `--` separator is interpreted as paths.
+
+    $ git effort master..feature master..hotfix
+
+      file                                          commits    active days
+
+      master..feature...............................4          2
+      master..hotfix................................1          1
 
 
 ## AUTHOR

--- a/man/git-effort.md
+++ b/man/git-effort.md
@@ -13,6 +13,9 @@ git-effort(1) -- Show effort statistics on file(s)
   - Commits: number of commits per file - highlighting files with most activity.  
   - Active days: total number of days which contributed modifications to this file.  
 
+  Because statistics are displayed in a linewise manner, filenames with newlines in them
+  will be displayed with the newline replaced by `\n`.
+
 ## OPTIONS
 
   --above &lt;value&gt;


### PR DESCRIPTION
This fixes an issue that was reported this week, with `$`'s in a filename breaking `git log` and take `git effort` with it. `git effort` now understands how to treat files with actual newlines in them as well.

[Shellcheck](https://github.com/koalaman/shellcheck) had some complaints, and I agreed to all of them. Because of that, there is a lot of code to review, so please look at each commit individually, if that makes it easier.

While I were at it, I expanded upon the docs, and made some small rewordings. If there are many comments on the doc edits, I'll split that out in it's own PR.


______

**Please help test this**

- [x] macOS
- [x] Linux
- [ ] BSD

You can use [this repo](https://github.com/nicolaiskogheim/testrepogiteffort) as a test repo. It contains files with names that should produce an error if the issue isn't fixed.