### PR TITLE
fall back to EMAIL when user.email is not configured

### DIFF
--- a/bin/git-pull-request
+++ b/bin/git-pull-request
@@ -31,6 +31,11 @@ EOF
 # user
 
 user=$(git config user.email)
+
+if [ -z "$user" ]; then
+  user="$EMAIL"
+fi
+
 test -z "$user" && abort "git config user.email required"
 
 # branch


### PR DESCRIPTION
As discussed in #625, `git commit` and friends fall back to environment variable EMAIL when user.email is not set. This PR imports this behavior to git-pull-request. 