### PR TITLE
Feature/git fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ install:
 			if grep "$(COMMAND)" need_git_commit >/dev/null; then \
 				cat ./helper/has-git-commit >> $(TEMPFILE); \
 			fi; \
+			if grep "# needed_by: $(COMMAND)" helper/config-value >/dev/null; then \
+				cat ./helper/config-value | grep -v "# needed_by:" >> $(TEMPFILE); \
+			fi; \
 			tail -n +2 bin/$(COMMAND) >> $(TEMPFILE); \
 			cp -f $(TEMPFILE) $(DESTDIR)$(BINPREFIX)/$(COMMAND); \
 		fi; \

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -44,8 +44,6 @@ if [[ -z "$user" ]]; then
 fi
 
 if [[ -z "$token" ]]; then
-  echo "Enter github password"
-  read password
   echo "Enter github two-factor authentication code (leave blank if not set up)"
   read MFA_CODE
 fi
@@ -55,10 +53,10 @@ header_info=''
 if [[ -n "$token" ]]; then
   header_info="-H \"Authorization: token ${token}\""
 elif [[ -n "$MFA_CODE" ]]; then
-  auth_info="-u \"$user:$password\""
+  auth_info="-u \"$user\""
   header_info="-H \"X-GitHub-OTP: $MFA_CODE\""
 elif [[ -n "$password" ]]; then
-  auth_info="-u \"$user:$password\""
+  auth_info="-u \"$user\""
 else
   echo "No login credentials specified."
   exit 1

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -64,9 +64,9 @@ fi
 
 # create fork
 IFS="'" cmd="curl -qs -X POST $auth_info $header_info https://$api_server/${api_prefix}repos/$owner/$project/forks"
-eval $cmd >/dev/null 
+eval $cmd  | grep "message" >/dev/null
 
-[ $? = 0 ] || abort "fork failed"
+[ $? = 0 ] && abort "fork failed"
 
 use_ssh=$(get_config_value "$server.use-ssh")
 if [[ -z "$use_ssh" ]]; then
@@ -103,10 +103,11 @@ else
       git clone "${remote_prefix}${user}/${project}.git" "$project" 2>/dev/null
     done
 
-    if [[ -d "$proejct" ]]; then
+    if [[ -d "$project" ]]; then
       # add reference to origin fork so can merge in upstream changes
       cd "$project"
-      git remote add upstream "${remote_prefix}${owner}/${project}.git"
+      git remote add upstream "${remote_prefix}${owner}/${project}.git" 2>/dev/null
+      [[ $? > 0 ]] && echo "WARN: upstream reference already exists"
       git fetch upstream
     else
       echo "Github did not fork within 60 seconds or issue cloning repo."

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -10,42 +10,73 @@ test -z "$url" && url=$(git remote get-url origin 2> /dev/null) && origin=true
 # validate repo url
 test -z "$url" && abort "github repo needs to be specified as an argument"
 
-# validate user
-echo "Enter your github username"
-read user
-[ -n "$user" ] || abort "git username required"
-echo "Enter github two-factor authentication code (leave blank if not set up)"
-read MFA_CODE
-
 # extract owner + project from repo url
 project=${url##*/}
 owner=${url%/$project}
 project=${project%.git}
-if [[ $owner == git@* ]]; then
-  owner=${owner##*:}
-else
-  owner=${owner##*/}
-fi
+owner=${owner##*[/:]}
+# Yes, the following extracts server for both SSH and https references
+server=${url##*@}
+server=${server##*://}
+server=${server%%[/:]*}
 
 # validate
 [ -z "$project" -o -z "$owner" ] && abort "github repo needs to be specified as an argument"
 
+# determine github credentials
+user=$(get_config_value "$server.user")
+token=$(get_config_value "$server.token")
+if [[ $(get_config_value "$server.add-api") == "true" ]]; then
+  api_server="api.$server"
+else
+  api_server=$server
+fi
+
+if [[ -z "$user" ]]; then
+  # validate user
+  echo "Enter your github username"
+  read user
+  [ -n "$user" ] || abort "git username required"
+fi
+
+if [[ -z "$token" ]]; then
+  echo "Enter github password"
+  read password
+  echo "Enter github two-factor authentication code (leave blank if not set up)"
+  read MFA_CODE
+fi
+
+auth_info=''
+header_info=''
+if [[ -n "$token" ]]; then
+  header_info="-H \"Authorization: token ${token}\""
+elif [[ -n "$MFA_CODE" ]]; then
+  auth_info="-u \"$user:$password\""
+  header_info="-H \"X-GitHub-OTP: $MFA_CODE\""
+elif [[ -n "$password" ]]; then
+  auth_info="-u \"$user:$password\""
+else
+  echo "No login credentials specified."
+  exit 1
+fi
+
 # create fork
-curl -qs \
-  -X POST \
-  -u "$user" \
-  -H "X-GitHub-OTP: $MFA_CODE" \
-  "https://api.github.com/repos/$owner/$project/forks"
+IFS="'" cmd="curl -qs -X POST $auth_info $header_info https://$api_server/repos/$owner/$project/forks"
+eval $cmd >/dev/null
 
 [ $? = 0 ] || abort "fork failed"
 
-echo "Add GitHub remote branch via SSH (you will be prompted to verify the server's credentials)? (y/n)"
-read use_ssh
+use_ssh=$(get_config_value "$server.use-ssh")
+if [[ -z "$use_ssh" ]]; then
+  echo "Add GitHub remote branch via SSH (you will be prompted to verify the server's credentials)? (y/n)"
+  read use_ssh
+fi
+
 # Check if user has ssh configured with GitHub
-if [ -n "$use_ssh" ] && ssh -T git@github.com 2>&1 | grep -qi 'success'; then
-  remote_prefix="git@github.com:"
+if [ -n "$use_ssh" ] && ssh -T git@$server 2>&1 | grep -qi 'success'; then
+  remote_prefix="git@$server:"
 else
-  remote_prefix="https://github.com/"
+  remote_prefix="https://$server/"
 fi
 
 if [ "$origin" = true ]; then

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -66,7 +66,7 @@ fi
 
 # create fork
 IFS="'" cmd="curl -qs -X POST $auth_info $header_info https://$api_server/${api_prefix}repos/$owner/$project/forks"
-eval $cmd >/dev/null
+eval $cmd >/dev/null 
 
 [ $? = 0 ] || abort "fork failed"
 
@@ -89,15 +89,29 @@ if [ "$origin" = true ]; then
     git fetch origin
 else
     # clone forked repo into current dir
-    git clone "${remote_prefix}${user}/${project}.git" "$project"
-    until [[ -d "$project" ]]; do
-      echo "Github is being slow today. Waiting 10 secs to attempt clone."
-      sleep 10
-      git clone "${remote_prefix}${user}/${project}.git" "$project"
-    done 
-    
-    # add reference to origin fork so can merge in upstream changes
-    cd "$project"
-    git remote add upstream "${remote_prefix}${owner}/${project}.git"
-    git fetch upstream
+    git clone "${remote_prefix}${user}/${project}.git" "$project" 2>/dev/null
+
+    # Check to make sure we cloned the repo. Backoff exponetially and try again
+    timeout=( 2 2 2 6 6 6 20 20 )
+    total_wait=0
+    until [[ (( "$total_wait" > 60 )) || -d "$project" ]]; do
+      echo "Github is being slow today. Waiting $timeout secs to attempt clone."
+      sleep ${timeout[0]}
+      total_wait=$(expr $total_wait + ${timeout[0]})
+      # drop the first element and prepare to wait the next time interval
+      unset timeout[0]
+      timeout=( ${timeout[@]} )
+
+      git clone "${remote_prefix}${user}/${project}.git" "$project" 2>/dev/null
+    done
+
+    if [[ -d "$proejct" ]]; then
+      # add reference to origin fork so can merge in upstream changes
+      cd "$project"
+      git remote add upstream "${remote_prefix}${owner}/${project}.git"
+      git fetch upstream
+    else
+      echo "Github did not fork within 60 seconds or issue cloning repo."
+      exit 1
+    fi
 fi

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -31,6 +31,10 @@ if [[ $(get_config_value "$server.add-api") == "true" ]]; then
 else
   api_server=$server
 fi
+# retrieve the API prefix and clean it up (i.e. "api/v3/")
+api_prefix="$(get_config_value "$server.api-prefix")/"
+api_prefix=${api_prefix#/}
+api_prefix=${api_prefix/%\/\//\/}
 
 if [[ -z "$user" ]]; then
   # validate user
@@ -61,7 +65,7 @@ else
 fi
 
 # create fork
-IFS="'" cmd="curl -qs -X POST $auth_info $header_info https://$api_server/repos/$owner/$project/forks"
+IFS="'" cmd="curl -qs -X POST $auth_info $header_info https://$api_server/${api_prefix}repos/$owner/$project/forks"
 eval $cmd >/dev/null
 
 [ $? = 0 ] || abort "fork failed"
@@ -86,6 +90,12 @@ if [ "$origin" = true ]; then
 else
     # clone forked repo into current dir
     git clone "${remote_prefix}${user}/${project}.git" "$project"
+    until [[ -d "$project" ]]; do
+      echo "Github is being slow today. Waiting 10 secs to attempt clone."
+      sleep 10
+      git clone "${remote_prefix}${user}/${project}.git" "$project"
+    done 
+    
     # add reference to origin fork so can merge in upstream changes
     cd "$project"
     git remote add upstream "${remote_prefix}${owner}/${project}.git"

--- a/helper/config-value
+++ b/helper/config-value
@@ -1,0 +1,11 @@
+# needed_by: git-fork
+
+get_config_value() {
+  echo $(git config git-extras.$1)
+}
+
+# set_config_value "key" "value" "global|system" (global or system not required)
+set_config_value() {
+  $(git config ${3+--$3} git-extras.$1 $2)
+  echo $?
+}

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -76,6 +76,11 @@ add\-api: In most cases this should be set to true\. This adds the \'api\'
     to access the Github API\. The time you would not set this is when
     your API hostname is the same as Github instance hostname\.
 
+api\-prefix: Github Enterprise much of the time uses "/api/v3/" as a
+    entry point to the API\. Regular Github access does not need to
+    have a prefix specified\. Consult your Github administrator for
+    the correct prefix to use\.
+
 use\-ssh: Set to true in order to set the upstream remote reference
     to use SSH instead of https\.
 .

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-FORK" "1" "August 2016" "" "Git Extras"
+.TH "GIT\-FORK" "1" "February 2017" "" ""
 .
 .SH "NAME"
 \fBgit\-fork\fR \- Fork a repo on github
@@ -40,7 +40,66 @@ adds the forked repo as a remote called \fBorigin\fR
 .P
 Remotes will use ssh if you have it configured with GitHub, if not, https will be used\.
 .
+.P
+Your Github settings can not be saved as git config values instead of specifying them each time\. To enable this you need to execute a few git config commands like the following\.
+.
+.IP "" 4
+.
+.nf
+
+$ git config \-\-global git\-extras\.github\.com\.user greatcoder99
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Assuming that your username is \'greatcoder99\'\. All the configuration values are prefixed with \'git\-extras\.\' followed by server hostname and then finally by the variable name (defined below)\.
+.
+.P
+In addition, other Github instances may be used other than just github\.com\. So if you have a Github Enterprise instance, then using that hostname instead of github\.com will work as expected\.
+.
+.P
+Variables that are currently supported:
+.
+.IP "" 4
+.
+.nf
+
+user: The username that the Github instance knows you as
+
+token: The personal access token that has been generated to allow
+    password\-less access to the API\.
+
+add\-api: In most cases this should be set to true\. This adds the \'api\'
+    hostname to the repo location (i\.e\. github\.com becomes api\.github\.com)
+    to access the Github API\. The time you would not set this is when
+    your API hostname is the same as Github instance hostname\.
+
+use\-ssh: Set to true in order to set the upstream remote reference
+    to use SSH instead of https\.
+.
+.fi
+.
+.IP "" 0
+.
 .SH "EXAMPLE"
+Create settings to prevent answering questions:
+.
+.IP "" 4
+.
+.nf
+
+$ git config \-\-global git\-extras\.github\.com\.user bigdog
+$ git config \-\-global git\-extras\.github\.com\.token d149feb47\.\.\.\.
+$ git config \-\-global git\-extras\.github\.com\.add\-api true
+$ git config \-\-global git\-extras\.github\.com\.use\-ssl true
+.
+.fi
+.
+.IP "" 0
+.
+.P
 Fork expect\.js:
 .
 .IP "" 4
@@ -101,6 +160,9 @@ $ git fork
 .
 .SH "AUTHOR"
 Written by Andrew Griffiths <\fImail@andrewgriffithsonline\.com\fR>
+.
+.P
+Github Enterprise support and settings by Gerard Hickey <\fIhickey@kinetic\-compute\.com\fR>
 .
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -41,7 +41,7 @@ adds the forked repo as a remote called \fBorigin\fR
 Remotes will use ssh if you have it configured with GitHub, if not, https will be used\.
 .
 .P
-Your Github settings can not be saved as git config values instead of specifying them each time\. To enable this you need to execute a few git config commands like the following\.
+Your Github settings can now be saved as git config values instead of specifying them each time\. To enable this you need to execute a few git config commands like the following\.
 .
 .IP "" 4
 .

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -64,7 +64,7 @@
 
   <ol class='man-decor man-head man head'>
     <li class='tl'>git-fork(1)</li>
-    <li class='tc'>Git Extras</li>
+    <li class='tc'></li>
     <li class='tr'>git-fork(1)</li>
   </ol>
 
@@ -99,7 +99,46 @@
 
 <p>  Remotes will use ssh if you have it configured with GitHub, if not, https will be used.</p>
 
+<p>  Your Github settings can not be saved as git config values instead of
+  specifying them each time. To enable this you need to execute a few git
+  config commands like the following.</p>
+
+<pre><code>$ git config --global git-extras.github.com.user greatcoder99
+</code></pre>
+
+<p>  Assuming that your username is 'greatcoder99'. All the configuration
+  values are prefixed with 'git-extras.' followed by server hostname and
+  then finally by the variable name (defined below).</p>
+
+<p>  In addition, other Github instances may be used other than just
+  github.com. So if you have a Github Enterprise instance, then using that
+  hostname instead of github.com will work as expected.</p>
+
+<p>  Variables that are currently supported:</p>
+
+<pre><code>user: The username that the Github instance knows you as
+
+token: The personal access token that has been generated to allow
+    password-less access to the API.
+
+add-api: In most cases this should be set to true. This adds the 'api'
+    hostname to the repo location (i.e. github.com becomes api.github.com)
+    to access the Github API. The time you would not set this is when
+    your API hostname is the same as Github instance hostname.
+
+use-ssh: Set to true in order to set the upstream remote reference
+    to use SSH instead of https.
+</code></pre>
+
 <h2 id="EXAMPLE">EXAMPLE</h2>
+
+<p>  Create settings to prevent answering questions:</p>
+
+<pre><code>$ git config --global git-extras.github.com.user bigdog
+$ git config --global git-extras.github.com.token d149feb47....
+$ git config --global git-extras.github.com.add-api true
+$ git config --global git-extras.github.com.use-ssl true
+</code></pre>
 
 <p>  Fork expect.js:</p>
 
@@ -130,7 +169,9 @@ $ cd expect.js &amp;&amp; git remote -v
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Andrew Griffiths &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#x6f;&#58;&#109;&#97;&#x69;&#x6c;&#64;&#x61;&#x6e;&#x64;&#x72;&#101;&#x77;&#103;&#114;&#x69;&#x66;&#102;&#105;&#116;&#x68;&#115;&#111;&#110;&#108;&#105;&#110;&#101;&#46;&#x63;&#111;&#x6d;" data-bare-link="true">&#109;&#97;&#105;&#x6c;&#x40;&#97;&#110;&#x64;&#114;&#101;&#x77;&#x67;&#114;&#x69;&#102;&#102;&#x69;&#x74;&#104;&#115;&#x6f;&#110;&#x6c;&#x69;&#110;&#x65;&#46;&#99;&#x6f;&#109;</a>&gt;</p>
+<p>Written by Andrew Griffiths &lt;<a href="&#109;&#x61;&#105;&#108;&#116;&#111;&#x3a;&#x6d;&#x61;&#105;&#108;&#x40;&#x61;&#x6e;&#100;&#x72;&#101;&#x77;&#x67;&#114;&#105;&#102;&#102;&#x69;&#x74;&#x68;&#115;&#x6f;&#x6e;&#108;&#105;&#x6e;&#x65;&#46;&#x63;&#x6f;&#109;" data-bare-link="true">&#109;&#x61;&#x69;&#108;&#x40;&#97;&#x6e;&#100;&#114;&#101;&#119;&#103;&#114;&#x69;&#102;&#102;&#x69;&#x74;&#104;&#x73;&#x6f;&#x6e;&#108;&#x69;&#x6e;&#101;&#46;&#x63;&#x6f;&#109;</a>&gt;</p>
+
+<p>Github Enterprise support and settings by Gerard Hickey &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#104;&#105;&#x63;&#107;&#x65;&#x79;&#64;&#107;&#x69;&#x6e;&#x65;&#x74;&#x69;&#99;&#45;&#99;&#x6f;&#109;&#x70;&#x75;&#116;&#101;&#46;&#99;&#x6f;&#109;" data-bare-link="true">&#x68;&#x69;&#x63;&#x6b;&#101;&#x79;&#64;&#107;&#x69;&#x6e;&#x65;&#116;&#x69;&#x63;&#x2d;&#99;&#111;&#109;&#x70;&#117;&#116;&#101;&#46;&#x63;&#x6f;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -143,7 +184,7 @@ $ cd expect.js &amp;&amp; git remote -v
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2016</li>
+    <li class='tc'>February 2017</li>
     <li class='tr'>git-fork(1)</li>
   </ol>
 

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -99,7 +99,7 @@
 
 <p>  Remotes will use ssh if you have it configured with GitHub, if not, https will be used.</p>
 
-<p>  Your Github settings can not be saved as git config values instead of
+<p>  Your Github settings can now be saved as git config values instead of
   specifying them each time. To enable this you need to execute a few git
   config commands like the following.</p>
 

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -126,6 +126,11 @@ add-api: In most cases this should be set to true. This adds the 'api'
     to access the Github API. The time you would not set this is when
     your API hostname is the same as Github instance hostname.
 
+api-prefix: Github Enterprise much of the time uses "/api/v3/" as a
+    entry point to the API. Regular Github access does not need to 
+    have a prefix specified. Consult your Github administrator for 
+    the correct prefix to use.
+
 use-ssh: Set to true in order to set the upstream remote reference
     to use SSH instead of https.
 </code></pre>
@@ -169,9 +174,9 @@ $ cd expect.js &amp;&amp; git remote -v
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Andrew Griffiths &lt;<a href="&#109;&#x61;&#105;&#108;&#116;&#111;&#x3a;&#x6d;&#x61;&#105;&#108;&#x40;&#x61;&#x6e;&#100;&#x72;&#101;&#x77;&#x67;&#114;&#105;&#102;&#102;&#x69;&#x74;&#x68;&#115;&#x6f;&#x6e;&#108;&#105;&#x6e;&#x65;&#46;&#x63;&#x6f;&#109;" data-bare-link="true">&#109;&#x61;&#x69;&#108;&#x40;&#97;&#x6e;&#100;&#114;&#101;&#119;&#103;&#114;&#x69;&#102;&#102;&#x69;&#x74;&#104;&#x73;&#x6f;&#x6e;&#108;&#x69;&#x6e;&#101;&#46;&#x63;&#x6f;&#109;</a>&gt;</p>
+<p>Written by Andrew Griffiths &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#x74;&#111;&#x3a;&#109;&#97;&#105;&#108;&#x40;&#x61;&#110;&#100;&#x72;&#101;&#119;&#x67;&#x72;&#x69;&#x66;&#102;&#105;&#x74;&#104;&#115;&#111;&#110;&#x6c;&#x69;&#x6e;&#101;&#46;&#x63;&#x6f;&#109;" data-bare-link="true">&#109;&#x61;&#105;&#x6c;&#64;&#97;&#110;&#100;&#114;&#101;&#119;&#x67;&#x72;&#x69;&#102;&#x66;&#x69;&#116;&#104;&#x73;&#x6f;&#110;&#x6c;&#105;&#x6e;&#101;&#46;&#99;&#111;&#x6d;</a>&gt;</p>
 
-<p>Github Enterprise support and settings by Gerard Hickey &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#x3a;&#104;&#105;&#x63;&#107;&#x65;&#x79;&#64;&#107;&#x69;&#x6e;&#x65;&#x74;&#x69;&#99;&#45;&#99;&#x6f;&#109;&#x70;&#x75;&#116;&#101;&#46;&#99;&#x6f;&#109;" data-bare-link="true">&#x68;&#x69;&#x63;&#x6b;&#101;&#x79;&#64;&#107;&#x69;&#x6e;&#x65;&#116;&#x69;&#x63;&#x2d;&#99;&#111;&#109;&#x70;&#117;&#116;&#101;&#46;&#x63;&#x6f;&#x6d;</a>&gt;</p>
+<p>Github Enterprise support and settings by Gerard Hickey &lt;<a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#x3a;&#104;&#105;&#x63;&#107;&#101;&#121;&#x40;&#x6b;&#105;&#110;&#x65;&#x74;&#x69;&#99;&#45;&#x63;&#111;&#109;&#x70;&#117;&#116;&#x65;&#46;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#x68;&#105;&#99;&#107;&#x65;&#121;&#64;&#x6b;&#105;&#x6e;&#x65;&#116;&#105;&#99;&#45;&#x63;&#x6f;&#x6d;&#112;&#x75;&#x74;&#101;&#x2e;&#99;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -47,6 +47,11 @@ git-fork(1) -- Fork a repo on github
         to access the Github API. The time you would not set this is when
         your API hostname is the same as Github instance hostname.
 
+    api-prefix: Github Enterprise much of the time uses "/api/v3/" as a
+        entry point to the API. Regular Github access does not need to 
+        have a prefix specified. Consult your Github administrator for 
+        the correct prefix to use.
+
     use-ssh: Set to true in order to set the upstream remote reference
         to use SSH instead of https.
 

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -21,7 +21,7 @@ git-fork(1) -- Fork a repo on github
 
   Remotes will use ssh if you have it configured with GitHub, if not, https will be used.
 
-  Your Github settings can not be saved as git config values instead of
+  Your Github settings can now be saved as git config values instead of
   specifying them each time. To enable this you need to execute a few git
   config commands like the following.
 

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -21,7 +21,43 @@ git-fork(1) -- Fork a repo on github
 
   Remotes will use ssh if you have it configured with GitHub, if not, https will be used.
 
+  Your Github settings can not be saved as git config values instead of
+  specifying them each time. To enable this you need to execute a few git
+  config commands like the following.
+
+    $ git config --global git-extras.github.com.user greatcoder99
+
+  Assuming that your username is 'greatcoder99'. All the configuration
+  values are prefixed with 'git-extras.' followed by server hostname and
+  then finally by the variable name (defined below).
+
+  In addition, other Github instances may be used other than just
+  github.com. So if you have a Github Enterprise instance, then using that
+  hostname instead of github.com will work as expected.
+
+  Variables that are currently supported:
+
+    user: The username that the Github instance knows you as
+
+    token: The personal access token that has been generated to allow
+        password-less access to the API.
+
+    add-api: In most cases this should be set to true. This adds the 'api'
+        hostname to the repo location (i.e. github.com becomes api.github.com)
+        to access the Github API. The time you would not set this is when
+        your API hostname is the same as Github instance hostname.
+
+    use-ssh: Set to true in order to set the upstream remote reference
+        to use SSH instead of https.
+
 ## EXAMPLE
+
+  Create settings to prevent answering questions:
+
+    $ git config --global git-extras.github.com.user bigdog
+    $ git config --global git-extras.github.com.token d149feb47....
+    $ git config --global git-extras.github.com.add-api true
+    $ git config --global git-extras.github.com.use-ssl true
 
   Fork expect.js:
 
@@ -50,6 +86,8 @@ git-fork(1) -- Fork a repo on github
 ## AUTHOR
 
 Written by Andrew Griffiths &lt;<mail@andrewgriffithsonline.com>&gt;
+
+Github Enterprise support and settings by Gerard Hickey &lt;<hickey@kinetic-compute.com>&gt;
 
 ## REPORTING BUGS
 


### PR DESCRIPTION
Added support for forking on instances of Github other than github.com.

In addition added ability to pull stored settings from git config so that one is not prompted each time for things like username and such.

Also introduced a self documenting way of including helper scripts into the generated scripts. See the Makefile and helper/config-value for details. Also helps keeping one from forgetting to update the needs_* files.