### PR TITLE
Columns in git-effort adopt to file length

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -5,6 +5,7 @@ above=0
 # if the output won't be printed to tty, disable the color
 test -t 1 && to_tty=true
 color=
+columns=45
 
 #
 # print usage message
@@ -104,7 +105,7 @@ effort() {
     len=${#path}
     dot="."
     f_dot="$path"
-    i=0 ; while test $i -lt $((45-$len)) ; do
+    i=0 ; while test $i -lt $(( $columns - $len )) ; do
       f_dot=$f_dot$dot
       i=$(($i+1))
     done
@@ -124,7 +125,7 @@ effort() {
 
 heading() {
   echo
-  printf "  %-45s %-10s %s\n" 'path' 'commits' 'active days'
+  printf "  %-${columns}s %-10s %s\n" 'path' 'commits' 'active days'
   echo
 }
 
@@ -176,6 +177,10 @@ fi
 # remove empty quotes that appear when there are no arguments
 args_to_git_log="${args_to_git_log#\ \'\'}"
 export args_to_git_log
+
+# set column width to match longest filename
+columns=$(( $(git ls-files | awk '{ print length, $0 }' | sort -rn | head -1 | cut -f1 -d' ') + 5 ))
+export columns
 
 # [path ...]
 

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -179,7 +179,7 @@ args_to_git_log="${args_to_git_log#\ \'\'}"
 export args_to_git_log
 
 # set column width to match longest filename
-columns=$(( $(git ls-files | awk '{ print length, $0 }' | sort -rn | head -1 | cut -f1 -d' ') + 5 ))
+columns=$(( $(git ls-files | awk '{ print length }' | sort -rn | head -1 ) + 5 ))
 export columns
 
 # [path ...]

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -5,7 +5,6 @@ above=0
 # if the output won't be printed to tty, disable the color
 test -t 1 && to_tty=true
 color=
-columns=45
 
 #
 # print usage message


### PR DESCRIPTION
The columns in git-effort end up in a mess when you have longer file names.
I have fixed that so the column width matches the longest file in the current git repo.