### PR TITLE
use remote detected instead of 'origin' in rename-branch

### DIFF
--- a/bin/git-rename-branch
+++ b/bin/git-rename-branch
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
+set -e
 
 # Assert there is at least one branch provided
 test -z $1 && echo "new branch name required." 1>&2 && exit 1
 
 new_branch="$1"
 old_branch="${2-$(git symbolic-ref --short -q HEAD)}"
+remote=$(git config branch."$old_branch".remote)
 
 git branch -m "$old_branch" "$new_branch"
-git push origin :"$old_branch"
-git push --set-upstream origin "$new_branch"
+# check if the branch is tracking a remote branch
+if [[ -n "$remote" && "$remote" != "." ]]
+then
+    git push "$remote" :"$old_branch"
+    git push --set-upstream "$remote" "$new_branch"
+fi


### PR DESCRIPTION
This change will deal with the case in #634 smoothly.
@lagden
Is this what you prefer?