### PR TITLE
Git bulk command

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -237,7 +237,7 @@ $ git effort bin/* lib/*
 
 ## git bulk
 
-`git bulk` adds covenient support for operations that you want to execute on multiple git repositories.
+`git bulk` adds convenient support for operations that you want to execute on multiple git repositories.
 
   * simply register workspaces that contain multiple git repos in their directory structure
   * run any git command on the repositories of the registered workspaces in one command to `git bulk`

--- a/Commands.md
+++ b/Commands.md
@@ -4,6 +4,7 @@
  - [`git authors`](#git-authors)
  - [`git back`](#git-back)
  - [`git bug`](#git-featurerefactorbugchore)
+ - [`git bulk`](#git-bulk)
  - [`git changelog`](#git-changelog)
  - [`git chore`](#git-featurerefactorbugchore)
  - [`git clear`](#git-clear)
@@ -232,6 +233,73 @@ $ git effort --above 5
 
 ```
 $ git effort bin/* lib/*
+```
+
+## git bulk
+
+`git bulk` adds covenien support for operations that you want to execute on multiple git repositories.
+
+  * simply register workspaces that contain multiple git repos in their directory structure
+  * run any git command on the repositories of the registered workspaces in one command to `git bulk`
+  * use the "guarded mode" to check on each execution
+
+```bash
+usage: git bulk [-g] [-w <ws-name>] <git command>
+       git bulk --addworkspace <ws-name> <ws-root-directory>
+       git bulk --removeworkspace <ws-name>
+       git bulk --addcurrent <ws-name>
+       git bulk --purge
+       git bulk --listall
+```
+
+  Register a workspace so that `git bulk` knows about it:
+
+```bash
+$ git bulk --addworkspace personal ~/workspaces/personal
+```
+
+  Register the current directory as a workspace to `git bulk`
+
+```bash
+$ git bulk --addcurrent personal
+```
+
+  List all registered workspaces:
+
+```bash
+$ git bulk --listall
+bulkworkspaces.personal /Users/niklasschlimm/workspaces/personal
+```
+
+  Run a git command on the repositories:
+
+```bash
+$ git bulk fetch
+```
+
+![fetchdemo](https://cloud.githubusercontent.com/assets/876604/23709805/e8178406-041a-11e7-9a0c-01de5fbf8944.png)
+
+  Run a git command on only one workspace ans its repositories:
+
+```bash
+$ git bulk -w personal fetch
+```
+
+  Run a git command but ask user for confirmation on every execution (guarded mode):
+
+```bash
+$ git bulk -g fetch
+```
+
+  Remove a registered workspace:
+
+```bash
+$ git bulk --removeworkspace personal
+```
+  Remove all registered workspaces:
+
+```bash
+$ git bulk --purge
 ```
 
 ## git repl

--- a/Commands.md
+++ b/Commands.md
@@ -244,7 +244,7 @@ $ git effort bin/* lib/*
   * use the "guarded mode" to check on each execution
 
 ```bash
-usage: git bulk [-g] [-w <ws-name>] <git command>
+usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>
        git bulk --addworkspace <ws-name> <ws-root-directory>
        git bulk --removeworkspace <ws-name>
        git bulk --addcurrent <ws-name>
@@ -271,7 +271,7 @@ $ git bulk --listall
 bulkworkspaces.personal /Users/niklasschlimm/workspaces/personal
 ```
 
-  Run a git command on the repositories:
+  Run a git command on the repositories of the current workspace:
 
 ```bash
 $ git bulk fetch
@@ -279,7 +279,13 @@ $ git bulk fetch
 
 ![fetchdemo](https://cloud.githubusercontent.com/assets/876604/23709805/e8178406-041a-11e7-9a0c-01de5fbf8944.png)
 
-  Run a git command on only one workspace ans its repositories:
+  Run a git command on one specific workspace and its repositories:
+
+```bash
+$ git bulk -w personal fetch
+```
+
+  Run a git command on all workspaces and their repositories:
 
 ```bash
 $ git bulk -w personal fetch

--- a/Commands.md
+++ b/Commands.md
@@ -252,7 +252,7 @@ usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>
        git bulk --listall
 ```
 
-  Register a workspace so that `git bulk` knows about it:
+  Register a workspace so that `git bulk` knows about it (notice that <ws-root-directory> must be absolute path):
 
 ```bash
 $ git bulk --addworkspace personal ~/workspaces/personal

--- a/Commands.md
+++ b/Commands.md
@@ -237,7 +237,7 @@ $ git effort bin/* lib/*
 
 ## git bulk
 
-`git bulk` adds covenien support for operations that you want to execute on multiple git repositories.
+`git bulk` adds covenient support for operations that you want to execute on multiple git repositories.
 
   * simply register workspaces that contain multiple git repos in their directory structure
   * run any git command on the repositories of the registered workspaces in one command to `git bulk`
@@ -288,7 +288,7 @@ $ git bulk -w personal fetch
   Run a git command on all workspaces and their repositories:
 
 ```bash
-$ git bulk -w personal fetch
+$ git bulk -a fetch
 ```
 
   Run a git command but ask user for confirmation on every execution (guarded mode):

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -86,7 +86,7 @@ function wsnameToCurrent () {
     if echo $PWD | grep -o -q $rwsdir; then wsname=$rwsname && return; fi
   done <<< "$(echo "$(listall)")"
   # when here then not in workspace dir
-  echo "error: you are not in a workspace directory. your workspaces:" && wslist=$(echo "$(listall)") && echo ${wslist:-'<no workspaces defined yet>'}  
+  echo "error: you are not in a workspace directory. your registered workspaces are:" && wslist="$(echo "$(listall)")" && echo "${wslist:-'<no workspaces defined yet>'}" && exit 1
 }
 
 # helper to check number of arguments
@@ -96,8 +96,8 @@ function allowedargcount () {
 
 # execute the bulk operation
 function executBulkOp () {
-  if ! $allwsmode && ! $singlemode; then wsnameToCurrent; fi # by default git bulk works within the 'current' workspace
   checkGitCommand
+  if ! $allwsmode && ! $singlemode; then wsnameToCurrent; fi # by default git bulk works within the 'current' workspace
   listall | while read workspacespec; do
     cwsname=$(echo $workspacespec | cut -f1 -d' ' | cut -f2 -d'.')
     if [[ -n $wsname ]] && [[ $cwsname != $wsname ]]; then continue; fi

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -44,7 +44,7 @@ function listWSDir () {
   git config --global --get-regexp bulkworkspaces
 }
 
-# atomic execution of a git command in one specific repository
+# guarded execution of a git command in one specific repository
 function guardedExecution () {
   if $guarded; then
     echo -n "${invers}git $gitcommand${reset} -> execute here (y/n)? "
@@ -57,7 +57,7 @@ function guardedExecution () {
   fi
 }
 
-# execute a git command with log
+# atomic git command execution with log
 function atomicExecution () {
   echo "${bldred}->${reset} executing ${invers}git $gitcommand${reset}"
   git $gitcommand
@@ -152,19 +152,19 @@ while [ "${#}" -ge 1 ] ; do
     -g)
       guarded=true
       ;;
-    -w)
+      -w)
       singlemode=true
       shift
       wsname="$1"
       checkWSName
       ;;
     -*)
-	  usage
+      usage
       echo 1>&2 "error: unknown argument $1"
       exit 1
       ;;
     --*)
-	  usage
+      usage
       echo 1>&2 "error: unknown argument $1"
       exit 1
       ;;
@@ -177,32 +177,31 @@ while [ "${#}" -ge 1 ] ; do
       break
       ;;
   esac
-
   shift
 done
 
 # check right number of arguments
 case $butilcommand in
-    @(listWSDir|purgeWS) )
-       if [[ $initialcount -ne 1 ]]; then
-       	 usage
-       	 echo 1>&2 "error: wrong number of arguments"
-         exit 1
-       fi 
+  @(listWSDir|purgeWS) )
+    if [[ $initialcount -ne 1 ]]; then
+      usage
+      echo 1>&2 "error: wrong number of arguments"
+      exit 1
+    fi 
     ;;
-    @(addCurrWSDir|remWSDir))
-       if [[ $initialcount -ne 2 ]]; then
-       	 usage
-       	 echo 1>&2 "error: wrong number of arguments"
-         exit 1
-       fi 
+  @(addCurrWSDir|remWSDir))
+    if [[ $initialcount -ne 2 ]]; then
+      usage
+      echo 1>&2 "error: wrong number of arguments"
+      exit 1
+    fi 
     ;;
-	addWSDir)
-       if [[ $initialcount -ne 3 ]]; then
-       	 usage
-       	 echo 1>&2 "error: wrong number of arguments"
-         exit 1
-       fi 
+  addWSDir)
+    if [[ $initialcount -ne 3 ]]; then
+      usage
+      echo 1>&2 "error: wrong number of arguments"
+      exit 1
+    fi 
     ;;
 esac
 

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -113,7 +113,8 @@ function executBulkOp () {
       local gitrepodir=${line::${#line}-5} # cut the .git part of find results to have the root git directory of that repository
       eval cd "\"$gitrepodir\"" # into git repo location
       local curdir=$(pwd)
-      echo "Current repository: ${actual#${curdir%/*}}/${bldred}${curdir##*/}${reset}"
+      local leadingpath=${curdir#${actual}}
+      echo "Current repository: ${leadingpath%/*}/${bldred}${curdir##*/}${reset}"
       guardedExecution
       eval cd "\"$rwsdir\"" # back to origin location of last find command
     done 

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -1,27 +1,4 @@
 #!/usr/bin/env bash
-# reset environment variables that could interfere with normal usage
-export GREP_OPTIONS=
-# put all utility functions here
-
-# make a temporary file
-git_extra_mktemp() {
-    mktemp -t "$(basename "$0")".XXX
-}
-
-#
-# check whether current directory is inside a git repository
-#
-
-is_git_repo() {
-  git rev-parse --show-toplevel > /dev/null 2>&1
-  result=$?
-  if test $result != 0; then
-    >&2 echo 'Not a git repo!'
-    exit $result
-  fi
-}
-
-is_git_repo
 invers=`tput rev`
 reset=`tput sgr0`
 txtbld=$(tput bold)             # Bold

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -80,7 +80,7 @@ function checkWSName () {
   while read workspace; do
     cwsname=$(echo $workspace | cut -f1 -d' ' | cut -f2 -d'.')
     if [[ $cwsname == $wsname ]]; then return; fi
-  done <<< "$(echo $(listWSDir))"
+  done <<< "$(echo "$(listWSDir)")"
   # when here the ws name was not found
   echo "error: unknown workspace name: $wsname"
   exit 1 
@@ -93,7 +93,7 @@ function executBulkOp () {
   fi
   listWSDir | while read workspacespec; do
     cwsname=$(echo $workspacespec | cut -f1 -d' ' | cut -f2 -d'.')
-    if $singlemode && $cwsname != $wsname ]]; then continue; fi
+    if $singlemode && [[ $cwsname != $wsname ]]; then continue; fi
     wslocation=$(echo $workspacespec | cut -f2 -d' ')
     eval cd "$wslocation"
     actual=$(pwd)

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 invers=`tput rev`
 reset=`tput sgr0`
-txtbld=$(tput bold)             # Bold
-bldred=${txtbld}$(tput setaf 1) #  red
+txtbld=$(tput bold)             
+bldred=${txtbld}$(tput setaf 1) 
 shopt -s extglob
 guarded=false
 singlemode=false
@@ -20,39 +20,26 @@ usage() {
 }
 
 # add another workspace to global git config
-function addworkspace () {
-  git config --global bulkworkspaces.$wsname "$wsdir"
-}
+function addworkspace { git config --global bulkworkspaces.$wsname "$wsdir"; }
 
 # add current directory
-function addcurrent () {
-  git config --global bulkworkspaces.$wsname "$PWD"
-}
+function addcurrent { git config --global bulkworkspaces.$wsname "$PWD"; }
 
 # remove workspace from global git config
-function removeworkspace () {
-  checkWSName
-  git config --global --unset bulkworkspaces.$wsname
-}
+function removeworkspace { checkWSName && git config --global --unset bulkworkspaces.$wsname; }
 
 # remove workspace from global git config
-function purge () {
-  git config --global --remove-section bulkworkspaces
-}
+function purge { git config --global --remove-section bulkworkspaces; }
 
 # list all current workspace locations defined
-function listall () {
-  git config --global --get-regexp bulkworkspaces
-}
+function listall { git config --global --get-regexp bulkworkspaces; }
 
 # guarded execution of a git command in one specific repository
 function guardedExecution () {
   if $guarded; then
     echo -n "${invers}git $gitcommand${reset} -> execute here (y/n)? "
     read -n 1 -r </dev/tty; echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      atomicExecution
-    fi
+    [[ $REPLY =~ ^[Yy]$ ]] && atomicExecution
   else
      atomicExecution
   fi
@@ -60,18 +47,19 @@ function guardedExecution () {
 
 # atomic git command execution with log
 function atomicExecution () {
-  echo "${bldred}->${reset} executing ${invers}git $gitcommand${reset}"
-  git $gitcommand
+  echo "${bldred}->${reset} executing ${invers}git $gitcommand${reset}" && git $gitcommand
 }
 
 # check if the passed command is known as a core git command
 function checkGitCommand () {
-  if git help -a | cat | grep -o -q "$corecommand"; then
+  if git help -a | cat | grep -o -q "\b${corecommand}\b"; then
     echo "Core command \"$corecommand\" accepted."
   else
-    usage
-    echo "error: unknown GIT command: $corecommand"
-    exit 1
+    if git config --get-regexp alias | grep -o -q "\.${corecommand} "; then
+      echo "Alias ${corecommand} accepted."
+    else
+      usage && echo "error: unknown GIT command: $corecommand" && exit 1
+    fi
   fi
 }
 
@@ -80,30 +68,21 @@ function checkWSName () {
   found=0
   while read workspace; do
     cwsname=$(echo $workspace | cut -f1 -d' ' | cut -f2 -d'.')
-    if [[ $cwsname == $wsname ]]; then return; fi
+    [[ $cwsname == $wsname ]] && return
   done <<< "$(echo "$(listall)")"
   # when here the ws name was not found
-  usage
-  echo "error: unknown workspace name: $wsname"
-  exit 1 
+  usage && echo "error: unknown workspace name: $wsname" && exit 1 
 }
 
 # helper to check number of arguments
 function allowedargcount () {
-  if [[ $initialcount -ne $1 ]]; then
-    usage
-    echo 1>&2 "error: wrong number of arguments"
-    exit 1
-  fi 
+  ( test $initialcount -ne $1 ) && ( usage && echo 1>&2 "error: wrong number of arguments" && exit 1 ) 
 }
 
 # execute the bulk operation
 function executBulkOp () {
   checkGitCommand
-  if $singlemode; then
-    echo "Selected single workspace mode in workspace: $wsname"
-    checkWSName
-  fi
+  ( [[ $singlemode ]] ) && ( echo "Selected single workspace mode in workspace: $wsname" && checkWSName ) 
   listall | while read workspacespec; do
     cwsname=$(echo $workspacespec | cut -f1 -d' ' | cut -f2 -d'.')
     if $singlemode && [[ $cwsname != $wsname ]]; then continue; fi
@@ -123,52 +102,26 @@ function executBulkOp () {
 }
 
 initialcount="${#}"
-initialarguments="${@}"
 
 # if no arguments show usage
-if [[ $initialcount -le 0 ]]; then
-  usage
-fi
+( [[ $initialcount -le 0 ]] ) && usage
 
 # parse command parameters
 while [ "${#}" -ge 1 ] ; do
-
   case "$1" in
     --listall|--purge|--removeworkspace|--addcurrent|--addworkspace)
-      butilcommand="${1:2}"
-      shift 
-      wsname="$1"
-      shift
-      wsdir="$1"
-      break
-      ;;
+      butilcommand="${1:2}" && shift && wsname="$1" && shift && wsdir="$1" && break ;;
     -g) 
-      guarded=true
-      ;;
+      guarded=true ;;
     -w) 
-      singlemode=true
-      shift
-      wsname="$1"
-      checkWSName
-      ;;
+      singlemode=true && shift && wsname="$1" && checkWSName ;;
     -*) 
-      usage
-      echo 1>&2 "error: unknown argument $1"
-      exit 1
-      ;;
+      usage && echo 1>&2 "error: unknown argument $1" && exit 1 ;;
     --*) 
-      usage
-      echo 1>&2 "error: unknown argument $1"
-      exit 1
-      ;;
+      usage && echo 1>&2 "error: unknown argument $1" && exit 1 ;;
     *) # git core commands
-      butilcommand="executBulkOp"
-      corecommand="$1"
-      gitcommand="$@"
-      break
-      ;;
-  esac
-  shift
+      butilcommand="executBulkOp" && corecommand="$1" && gitcommand="$@" && break ;;
+  esac && shift
 done
 
 # check right number of arguments

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -13,34 +13,35 @@ singlemode=false
 usage() {
   echo 1>&2 "usage: git bulk [-g] [-w <ws-name>] <git command>"
   echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory>"
-  echo 1>&2 "       git bulk --removeworkspace <ws-name> <ws-root-directory>"
+  echo 1>&2 "       git bulk --removeworkspace <ws-name>"
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
   echo 1>&2 "       git bulk --purge"
   echo 1>&2 "       git bulk --listall"
 }
 
 # add another workspace to global git config
-function addWSDir () {
+function addworkspace () {
   git config --global bulkworkspaces.$wsname "$wsdir"
 }
 
 # add current directory
-function addCurrWSDir () {
+function addcurrent () {
   git config --global bulkworkspaces.$wsname "$PWD"
 }
 
 # remove workspace from global git config
-function remWSDir () {
+function removeworkspace () {
+  checkWSName
   git config --global --unset bulkworkspaces.$wsname
 }
 
 # remove workspace from global git config
-function purgeWS () {
+function purge () {
   git config --global --remove-section bulkworkspaces
 }
 
 # list all current workspace locations defined
-function listWSDir () {
+function listall () {
   git config --global --get-regexp bulkworkspaces
 }
 
@@ -80,18 +81,30 @@ function checkWSName () {
   while read workspace; do
     cwsname=$(echo $workspace | cut -f1 -d' ' | cut -f2 -d'.')
     if [[ $cwsname == $wsname ]]; then return; fi
-  done <<< "$(echo "$(listWSDir)")"
+  done <<< "$(echo "$(listall)")"
   # when here the ws name was not found
+  usage
   echo "error: unknown workspace name: $wsname"
   exit 1 
 }
 
+# helper to check number of arguments
+function allowedargcount () {
+  if [[ $initialcount -ne $1 ]]; then
+    usage
+    echo 1>&2 "error: wrong number of arguments"
+    exit 1
+  fi 
+}
+
 # execute the bulk operation
 function executBulkOp () {
+  checkGitCommand
   if $singlemode; then
     echo "Selected single workspace mode in workspace: $wsname"
+    checkWSName
   fi
-  listWSDir | while read workspacespec; do
+  listall | while read workspacespec; do
     cwsname=$(echo $workspacespec | cut -f1 -d' ' | cut -f2 -d'.')
     if $singlemode && [[ $cwsname != $wsname ]]; then continue; fi
     wslocation=$(echo $workspacespec | cut -f2 -d' ')
@@ -102,7 +115,7 @@ function executBulkOp () {
       gitrepodir=${line::${#line}-5} # cut the .git part of find results to have the root git directory of that repository
       eval cd "$gitrepodir" # into git repo location
       curdir=$(pwd)
-      echo "Current repository: ${curdir%/*}/${bldred}${curdir##*/}${reset}"
+      echo "Current repository: ${actual#${curdir%/*}}/${bldred}${curdir##*/}${reset}"
       guardedExecution
       eval cd "$wslocation" # back to origin location of last find command
     done 
@@ -112,68 +125,46 @@ function executBulkOp () {
 initialcount="${#}"
 initialarguments="${@}"
 
-# if no arguments show registered workspaces
+# if no arguments show usage
 if [[ $initialcount -le 0 ]]; then
-  listWSDir
+  usage
 fi
 
 # parse command parameters
 while [ "${#}" -ge 1 ] ; do
 
   case "$1" in
-    --listall)
-      butilcommand="listWSDir"
-      break
-      ;;
-    --purge)
-      butilcommand="purgeWS"
-      break
-      ;;
-    --removeworkspace)
-      shift
-      wsname="$1"
-      butilcommand="remWSDir"
-      break
-      ;;
-    --addcurrent)
-      shift
-      wsname="$1"
-      butilcommand="addCurrWSDir"
-      break
-      ;;
-    --addworkspace)
-      shift
+    --listall|--purge|--removeworkspace|--addcurrent|--addworkspace)
+      butilcommand="${1:2}"
+      shift 
       wsname="$1"
       shift
       wsdir="$1"
-      butilcommand="addWSDir"
       break
       ;;
-    -g)
+    -g) 
       guarded=true
       ;;
-      -w)
+    -w) 
       singlemode=true
       shift
       wsname="$1"
       checkWSName
       ;;
-    -*)
+    -*) 
       usage
       echo 1>&2 "error: unknown argument $1"
       exit 1
       ;;
-    --*)
+    --*) 
       usage
       echo 1>&2 "error: unknown argument $1"
       exit 1
       ;;
-    *)
+    *) # git core commands
       butilcommand="executBulkOp"
       corecommand="$1"
       gitcommand="$@"
-      checkGitCommand
-      butilcommand="executBulkOp"
       break
       ;;
   esac
@@ -182,27 +173,9 @@ done
 
 # check right number of arguments
 case $butilcommand in
-  @(listWSDir|purgeWS) )
-    if [[ $initialcount -ne 1 ]]; then
-      usage
-      echo 1>&2 "error: wrong number of arguments"
-      exit 1
-    fi 
-    ;;
-  @(addCurrWSDir|remWSDir))
-    if [[ $initialcount -ne 2 ]]; then
-      usage
-      echo 1>&2 "error: wrong number of arguments"
-      exit 1
-    fi 
-    ;;
-  addWSDir)
-    if [[ $initialcount -ne 3 ]]; then
-      usage
-      echo 1>&2 "error: wrong number of arguments"
-      exit 1
-    fi 
-    ;;
+  @(listall|purge) ) allowedargcount 1;;
+  @(addcurrent|removeworkspace)) allowedargcount 2;;
+  addworkspace) allowedargcount 3;;
 esac
 
 $butilcommand # run user command

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -3,15 +3,17 @@ invers=`tput rev`
 reset=`tput sgr0`
 txtbld=$(tput bold)             
 bldred=${txtbld}$(tput setaf 1) 
-shopt -s extglob
-guarded=false
+
+# default option settings
+guardedmode=false
 singlemode=false
+allwsmode=false
 
 #
 # print usage message
 #
 usage() {
-  echo 1>&2 "usage: git bulk [-g] [-w <ws-name>] <git command>"
+  echo 1>&2 "usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>"
   echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory>"
   echo 1>&2 "       git bulk --removeworkspace <ws-name>"
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
@@ -36,10 +38,10 @@ function listall { git config --global --get-regexp bulkworkspaces; }
 
 # guarded execution of a git command in one specific repository
 function guardedExecution () {
-  if $guarded; then
+  if $guardedmode; then
     echo -n "${invers}git $gitcommand${reset} -> execute here (y/n)? "
     read -n 1 -r </dev/tty; echo
-    [[ $REPLY =~ ^[Yy]$ ]] && atomicExecution
+    if [[ $REPLY =~ ^[Yy]$ ]]; then atomicExecution; fi
   else
      atomicExecution
   fi
@@ -67,11 +69,24 @@ function checkGitCommand () {
 function checkWSName () {
   found=0
   while read workspace; do
-    cwsname=$(echo $workspace | cut -f1 -d' ' | cut -f2 -d'.')
-    [[ $cwsname == $wsname ]] && return
+    rwsname=$(echo $workspace | cut -f1 -d' ' | cut -f2 -d'.')
+    if [[ $rwsname == $wsname ]]; then return; fi
   done <<< "$(echo "$(listall)")"
   # when here the ws name was not found
   usage && echo "error: unknown workspace name: $wsname" && exit 1 
+}
+
+# detects the wsname of the current directory
+function wsnameToCurrent () {
+  currdir=$PWD
+  while read workspace; do
+    if [ -z "$workspace" ]; then continue; fi
+    rwsdir=$(echo $workspace | grep -o ' /.*')
+    rwsname=$(echo $workspace | cut -f1 -d' ' | cut -f2 -d'.')
+    if echo $PWD | grep -o -q $rwsdir; then wsname=$rwsname && return; fi
+  done <<< "$(echo "$(listall)")"
+  # when here then not in workspace dir
+  echo "error: you are not in a workspace directory. your workspaces:" && wslist=$(echo "$(listall)") && echo ${wslist:-'<no workspaces defined yet>'}  
 }
 
 # helper to check number of arguments
@@ -81,11 +96,11 @@ function allowedargcount () {
 
 # execute the bulk operation
 function executBulkOp () {
+  if ! $allwsmode && ! $singlemode; then wsnameToCurrent; fi # by default git bulk works within the 'current' workspace
   checkGitCommand
-  ( [[ $singlemode ]] ) && ( echo "Selected single workspace mode in workspace: $wsname" && checkWSName ) 
   listall | while read workspacespec; do
     cwsname=$(echo $workspacespec | cut -f1 -d' ' | cut -f2 -d'.')
-    if $singlemode && [[ $cwsname != $wsname ]]; then continue; fi
+    if [[ -n $wsname ]] && [[ $cwsname != $wsname ]]; then continue; fi
     wslocation=$(echo $workspacespec | cut -f2 -d' ')
     eval cd "$wslocation"
     actual=$(pwd)
@@ -104,15 +119,19 @@ function executBulkOp () {
 initialcount="${#}"
 
 # if no arguments show usage
-( [[ $initialcount -le 0 ]] ) && usage
+if [[ $initialcount -le 0 ]]; then usage; fi
 
 # parse command parameters
 while [ "${#}" -ge 1 ] ; do
   case "$1" in
-    --listall|--purge|--removeworkspace|--addcurrent|--addworkspace)
+    --listall|--purge)
+      butilcommand="${1:2}" && break ;;
+    --removeworkspace|--addcurrent|--addworkspace)
       butilcommand="${1:2}" && shift && wsname="$1" && shift && wsdir="$1" && break ;;
+    -a) 
+      allwsmode=true ;;
     -g) 
-      guarded=true ;;
+      guardedmode=true ;;
     -w) 
       singlemode=true && shift && wsname="$1" && checkWSName ;;
     -*) 
@@ -124,10 +143,16 @@ while [ "${#}" -ge 1 ] ; do
   esac && shift
 done
 
+# check option compatability
+if $allwsmode && $singlemode; then echo 1>&2 "error: options -w and -a are incompatible" && exit 1; fi
+
+# if single mode check the supplied workspace name
+if $singlemode; then echo "Selected single workspace mode in workspace: $wsname" && checkWSName; fi 
+
 # check right number of arguments
 case $butilcommand in
-  @(listall|purge) ) allowedargcount 1;;
-  @(addcurrent|removeworkspace)) allowedargcount 2;;
+  listall|purge) allowedargcount 1;;
+  addcurrent|removeworkspace) allowedargcount 2;;
   addworkspace) allowedargcount 3;;
 esac
 

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# reset environment variables that could interfere with normal usage
+export GREP_OPTIONS=
+# put all utility functions here
+
+# make a temporary file
+git_extra_mktemp() {
+    mktemp -t "$(basename "$0")".XXX
+}
+
+#
+# check whether current directory is inside a git repository
+#
+
+is_git_repo() {
+  git rev-parse --show-toplevel > /dev/null 2>&1
+  result=$?
+  if test $result != 0; then
+    >&2 echo 'Not a git repo!'
+    exit $result
+  fi
+}
+
+is_git_repo
+invers=`tput rev`
+reset=`tput sgr0`
+txtbld=$(tput bold)             # Bold
+bldred=${txtbld}$(tput setaf 1) #  red
+shopt -s extglob
+guarded=false
+singlemode=false
+
+#
+# print usage message
+#
+usage() {
+  echo 1>&2 "usage: git bulk [-g] [-w <ws-name>] <git command>"
+  echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory>"
+  echo 1>&2 "       git bulk --removeworkspace <ws-name> <ws-root-directory>"
+  echo 1>&2 "       git bulk --addcurrent <ws-name>"
+  echo 1>&2 "       git bulk --purge"
+  echo 1>&2 "       git bulk --listall"
+}
+
+# add another workspace to global git config
+function addWSDir () {
+  git config --global bulkworkspaces.$wsname "$wsdir"
+}
+
+# add current directory
+function addCurrWSDir () {
+  git config --global bulkworkspaces.$wsname "$PWD"
+}
+
+# remove workspace from global git config
+function remWSDir () {
+  git config --global --unset bulkworkspaces.$wsname
+}
+
+# remove workspace from global git config
+function purgeWS () {
+  git config --global --remove-section bulkworkspaces
+}
+
+# list all current workspace locations defined
+function listWSDir () {
+  git config --global --get-regexp bulkworkspaces
+}
+
+# atomic execution of a git command in one specific repository
+function guardedExecution () {
+  if $guarded; then
+    echo -n "${invers}git $gitcommand${reset} -> execute here (y/n)? "
+    read -n 1 -r </dev/tty; echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      atomicExecution
+    fi
+  else
+     atomicExecution
+  fi
+}
+
+# execute a git command with log
+function atomicExecution () {
+  echo "${bldred}->${reset} executing ${invers}git $gitcommand${reset}"
+  git $gitcommand
+}
+
+# check if the passed command is known as a core git command
+function checkGitCommand () {
+  if git help -a | cat | grep -o -q "$corecommand"; then
+    echo "Core command \"$corecommand\" accepted."
+  else
+    usage
+    echo "error: unknown GIT command: $corecommand"
+    exit 1
+  fi
+}
+
+# check if workspace name is registered
+function checkWSName () {
+  found=0
+  while read workspace; do
+    cwsname=$(echo $workspace | cut -f1 -d' ' | cut -f2 -d'.')
+    if [[ $cwsname == $wsname ]]; then return; fi
+  done <<< "$(echo $(listWSDir))"
+  # when here the ws name was not found
+  echo "error: unknown workspace name: $wsname"
+  exit 1 
+}
+
+# execute the bulk operation
+function executBulkOp () {
+  if $singlemode; then
+    echo "Selected single workspace mode in workspace: $wsname"
+  fi
+  listWSDir | while read workspacespec; do
+    cwsname=$(echo $workspacespec | cut -f1 -d' ' | cut -f2 -d'.')
+    if $singlemode && $cwsname != $wsname ]]; then continue; fi
+    wslocation=$(echo $workspacespec | cut -f2 -d' ')
+    eval cd "$wslocation"
+    actual=$(pwd)
+    echo "Executing bulk operation in workspace ${invers}$actual${reset}"
+    eval find . -name ".git" | while read line; do
+      gitrepodir=${line::${#line}-5} # cut the .git part of find results to have the root git directory of that repository
+      eval cd "$gitrepodir" # into git repo location
+      curdir=$(pwd)
+      echo "Current repository: ${curdir%/*}/${bldred}${curdir##*/}${reset}"
+      guardedExecution
+      eval cd "$wslocation" # back to origin location of last find command
+    done 
+  done 
+}
+
+initialcount="${#}"
+initialarguments="${@}"
+
+# if no arguments show registered workspaces
+if [[ $initialcount -le 0 ]]; then
+  listWSDir
+fi
+
+# parse command parameters
+while [ "${#}" -ge 1 ] ; do
+
+  case "$1" in
+    --listall)
+      butilcommand="listWSDir"
+      break
+      ;;
+    --purge)
+      butilcommand="purgeWS"
+      break
+      ;;
+    --removeworkspace)
+      shift
+      wsname="$1"
+      butilcommand="remWSDir"
+      break
+      ;;
+    --addcurrent)
+      shift
+      wsname="$1"
+      butilcommand="addCurrWSDir"
+      break
+      ;;
+    --addworkspace)
+      shift
+      wsname="$1"
+      shift
+      wsdir="$1"
+      butilcommand="addWSDir"
+      break
+      ;;
+    -g)
+      guarded=true
+      ;;
+    -w)
+      singlemode=true
+      shift
+      wsname="$1"
+      checkWSName
+      ;;
+    -*)
+	  usage
+      echo 1>&2 "error: unknown argument $1"
+      exit 1
+      ;;
+    --*)
+	  usage
+      echo 1>&2 "error: unknown argument $1"
+      exit 1
+      ;;
+    *)
+      butilcommand="executBulkOp"
+      corecommand="$1"
+      gitcommand="$@"
+      checkGitCommand
+      butilcommand="executBulkOp"
+      break
+      ;;
+  esac
+
+  shift
+done
+
+# check right number of arguments
+case $butilcommand in
+    @(listWSDir|purgeWS) )
+       if [[ $initialcount -ne 1 ]]; then
+       	 usage
+       	 echo 1>&2 "error: wrong number of arguments"
+         exit 1
+       fi 
+    ;;
+    @(addCurrWSDir|remWSDir))
+       if [[ $initialcount -ne 2 ]]; then
+       	 usage
+       	 echo 1>&2 "error: wrong number of arguments"
+         exit 1
+       fi 
+    ;;
+	addWSDir)
+       if [[ $initialcount -ne 3 ]]; then
+       	 usage
+       	 echo 1>&2 "error: wrong number of arguments"
+         exit 1
+       fi 
+    ;;
+esac
+
+$butilcommand # run user command

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -360,6 +360,7 @@ zstyle ':completion:*:*:git:*' user-commands \
     authors:'generate authors report' \
     back:'undo and stage latest commits' \
     bug:'create bug branch' \
+    bulk:'run bulk commands' \
     changelog:'generate a changelog report' \
     chore:'create chore branch' \
     clear-soft:'soft clean up a repository' \

--- a/man/git-bulk.1
+++ b/man/git-bulk.1
@@ -51,7 +51,7 @@ Any git Command you wish to execute on the repositories\.
 \-\-addworkspace <ws\-name> <ws\-root\-directory>
 .
 .P
-Register a workspace for bulk operations\. All repositories in the diretories below <ws\-root\-directory> get registered under this workspace with the name <ws\-name>\. <ws\-root\-directory> must be absultue path\.
+Register a workspace for bulk operations\. All repositories in the diretories below <ws\-root\-directory> get registered under this workspace with the name <ws\-name>\. <ws\-root\-directory> must be absolute path\.
 .
 .P
 \-\-removeworkspace <ws\-name>

--- a/man/git-bulk.1
+++ b/man/git-bulk.1
@@ -1,0 +1,125 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-BULK" "1" "March 2017" "" "Git Extras"
+.
+.SH "NAME"
+\fBgit\-bulk\fR \- Run git commands on multiple repositories
+.
+.SH "SYNOPSIS"
+usage: usage: git bulk [\-g] ([\-a]|[\-w <ws\-name>]) <git command> git bulk \-\-addworkspace <ws\-name> <ws\-root\-directory> git bulk \-\-removeworkspace <ws\-name> git bulk \-\-addcurrent <ws\-name> git bulk \-\-purge git bulk \-\-listall
+.
+.SH "DESCRIPTION"
+git bulk adds convenien support for operations that you want to execute on multiple git repositories\.
+.
+.IP "\(bu" 4
+simply register workspaces that contain multiple git repos in their directory structure
+.
+.IP "\(bu" 4
+run any git command on the repositories of the registered workspaces in one command to \fBgit bulk\fR
+.
+.IP "\(bu" 4
+use the "guarded mode" to check on each execution
+.
+.IP "" 0
+.
+.SH "OPTIONS"
+\-a
+.
+.P
+Run a git command on all workspaces and their repositories\.
+.
+.P
+\-g
+.
+.P
+Ask the user for confirmation on every execution\.
+.
+.P
+\-w <ws\-name>
+.
+.P
+Run the git command on the specified workspace\. The workspace must be registered\.
+.
+.P
+<git command>
+.
+.P
+Any git Command you wish to execute on the repositories\.
+.
+.P
+\-\-addworkspace <ws\-name> <ws\-root\-directory>
+.
+.P
+Register a workspace for bulk operations\. All repositories in the diretories below <ws\-root\-directory> get registered under this workspace with the name <ws\-name>\.
+.
+.P
+\-\-removeworkspace <ws\-name>
+.
+.P
+Remove the workspace with the logical name <ws\-name>\.
+.
+.P
+\-\-addcurrent <ws\-name>
+.
+.P
+Adds the current directory as workspace to git bulk operations\. The workspace is referenced with its logical name <ws\-name>\.
+.
+.P
+git bulk \-\-purge
+.
+.P
+Removes all defined repository locations\.
+.
+.P
+git bulk \-\-listall
+.
+.P
+List all registered repositories\.
+.
+.SH "EXAMPLES"
+.
+.nf
+
+Register a workspace so that git bulk knows about it:
+
+$ git bulk \-\-addworkspace personal ~/workspaces/personal
+
+Register the current directory as a workspace to git bulk:
+
+$ git bulk \-\-addcurrent personal
+
+List all registered workspaces:
+
+$ git bulk \-\-listall
+
+Run a git command on the repositories of the current workspace:
+
+$ git bulk fetch
+
+Run a git command on the specified workspace and its repositories:
+
+$ git bulk \-w personal fetch
+
+Run a git command but ask user for confirmation on every execution (guarded mode):
+
+$ git bulk \-g fetch
+
+Remove a registered workspace:
+
+$ git bulk \-\-removeworkspace personal
+
+Remove all registered workspaces:
+
+$ git bulk \-\-purge
+.
+.fi
+.
+.SH "AUTHOR"
+Written by Niklas Schlimm <\fIns103@hotmail\.de\fR>
+.
+.SH "REPORTING BUGS"
+<https://github\.com/nschlimm/git\-bulk>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-bulk.1
+++ b/man/git-bulk.1
@@ -51,7 +51,7 @@ Any git Command you wish to execute on the repositories\.
 \-\-addworkspace <ws\-name> <ws\-root\-directory>
 .
 .P
-Register a workspace for bulk operations\. All repositories in the diretories below <ws\-root\-directory> get registered under this workspace with the name <ws\-name>\.
+Register a workspace for bulk operations\. All repositories in the diretories below <ws\-root\-directory> get registered under this workspace with the name <ws\-name>\. <ws\-root\-directory> must be absultue path\.
 .
 .P
 \-\-removeworkspace <ws\-name>

--- a/man/git-bulk.html
+++ b/man/git-bulk.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-bulk(1) - Run git commands on multiple repositories</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-bulk(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-bulk(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-bulk</code> - <span class="man-whatis">Run git commands on multiple repositories</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p>usage: usage: git bulk [-g] ([-a]|[-w &lt;ws-name&gt;]) &lt;git command&gt;
+       git bulk --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
+       git bulk --removeworkspace &lt;ws-name&gt;
+       git bulk --addcurrent &lt;ws-name&gt;
+       git bulk --purge
+       git bulk --listall</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>git bulk adds convenien support for operations that you want to execute on multiple git repositories.</p>
+
+<ul>
+<li>simply register workspaces that contain multiple git repos in their directory structure</li>
+<li>run any git command on the repositories of the registered workspaces in one command to <code>git bulk</code></li>
+<li>use the "guarded mode" to check on each execution</li>
+</ul>
+
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -a</p>
+
+<p>  Run a git command on all workspaces and their repositories.</p>
+
+<p>  -g</p>
+
+<p>  Ask the user for confirmation on every execution.</p>
+
+<p>  -w &lt;ws-name&gt;</p>
+
+<p>  Run the git command on the specified workspace. The workspace must be registered.</p>
+
+<p>  &lt;git command&gt;</p>
+
+<p>  Any git Command you wish to execute on the repositories.</p>
+
+<p>  --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;</p>
+
+<p>  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;.</p>
+
+<p>  --removeworkspace &lt;ws-name&gt;</p>
+
+<p>  Remove the workspace with the logical name &lt;ws-name&gt;.</p>
+
+<p>  --addcurrent &lt;ws-name&gt;</p>
+
+<p>  Adds the current directory as workspace to git bulk operations. The workspace is referenced with its logical name &lt;ws-name&gt;.</p>
+
+<p>  git bulk --purge</p>
+
+<p>  Removes all defined repository locations.</p>
+
+<p>  git bulk --listall</p>
+
+<p>  List all registered repositories.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<pre><code>Register a workspace so that git bulk knows about it:
+
+$ git bulk --addworkspace personal ~/workspaces/personal
+
+Register the current directory as a workspace to git bulk:
+
+$ git bulk --addcurrent personal
+
+List all registered workspaces:
+
+$ git bulk --listall
+
+Run a git command on the repositories of the current workspace:
+
+$ git bulk fetch
+
+Run a git command on the specified workspace and its repositories:
+
+$ git bulk -w personal fetch
+
+Run a git command but ask user for confirmation on every execution (guarded mode):
+
+$ git bulk -g fetch
+
+Remove a registered workspace:
+
+$ git bulk --removeworkspace personal
+
+Remove all registered workspaces:
+
+$ git bulk --purge
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Niklas Schlimm &lt;<a href="&#109;&#97;&#105;&#x6c;&#116;&#111;&#58;&#x6e;&#x73;&#49;&#48;&#x33;&#64;&#x68;&#x6f;&#x74;&#109;&#97;&#105;&#108;&#x2e;&#x64;&#x65;" data-bare-link="true">&#x6e;&#x73;&#x31;&#x30;&#x33;&#x40;&#x68;&#x6f;&#116;&#x6d;&#x61;&#x69;&#x6c;&#x2e;&#x64;&#101;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;https://github.com/nschlimm/git-bulk&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>March 2017</li>
+    <li class='tr'>git-bulk(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-bulk.html
+++ b/man/git-bulk.html
@@ -114,7 +114,7 @@
 
 <p>  --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;</p>
 
-<p>  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;. &lt;ws-root-directory&gt; must be absultue path.</p>
+<p>  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;. &lt;ws-root-directory&gt; must be absolute path.</p>
 
 <p>  --removeworkspace &lt;ws-name&gt;</p>
 
@@ -169,7 +169,7 @@ $ git bulk --purge
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Niklas Schlimm &lt;<a href="&#x6d;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x6e;&#x73;&#x31;&#48;&#x33;&#x40;&#104;&#111;&#x74;&#109;&#x61;&#105;&#x6c;&#x2e;&#100;&#x65;" data-bare-link="true">&#x6e;&#115;&#49;&#x30;&#51;&#x40;&#104;&#111;&#116;&#109;&#x61;&#105;&#x6c;&#46;&#100;&#x65;</a>&gt;</p>
+<p>Written by Niklas Schlimm &lt;<a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#x3a;&#x6e;&#115;&#49;&#x30;&#51;&#x40;&#x68;&#111;&#116;&#x6d;&#x61;&#x69;&#108;&#x2e;&#100;&#x65;" data-bare-link="true">&#110;&#115;&#x31;&#x30;&#x33;&#x40;&#x68;&#x6f;&#x74;&#x6d;&#x61;&#105;&#108;&#46;&#x64;&#101;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-bulk.html
+++ b/man/git-bulk.html
@@ -114,7 +114,7 @@
 
 <p>  --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;</p>
 
-<p>  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;.</p>
+<p>  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;. &lt;ws-root-directory&gt; must be absultue path.</p>
 
 <p>  --removeworkspace &lt;ws-name&gt;</p>
 
@@ -169,7 +169,7 @@ $ git bulk --purge
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Niklas Schlimm &lt;<a href="&#109;&#97;&#105;&#x6c;&#116;&#111;&#58;&#x6e;&#x73;&#49;&#48;&#x33;&#64;&#x68;&#x6f;&#x74;&#109;&#97;&#105;&#108;&#x2e;&#x64;&#x65;" data-bare-link="true">&#x6e;&#x73;&#x31;&#x30;&#x33;&#x40;&#x68;&#x6f;&#116;&#x6d;&#x61;&#x69;&#x6c;&#x2e;&#x64;&#101;</a>&gt;</p>
+<p>Written by Niklas Schlimm &lt;<a href="&#x6d;&#97;&#x69;&#x6c;&#x74;&#x6f;&#58;&#x6e;&#x73;&#x31;&#48;&#x33;&#x40;&#104;&#111;&#x74;&#109;&#x61;&#105;&#x6c;&#x2e;&#100;&#x65;" data-bare-link="true">&#x6e;&#115;&#49;&#x30;&#51;&#x40;&#104;&#111;&#116;&#109;&#x61;&#105;&#x6c;&#46;&#100;&#x65;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -1,0 +1,99 @@
+git-bulk(1) -- Run git commands on multiple repositories
+========================================================
+
+## SYNOPSIS
+
+usage: git bulk [-g] [-w &lt;ws-name&gt;] &lt;git command&gt;
+       git bulk --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
+       git bulk --removeworkspace &lt;ws-name&gt;
+       git bulk --addcurrent &lt;ws-name&gt;
+       git bulk --purge
+       git bulk --listall
+
+## DESCRIPTION
+
+git bulk adds covenien support for operations that you want to execute on multiple git repositories.
+
+- simply register workspaces that contain multiple git repos in their directory structure
+- run any git command on the repositories of the registered workspaces in one command to `git bulk`
+- use the "guarded mode" to check on each execution
+
+## OPTIONS
+
+  -g 
+
+  Ask the user for confitmation on every execution.
+
+  -w <ws-name>
+
+  Run the GIT command only on the specified workspace. The workspace must be registered.
+
+  &lt;git command&gt;
+
+  Any GIT Command you wish to execute on all the Repositories.
+
+  --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
+
+  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;.
+
+  --removeworkspace &lt;ws-name&gt;
+
+  Remove the workspace with the logical name &lt;ws-name&gt;.
+
+  --addcurrent &lt;ws-name&gt;
+
+  Adds the current difrectory as workspace to git bulk operations. The workspace is referenced wioth ist logical name &lt;ws-name&gt;.
+
+  git bulk --purge
+
+  Removes all defined repository locations.
+
+  git bulk --listall
+
+  List all registered repositories.
+
+## EXAMPLES
+
+    Register a workspace so that git bulk knows about it:
+    
+    $ git bulk --addworkspace personal ~/workspaces/personal
+    
+    Register the current directory as a workspace to git bulk:
+    
+    $ git bulk --addcurrent personal
+    
+    List all registered workspaces:
+    
+    $ git bulk --listall
+    
+    Run a git command on the repositories:
+    
+    $ git bulk fetch
+
+    Run a git command on only one workspace and its repositories:
+
+    $ git bulk -w personal fetch
+    
+    Run a git command but ask user for confirmation on every execution (guarded mode):
+    
+    $ git bulk -g fetch
+    
+    Remove a registered workspace:
+    
+    $ git bulk --removeworkspace personal
+
+    Remove all registered workspaces:
+    
+    $ git bulk --purge
+
+## AUTHOR
+
+Written by Niklas Schlimm &lt;<ns103@hotmail.de>&gt;
+
+## REPORTING BUGS
+
+&lt;https://github.com/nschlimm/git-bulk&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -38,7 +38,7 @@ git bulk adds convenien support for operations that you want to execute on multi
 
   --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
 
-  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;. &lt;ws-root-directory&gt; must be absultue path.
+  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;. &lt;ws-root-directory&gt; must be absolute path.
 
   --removeworkspace &lt;ws-name&gt;
 

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -38,7 +38,7 @@ git bulk adds convenien support for operations that you want to execute on multi
 
   --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
 
-  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;.
+  Register a workspace for bulk operations. All repositories in the diretories below &lt;ws-root-directory&gt; get registered under this workspace with the name &lt;ws-name&gt;. &lt;ws-root-directory&gt; must be absultue path.
 
   --removeworkspace &lt;ws-name&gt;
 

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -22,19 +22,19 @@ git bulk adds covenien support for operations that you want to execute on multip
 
   -a
 
-  Run a GIT command on all workspaces and their repositories.
+  Run a git command on all workspaces and their repositories.
 
   -g 
 
-  Ask the user for confitmation on every execution.
+  Ask the user for confirmation on every execution.
 
   -w &lt;ws-name&gt;
 
-  Run the GIT command on the specified workspace. The workspace must be registered.
+  Run the git command on the specified workspace. The workspace must be registered.
 
   &lt;git command&gt;
 
-  Any GIT Command you wish to execute on the repositories.
+  Any git Command you wish to execute on the repositories.
 
   --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
 
@@ -46,7 +46,7 @@ git bulk adds covenien support for operations that you want to execute on multip
 
   --addcurrent &lt;ws-name&gt;
 
-  Adds the current difrectory as workspace to git bulk operations. The workspace is referenced wioth ist logical name &lt;ws-name&gt;.
+  Adds the current directory as workspace to git bulk operations. The workspace is referenced with its logical name &lt;ws-name&gt;.
 
   git bulk --purge
 

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -12,7 +12,7 @@ usage: usage: git bulk [-g] ([-a]|[-w &lt;ws-name&gt;]) &lt;git command&gt;
 
 ## DESCRIPTION
 
-git bulk adds covenien support for operations that you want to execute on multiple git repositories.
+git bulk adds convenien support for operations that you want to execute on multiple git repositories.
 
 - simply register workspaces that contain multiple git repos in their directory structure
 - run any git command on the repositories of the registered workspaces in one command to `git bulk`

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -3,7 +3,7 @@ git-bulk(1) -- Run git commands on multiple repositories
 
 ## SYNOPSIS
 
-usage: git bulk [-g] [-w &lt;ws-name&gt;] &lt;git command&gt;
+usage: usage: git bulk [-g] ([-a]|[-w &lt;ws-name&gt;]) &lt;git command&gt;
        git bulk --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
        git bulk --removeworkspace &lt;ws-name&gt;
        git bulk --addcurrent &lt;ws-name&gt;
@@ -20,17 +20,21 @@ git bulk adds covenien support for operations that you want to execute on multip
 
 ## OPTIONS
 
+  -a
+
+  Run a GIT command on all workspaces and their repositories.
+
   -g 
 
   Ask the user for confitmation on every execution.
 
-  -w <ws-name>
+  -w &lt;ws-name&gt;
 
-  Run the GIT command only on the specified workspace. The workspace must be registered.
+  Run the GIT command on the specified workspace. The workspace must be registered.
 
   &lt;git command&gt;
 
-  Any GIT Command you wish to execute on all the Repositories.
+  Any GIT Command you wish to execute on the repositories.
 
   --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt;
 
@@ -66,11 +70,11 @@ git bulk adds covenien support for operations that you want to execute on multip
     
     $ git bulk --listall
     
-    Run a git command on the repositories:
+    Run a git command on the repositories of the current workspace:
     
     $ git bulk fetch
 
-    Run a git command on only one workspace and its repositories:
+    Run a git command on the specified workspace and its repositories:
 
     $ git bulk -w personal fetch
     


### PR DESCRIPTION
This is a new command 'git bulk' that you can use to run commands on multiple repositories within registered workspace. A workspace is a directory that contains multiple git repositories.
I have tested the command on:
- GNU bash, Version 4.4.12(1)-release (x86_64-apple-darwin16.3.0).
- GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin16)

Looking forward to here your feedback on this.
Best regards,
Niklas