### PR TITLE
Remove slashes from git-config command

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -18,5 +18,5 @@ else
 fi
 git fetch -fu $remote refs/pull/$id/head:$branch && \
 git checkout $branch && \
-git config --local --replace branch.\"$branch\".merge refs/pull/$id/head && \
-git config --local --replace branch.\"$branch\".remote $remote;
+git config --local --replace branch.$branch.merge refs/pull/$id/head && \
+git config --local --replace branch.$branch.remote $remote;


### PR DESCRIPTION
These slashes were causing the branches to be saved in `.git/config` with headings such as `[branch "\"pr/123\""]` as opposed to `[branch "pr/123"]`. This in turn prevented these entries from being removed when running `git pr clean`.