### PR TITLE
Upgrade git-standup to new interface

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -1109,9 +1109,9 @@ Commit: Jack <jack@work.com>
 ## git standup
 
 Recall what you did or find what someone else did in a given range of time.
-For instance, recall John's commits since last week:
+For instance, recall John's commits since last week(7 days ago):
 ```
-git standup John "last week"
+git standup -a John -d 7
 ```
 
 ## git touch

--- a/bin/git-standup
+++ b/bin/git-standup
@@ -2,10 +2,29 @@
 
 # Code modified from https://github.com/kamranahmedse/git-standup,
 # under the MIT LICENSE.
-if [[ $# -gt 3 ]] ; then
-  >&2 printf "Usage: $0 [fullname] [since] [until]\nExample: $0 \"John Doe\" \"last Mon\" yesterday\n"
-  exit 1
-fi
+usage() {
+    cat <<EOS
+    Usage:
+    git standup [-a <author name>] [-w <weekstart-weekend>] [-d <days-ago>] [-m <max-dir-depth>] [-g] [-h] [-f]
+
+    -a      - Specify author to restrict search to
+    -w      - Specify weekday range to limit search to
+    -m      - Specify the depth of recursive directory search
+    -L      - Toggle inclusion of symbolic links in recursive directory search
+    -d      - Specify the number of days back to include
+    -D      - Specify the date format for "git log" (default: relative)
+    -h      - Display this help screen
+    -g      - Show if commit is GPG signed (G) or not (N)
+    -f      - Fetch the latest commits beforehand
+
+    Examples:
+    git standup -a "John Doe" -w "MON-FRI" -m 3
+EOS
+}
+
+warn() {
+    >&2 echo "${BOLD}${RED}WARNING: $1${NORMAL}"
+}
 
 git rev-parse --show-toplevel > /dev/null 2>&1
 in_git_repo=$?
@@ -13,42 +32,114 @@ in_git_repo=$?
 # Use colors, but only if connected to a terminal, and that terminal
 # supports them.
 if which tput >/dev/null 2>&1; then
-  ncolors=$(tput colors)
+    ncolors=$(tput colors)
 fi
 if [[ -t 1 ]] && [[ -n "$ncolors" ]] && [[ "$ncolors" -ge 8 ]] ; then
-  RED="$(tput setaf 1)"
-  GREEN="$(tput setaf 2)"
-  YELLOW="$(tput setaf 3)"
-  BLUE="$(tput setaf 4)"
-  BOLD="$(tput bold)"
-  NORMAL="$(tput sgr0)"
-  BOLD=$(tput bold)
-  UNDERLINE=$(tput smul)
-  NORMAL=$(tput sgr0)
+    RED="$(tput setaf 1)"
+    GREEN="$(tput setaf 2)"
+    YELLOW="$(tput setaf 3)"
+    BOLD="$(tput bold)"
+    NORMAL="$(tput sgr0)"
+    BOLD=$(tput bold)
+    UNDERLINE=$(tput smul)
+    NORMAL=$(tput sgr0)
 else
-  RED=""
-  GREEN=""
-  YELLOW=""
-  BLUE=""
-  BOLD=""
-  NORMAL=""
-  BOLD=""
-  UNDERLINE=""
-  NORMAL=""
+    RED=""
+    GREEN=""
+    YELLOW=""
+    BOLD=""
+    NORMAL=""
+    BOLD=""
+    UNDERLINE=""
+    NORMAL=""
 fi
 
 # Only enable exit-on-error after the non-critical colorization stuff,
 # which may fail on systems lacking tput or terminfo
 set -e
 
-AUTHOR=${1:-"$(git config user.name)"}
-SINCE=${2:-yesterday}
-UNTIL=${3:-today}
+while getopts "hgfd:a:w:m:D:L" opt; do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        a)
+            if [[ "$OPTARG" = 'all' ]] ; then
+                AUTHOR=".*"
+            else
+                AUTHOR="$OPTARG"
+            fi
+            ;;
+        d)
+            test -n "$SINCE" && warn "-d option is conflict with -w"
+            SINCE=${SINCE:="$OPTARG days ago"}
+            ;;
+        w)
+            if [ -n "$SINCE" ]; then
+                warn "-w option is conflict with -d"
+                continue
+            fi
 
+            week_range=${OPTARG}
+            week_start="${week_range%%-*}"
+            week_start="${week_start:="Mon"}"
+            week_end="${week_range##*-}"
+            week_end=${week_end:="Fri"}
 
-## In case it is the start of week, we need to
-## show the commits since the last weekend
-shopt -s nocasematch
+            ## In case it is the start of week, we need to
+            ## show the commits since the last weekend
+            shopt -s nocasematch
+            if [[ "$week_start" == "$(LC_ALL=C date +%a)" ]] ; then
+                SINCE="last $week_end";
+            fi
+            ;;
+        f)
+            FETCH_LAST_COMMIT=true
+            ;;
+        m)
+            MAXDEPTH=$((OPTARG + 1))
+            if [ "$MAXDEPTH" -lt 1 ]; then
+                >&2 echo "Specify depth less than one is invalid"
+                exit 1
+            fi
+            ;;
+        L)
+            INCLUDE_LINKS=-L
+            ;;
+        D)
+            GIT_DATE_FORMAT=${OPTARG}
+            ;;
+        g)
+            GIT_PRETTY_FORMAT="%C(yellow)gpg: %G?%Creset"
+            ;;
+        \?)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [[ $# -gt 0 ]]; then
+    warn "please upgrate to new-style interface. Run 'git help standup' to get more info."
+    if [[ $# -gt 3 ]] ; then
+        usage
+        exit 1
+    fi
+    AUTHOR=$1
+    SINCE=$2
+    UNTIL=$3
+fi
+
+AUTHOR=${AUTHOR:="$(git config user.name)"}
+SINCE=${SINCE:=yesterday}
+UNTIL=${UNTIL:=today}
+FETCH_LAST_COMMIT=${FETCH_LAST_COMMIT:=false}
+MAXDEPTH=${MAXDEPTH:=2}
+GIT_PRETTY_FORMAT="%Cred%h%Creset - %s %Cgreen(%cd) %C(bold blue)<%an>%Creset $GIT_PRETTY_FORMAT"
+GIT_DATE_FORMAT=${GIT_DATE_FORMAT:=relative}
 
 GIT_LOG_COMMAND="git --no-pager log \
     --all
@@ -58,33 +149,68 @@ GIT_LOG_COMMAND="git --no-pager log \
     --author=\"$AUTHOR\"
     --abbrev-commit
     --oneline
-    --pretty=format:'%Cred%h%Creset - %s %Cgreen(%cr) %C(bold blue)<%an>%Creset'"
+    --pretty=format:'$GIT_PRETTY_FORMAT'
+    --date='$GIT_DATE_FORMAT'"
 
 ## For when the command has been run in a non-repo directory
 if [[ $in_git_repo != 0 ]]; then
+    ## Set delimiter to newline for the loop
+    IFS=$'\n'
+    ## Recursively search for git repositories
+    PROJECT_DIRS=$(find $INCLUDE_LINKS . -maxdepth "$MAXDEPTH" -mindepth 0 -name .git)
 
-    ## Iterate through all the top level directories inside
-    ## and look for any git repositories.
-    for DIR in */ ; do
+    # Fetch the latest commits, if required
+    if [ "$FETCH_LAST_COMMIT" = true ]; then
 
-        cd "$DIR"
+        echo "${BOLD}${GREEN}Fetching commits ..${NORMAL}"
 
+        # Foreach of the project directories, fetch the commits
+        for DIR in $PROJECT_DIRS; do
+            DIR="$(dirname "$DIR")"
+            pushd "$DIR" > /dev/null
+
+            if [[ -d ".git" ]] ; then
+                echo "   ${YELLOW}$(basename "$DIR")${NORMAL}"
+                git fetch --all > /dev/null 2>&1
+            fi
+
+            popd > /dev/null
+        done
+    fi
+
+    # Get the standup details for each of the projects
+    for DIR in $PROJECT_DIRS; do
+        DIR="$(dirname "$DIR")"
+        pushd "$DIR" > /dev/null
         ## Show the detail only if it is a git repository
-        if [[ -d ".git" ]] ; then
+        if [[ -d ".git" || -f ".git" ]] ; then
             if GITOUT=$(eval ${GIT_LOG_COMMAND}); then
-                ## Only output if there is some activity
+                ## Only output if there is some activities
                 if [[ ! -z "$GITOUT" ]] ;  then
-                    echo "${BOLD}${UNDERLINE}${YELLOW}$DIR${NORMAL}"
+                    echo "${BOLD}${UNDERLINE}${YELLOW}$(basename "$DIR")${NORMAL}"
                     echo "$GITOUT"
                 fi
             else
-                echo "Repository under $DIR could not be queried. Missing initial commit?" >&2
+                echo "Repository under $DIR could not be queried." >&2
             fi
         fi
-
-        cd ..
+        popd > /dev/null
     done
 else
-    eval ${GIT_LOG_COMMAND}
-    echo "" ## To avoid that ugly # icon representing the end of line
+    if [ "$FETCH_LAST_COMMIT" = true ]; then
+        echo "${GREEN}Fetching commits ..${NORMAL}"
+        git fetch --all > /dev/null 2>&1
+    fi
+
+    if GITOUT=$(eval ${GIT_LOG_COMMAND}); then
+        if [[ ! -z "$GITOUT" ]] ;  then
+            echo "$GITOUT"
+        else
+            if [[ $AUTHOR = '.*' ]] ; then
+                AUTHOR="all the contributors"
+            fi
+
+            echo "${YELLOW}Seems like $AUTHOR did nothing!${NORMAL}"
+        fi
+    fi
 fi

--- a/bin/git-standup
+++ b/bin/git-standup
@@ -73,7 +73,11 @@ while getopts "hgfd:a:w:m:D:L" opt; do
             ;;
         d)
             test -n "$SINCE" && warn "-d option is conflict with -w"
-            SINCE=${SINCE:="$OPTARG days ago"}
+            if [ "$OPTARG" -lt 1 ]; then
+                >&2 echo "Specify days less than one is invalid"
+                exit 1
+            fi
+            SINCE="$OPTARG days ago"
             ;;
         w)
             if [ -n "$SINCE" ]; then

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -342,6 +342,18 @@ _git-stamp() {
          '(--replace -r)'{--replace,-r}'[replace stamps with same id]'
 }
 
+_git-standup() {
+    _arguments -C \
+        '-a[Specify the author of commits. Use "all" to specify all authors.]' \
+        '-d[Show history since N days ago]' \
+        '-D[Specify the date format displayed in commit history]' \
+        '-f[Fetch commits before showing history]' \
+        '-g[Display GPG signed info]' \
+        '-h[Display help message]' \
+        '-L[Enable the inclusion of symbolic links]' \
+        '-m[The depth of recursive directory search]'
+}
+
 _git-summary() {
     _arguments '--line[summarize with lines rather than commits]'
     __gitex_commits

--- a/man/git-standup.1
+++ b/man/git-standup.1
@@ -1,34 +1,70 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-STANDUP" "1" "April 2016" "" ""
+.TH "GIT\-STANDUP" "1" "April 2017" "" ""
 .
 .SH "NAME"
 \fBgit\-standup\fR \- Recall the commit history
 .
 .SH "SYNOPSIS"
-\fBgit\-standup\fR [<full name>] [<since>] [<until>]
+\fBgit\-standup\fR [\-a author] [\-m depth] [\-d days ago] [\-D date format] [\-g] [\-L] [\-f]
+.
+.P
+\fBgit\-standup\fR \-h
 .
 .SH "DESCRIPTION"
 Recall what you did on the last working day \.\.or be nosy and find what someone else did\.
 .
 .SH "OPTIONS"
-<full name>
+\-a author
 .
 .P
-The author of commits\. Defaults to \fB$(git config user\.name)\fR\.
+The author of commits\. Use "all" means specifying "all authors"\. Defaults to \fB$(git config user\.name)\fR\.
 .
 .P
-<since>
+\-m depth
 .
 .P
-The start of commit history\. Defaults to \fByesterday\fR\.
+The depth of recursive directory search\. Defaults to 1\.
 .
 .P
-<until>
+\-L
 .
 .P
-The end of commit history\. Defaults to \fBtoday\fR\.
+Enable the inclusion of symbolic links in recursive directory search\.
+.
+.P
+\-d 1
+.
+.P
+The start of commit history\. Defaults to 1, means "1 days ago"\.
+.
+.P
+\-D relative
+.
+.P
+The date format displayed in commit history\. Defaults to "relative"\.
+.
+.P
+\-h
+.
+.P
+Display help message\.
+.
+.P
+\-g
+.
+.P
+Display if commit is GPG signed (G) or not (N) in commit message\.
+.
+.P
+\-f
+.
+.P
+Fetch the latest commits before showing commit history\.
+.
+.P
+The former version of \fBgit standup\fR accepted \fB<author> <since> <until>\fR as options\. This interface is deprecated now, and please avoid to use it!
 .
 .SH "EXAMPLES"
 This shows your commits since yesterday:
@@ -52,7 +88,7 @@ This shows the author\'s commits since last week:
 .
 .nf
 
-$ git standup spacewander "last week"
+$ git standup \-a spacewander \-d 7
 
 a26d1f9 \- add profile hook (70 minutes ago) <spacewander>
 4e19859 \- fix getTotalSize return value error (6 days ago) <spacewander>
@@ -72,7 +108,7 @@ If current directory is not a git repo, git\-standup will fetch data from all to
 .nf
 
 $ cd \.\.
-$ git standup spacewander "last week" yesterday
+$ git standup \-a spacewander \-d 7
 
 someProject/
 4e19859 \- fix getTotalSize return value error (6 days ago) <spacewander>

--- a/man/git-standup.html
+++ b/man/git-standup.html
@@ -76,7 +76,9 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-standup</code> [&lt;full name&gt;] [&lt;since&gt;] [&lt;until&gt;]</p>
+<p><code>git-standup</code> [-a author] [-m depth] [-d days ago] [-D date format] [-g] [-L] [-f]</p>
+
+<p><code>git-standup</code> -h</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -84,17 +86,41 @@
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>&lt;full name&gt;</p>
+<p>-a author</p>
 
-<p>The author of commits. Defaults to <code>$(git config user.name)</code>.</p>
+<p>The author of commits. Use "all" means specifying "all authors".
+Defaults to <code>$(git config user.name)</code>.</p>
 
-<p>&lt;since&gt;</p>
+<p>-m depth</p>
 
-<p>The start of commit history. Defaults to <code>yesterday</code>.</p>
+<p>The depth of recursive directory search. Defaults to 1.</p>
 
-<p>&lt;until&gt;</p>
+<p>-L</p>
 
-<p>The end of commit history. Defaults to <code>today</code>.</p>
+<p>Enable the inclusion of symbolic links in recursive directory search.</p>
+
+<p>-d 1</p>
+
+<p>The start of commit history. Defaults to 1, means "1 days ago".</p>
+
+<p>-D relative</p>
+
+<p>The date format displayed in commit history. Defaults to "relative".</p>
+
+<p>-h</p>
+
+<p>Display help message.</p>
+
+<p>-g</p>
+
+<p>Display if commit is GPG signed (G) or not (N) in commit message.</p>
+
+<p>-f</p>
+
+<p>Fetch the latest commits before showing commit history.</p>
+
+<p>The former version of <code>git standup</code> accepted <code>&lt;author> &lt;since> &lt;until></code> as options.
+This interface is deprecated now, and please avoid to use it!</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -107,7 +133,7 @@ a26d1f9 - add profile hook (69 minutes ago) &lt;spacewander>
 
 <p>This shows the author's commits since last week:</p>
 
-<pre><code>$ git standup spacewander "last week"
+<pre><code>$ git standup -a spacewander -d 7
 
 a26d1f9 - add profile hook (70 minutes ago) &lt;spacewander>
 4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander>
@@ -119,7 +145,7 @@ a26d1f9 - add profile hook (70 minutes ago) &lt;spacewander>
 <p>If current directory is not a git repo, git-standup will fetch data from all top-level git repos under it:</p>
 
 <pre><code>$ cd ..
-$ git standup spacewander "last week" yesterday
+$ git standup -a spacewander -d 7
 
 someProject/
 4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander>
@@ -143,7 +169,7 @@ someProject/
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2016</li>
+    <li class='tc'>April 2017</li>
     <li class='tr'>git-standup(1)</li>
   </ol>
 

--- a/man/git-standup.md
+++ b/man/git-standup.md
@@ -3,7 +3,9 @@ git-standup(1) -- Recall the commit history
 
 ## SYNOPSIS
 
-`git-standup` [&lt;full name&gt;] [&lt;since&gt;] [&lt;until&gt;]
+`git-standup` [-a author] [-m depth] [-d days ago] [-D date format] [-g] [-L] [-f]
+
+`git-standup` -h
 
 ## DESCRIPTION
 
@@ -11,17 +13,41 @@ Recall what you did on the last working day ..or be nosy and find what someone e
 
 ## OPTIONS
 
-&lt;full name&gt;
+-a author
 
-The author of commits. Defaults to `$(git config user.name)`.
+The author of commits. Use "all" means specifying "all authors".
+Defaults to `$(git config user.name)`.
 
-&lt;since&gt;
+-m depth
 
-The start of commit history. Defaults to `yesterday`.
+The depth of recursive directory search. Defaults to 1.
 
-&lt;until&gt;
+-L
 
-The end of commit history. Defaults to `today`.
+Enable the inclusion of symbolic links in recursive directory search.
+
+-d 1
+
+The start of commit history. Defaults to 1, means "1 days ago".
+
+-D relative
+
+The date format displayed in commit history. Defaults to "relative".
+
+-h
+
+Display help message.
+
+-g
+
+Display if commit is GPG signed (G) or not (N) in commit message.
+
+-f
+
+Fetch the latest commits before showing commit history.
+
+The former version of `git standup` accepted `<author> <since> <until>` as options.
+This interface is deprecated now, and please avoid to use it!
 
 ## EXAMPLES
 
@@ -33,7 +59,7 @@ This shows your commits since yesterday:
 
 This shows the author's commits since last week:
 
-    $ git standup spacewander "last week"
+    $ git standup -a spacewander -d 7
 
     a26d1f9 - add profile hook (70 minutes ago) <spacewander>
     4e19859 - fix getTotalSize return value error (6 days ago) <spacewander>
@@ -44,7 +70,7 @@ This shows the author's commits since last week:
 If current directory is not a git repo, git-standup will fetch data from all top-level git repos under it:
 
     $ cd ..
-    $ git standup spacewander "last week" yesterday
+    $ git standup -a spacewander -d 7
 
     someProject/
     4e19859 - fix getTotalSize return value error (6 days ago) <spacewander>


### PR DESCRIPTION
For issue #645 
Now we can use `-g` option to show GPG info.

@sbriskin
Maybe it is something your want?
Remember to run `git standup` with new style options, for example,
`git standup -a $author -d $days_ago -g`.