### PR TITLE
Add BSD cat support

### DIFF
--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -40,7 +40,7 @@ stamp() {
     commit_msg=$(
       echo "${commit_msg}" \
         | grep --ignore-case --invert-match "^${ID}\b" \
-        | cat --squeeze-blank
+        | cat -s
     )
   fi
 


### PR DESCRIPTION
on macOS cat doesn't support the long operator