### PR TITLE
git-fork: Let curl exit with error code on fail

### DIFF
--- a/bin/git-fork
+++ b/bin/git-fork
@@ -31,7 +31,7 @@ fi
 [ -z "$project" -o -z "$owner" ] && abort "github repo needs to be specified as an argument"
 
 # create fork
-curl -qs \
+curl -qsf \
   -X POST \
   -u "$user" \
   -H "X-GitHub-OTP: $MFA_CODE" \


### PR DESCRIPTION
The next line checks if curl failed, and aborts the script if it has.

This adds the `-f` flag to the curl call, so when the request failed (i.e. when you typed a wrong password), the script aborts appropriately, instead of creating a branch for a non-existent remote.