### PR TITLE
Fix typo in git-extras

### DIFF
--- a/bin/git-extras
+++ b/bin/git-extras
@@ -21,7 +21,7 @@ updateForWindows() {
   # we need to clean up /tmp manually on windows
   cd /tmp \
     && rm -rf ./git-extras \
-    && echo "Setting up 'git-exras'...." \
+    && echo "Setting up 'git-extras'...." \
     && git clone https://github.com/tj/git-extras.git &> /dev/null \
     && cd git-extras \
 	&& git checkout \


### PR DESCRIPTION
Output said "Setting up 'git-exras" instead of "Setting up 'git-extras"