### PR TITLE
Fix Issue #186

### DIFF
--- a/bin/git-bug
+++ b/bin/git-bug
@@ -10,5 +10,5 @@ else
     echo "too many arguments; if not finishing a bug, only <name> of new bug is expected" && exit 1
   fi
   branch=bug/$1
-  git checkout -b $branch
+  git create-branch $branch
 fi

--- a/bin/git-chore
+++ b/bin/git-chore
@@ -10,5 +10,5 @@ else
     echo "too many arguments; if not finishing a chore, only <name> of new chore is expected" && exit 1
   fi
   branch=chore/$1
-  git checkout -b $branch
+  git create-branch $branch
 fi

--- a/bin/git-feature
+++ b/bin/git-feature
@@ -37,5 +37,5 @@ else
   else 
     branch="$branch_prefix"/"${argv[0]}"
   fi
-  git checkout -b $branch
+  git create-branch $branch
 fi

--- a/bin/git-refactor
+++ b/bin/git-refactor
@@ -10,5 +10,5 @@ else
     echo "too many arguments; if not finishing a refactor, only <name> of new refactoring is expected" && exit 1
   fi
   branch=refactor/$1
-  git checkout -b $branch
+  git create-branch $branch
 fi


### PR DESCRIPTION
Use `git create-branch` instead of `git checkout -b` in:
git-bug
git-chore
git-feature
git-refactor

Since `git-finish` uses `git-delete-branch` (which expects the branch to
have been pushed to origin) we should use `git-create-branch` to create
it.