### PR TITLE
Improve ignore-io

### DIFF
--- a/bin/git-ignore-io
+++ b/bin/git-ignore-io
@@ -16,8 +16,7 @@ print_in_alphabetical_order() {
 }
 
 print_in_table_format() {
-    table_width=5
-    echo "$gi_list" | xargs -n $table_width | column -t
+    echo "$gi_list" | column
 }
 
 search() {

--- a/bin/git-ignore-io
+++ b/bin/git-ignore-io
@@ -8,11 +8,22 @@ update_gi_list() {
 }
 
 print_in_alphabetical_order() {
-    for i in {a..z};
+    first=true
+    for ignorable in $(echo "$gi_list" | sort);
     do
-        echo "$gi_list" | grep "^$i" | tr "\n" " "
-        echo
+        first_character=${ignorable:0:1}
+        if [[ $first_character = $previous_first_character ]]; then
+            printf " $ignorable"
+        elif [[ $first = true ]]; then
+            previous_first_character=$first_character
+            first=false
+            printf "$ignorable"
+        else
+            previous_first_character=$first_character
+            printf "\n$ignorable"
+        fi
     done
+    echo
 }
 
 print_in_table_format() {

--- a/bin/git-ignore-io
+++ b/bin/git-ignore-io
@@ -8,19 +8,20 @@ update_gi_list() {
 }
 
 print_in_alphabetical_order() {
-    first=true
+    local first_character previous_first_character ignorable
+    local first=true
     for ignorable in $(echo "$gi_list" | sort);
     do
         first_character=${ignorable:0:1}
         if [[ $first_character = $previous_first_character ]]; then
-            printf " $ignorable"
+            printf " %s" "$ignorable"
         elif [[ $first = true ]]; then
             previous_first_character=$first_character
             first=false
-            printf "$ignorable"
+            printf "%s" "$ignorable"
         else
             previous_first_character=$first_character
-            printf "\n$ignorable"
+            printf "\n%s" "$ignorable"
         fi
     done
     echo


### PR DESCRIPTION
This makes two improvements to `git ignore-io`:

- Fixes a bug where `git ignore-io -L` omitted entries which did not start with `a..z`
- Removes the arbitrary choice of 5 columns on `git ignore-io -L`, in favour of `column`'s default