### PR TITLE
git-effort: restore normal (visible) cursor properly

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -39,7 +39,7 @@ hide_cursor() {
 #
 
 show_cursor_and_cleanup() {
-  tputq cvvis
+  tputq cnorm
   tputq sgr0
   rm "$tmp" > /dev/null 2>&1
   exit 0


### PR DESCRIPTION
If I understand GNU* correctly, cnorm should be used to undo `civis` (make
invisible). `cvvis` is just another abnormal mode, namely "very visible".

*) https://www.gnu.org/software/termutils/manual/termutils-2.0/html_chapter/tput_1.html