### PR TITLE
Fix 'Invalid code page' error when restoring code page at end of script for Windows

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -14,7 +14,7 @@ SETLOCAL enabledelayedexpansion
 for /F "tokens=*" %%F in ('chcp') do (
     for %%A in (%%F) do (set _last=%%A)
 )
-SET CP=%_last:~0,-1%
+SET CP=%_last:~0%
 chcp 850 > NUL
 :: echo %CP%
 


### PR DESCRIPTION
On Windows before setting the code page to 850 the install.cmd script stores the current code page. The current code page is however stored minus the last character, so a current code page '850' will be stored as '85'. This results in the 'Invalid code page' error when trying to restore the code page at the end of the script.