### PR TITLE
Docs> Add -- in front of cmd for git log

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -236,7 +236,7 @@ $ git effort --above 5
   If you wish to see only the commits in the last month you may use `--since` (it supports the same syntax like `git log --since`):
 
 ```
- $ git effort --since='last month'
+ $ git effort -- --since='last month'
 ```
 
   By default `git ls-files` is used, however you may pass one or more files to `git-effort(1)`, for example:


### PR DESCRIPTION
The current docs are incorrect, using the command gives an error msg:

```
error: unknown argument --since=1 week ago
error: if that argument was meant for git-log,
error: please put it after two dashes ( -- ).
```