### PR TITLE
Preserve existing user commands in zsh completion

### DIFF
--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -427,7 +427,9 @@ _git-undo(){
         '(--hard -h)'{--hard,-h}'[wipes your commit(s)]'
 }
 
-zstyle ':completion:*:*:git:*' user-commands \
+zstyle -g existing_user_commands ':completion:*:*:git:*' user-commands
+
+zstyle ':completion:*:*:git:*' user-commands $existing_user_commands \
     alias:'define, search and show aliases' \
     archive-file:'export the current head of the git repository to an archive' \
     authors:'generate authors report' \


### PR DESCRIPTION
Hi,

this PR addresses #604. Instead of completely overwriting the user-commands variable, we retrieve its value first and we add the additional completion mechanisms later. This is needed when the user has several packages that try to use this completion extension mechanism. With the current code, the last loaded package overwrites the rest.

Regards