### PR TITLE
feat(git-release): push tags first to help ci tools not miss them

### DIFF
--- a/bin/git-release
+++ b/bin/git-release
@@ -91,8 +91,8 @@ if test $# -gt 0; then
   git commit -a -m "$msg"
   # shellcheck disable=SC2086
   git tag $version -a -m "$msg" \
-    && git push $remote \
     && git push $remote --tags \
+    && git push $remote \
     && hook post-release $hook_args \
     && echo "... complete"
 else


### PR DESCRIPTION
If you are buliding on CircleCI for example, pushing the commits first can lead to a race where CI env will not see the tags since the pull happened before the tags were finished pushing.

It should be fully safe (and backwards-compatible) to change the order of pushing to the remote. This should make integrating with CI tools less of a race.