### PR TITLE
Remove trailing dot of German Windows

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -15,6 +15,9 @@ for /F "tokens=*" %%F in ('chcp') do (
     for %%A in (%%F) do (set _last=%%A)
 )
 SET CP=%_last:~0%
+if "!CP:~-1!"=="." (
+    SET CP=!CP:~0,-1!
+)
 chcp 850 > NUL
 :: echo %CP%
 


### PR DESCRIPTION
This fixed `install.cmd` for German Windows distributions.

When executing `CP`, the output is

    Aktive Codepage: 850.

Thus, the content of the variable `CP` is

    850.

When passing this to `chcp`, the output is

    Parameterformat falsch - 850.

Thus, the final lines of the script have no effect.

With this patch, the restore of the old code page works.