### PR TITLE
git-summary: unescape tab for linux column utility

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -54,7 +54,7 @@ authors() {
       printf "%s♪%2.1f%%\n", args[i], 100 * args[i] / sum
     }
   }
-  ' | column -t -s♪
+  ' | column -t -s♪ | sed "s/\\\x09/\t/g"
 }
 
 #

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -47,6 +47,9 @@ file_count() {
 #
 
 authors() {
+  # a rare unicode character is used as separator to avoid conflicting with
+  # author name. However, Linux column utility will escape tab if separator
+  # specified, so we do unesaping after it.
   git shortlog -n -s $commit | LC_ALL=C awk '
   { args[NR] = $0; sum += $0 }
   END {


### PR DESCRIPTION
Linux column utility will escape tab if a separator is specified.
This problem is first reported in Fedora 27.

May fix #694 