### PR TITLE
Installation.md: Zsh-plugin method which doesn't require root access

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -112,6 +112,18 @@ One-liner:
 curl -sSL http://git.io/git-extras-setup | sudo bash /dev/stdin
 ```
 
+## Installing as Zsh plugin
+
+[Zplugin](https://github.com/zdharma/zplugin) can install git-extras by using:
+
+```zsh
+zplugin ice as"program" pick"$ZPFX/bin/git-*" make"PREFIX=$ZPFX"
+zplugin light tj/git-extras
+```
+
+`$ZPFX` is `~/.zplugin/polaris` by default. Use `zplugin update tj/git-extras` to update.
+This method installs in `$HOME`, so you don't need to ask administrator to install package.
+
 ## Updating
 
 If you installed git-extras with a package manager, use that package manager's tools to update it.


### PR DESCRIPTION
A short section to `Installation.md`. It describes how to install as Zsh plugin. Benefits of such method:

 - no administrator access required (easy install on e.g. digital ocean, etc.),
 - declarative method of installing – 2 lines in .zshrc lead to git-extras on each account.
