### PR TITLE
docs: adding man git-fork options

### DIFF
--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -21,6 +21,20 @@ git-fork(1) -- Fork a repo on github
 
   Remotes will use ssh if you have it configured with GitHub, if not, https will be used.
 
+## OPTIONS
+
+  --org=ORGANIZATION
+
+  Fork to an organization.
+
+  --no-remote
+
+  Do not add a remote locally.
+
+  --remote-name=REMOTE
+
+  Choose a remote name for your fork.
+
 ## EXAMPLE
 
   Fork expect.js:


### PR DESCRIPTION
These are missing from `> man git-fork`. This should add them in, although I may need to add more details.