### PR TITLE
Improve the git-sed command

### DIFF
--- a/bin/git-sed
+++ b/bin/git-sed
@@ -66,7 +66,22 @@ actual command:
     shift
 done
 
+all="$search$replacement$flags"
+case "$all" in
+    */*)
+        ascii="$(for((i=32;i<=127;i++)) do printf '%b' "\\$(printf '%03o' "$i")"; done)"
+        sep="$(printf '%s' "$ascii" | tr -d "$all")"
+        sep="$(printf %.1s "$sep")"
+        if [ "X$sep" = "X" ] ; then
+            echo 'could not find an unused character for sed separator character'
+            exit 1
+        fi
+        ;;
+    *)
+        sep=/
+        ;;
+esac
 r=$(xargs -r false < /dev/null > /dev/null 2>&1 && echo r)
-command="git grep -lz '$search' | xargs -0$r sed -i 's/$search/$replacement/$flags'"
-git grep -lz "$search" | xargs -0"$r" sed -i "s/$search/$replacement/$flags"
+command="git grep -lz '$search' | xargs -0$r sed -i 's$sep$search$sep$replacement$sep$flags'"
+git grep -lz "$search" | xargs -0"$r" sed -i "s$sep$search$sep$replacement$sep$flags"
 do_commit

--- a/bin/git-sed
+++ b/bin/git-sed
@@ -2,10 +2,10 @@
 
 usage() {
     cat <<EOF
-usage: git sed [ -c ] [ -f <flags> ] <search> <replacement>
+usage: git sed [ -c ] [ -f <flags> ] <search> <replacement> [ <flags> ]
 
 Run git grep and then send results to sed for replacement with the
-given flags, if -f is provided.
+given flags, if they are provided via -f or as the third argument.
 
 Also runs git commit if -c is provided.
 EOF
@@ -54,6 +54,8 @@ actual command:
                 search="$1"
             elif [ "X$replacement" = "X" ]; then
                 replacement="$1"
+            elif [ "X$flags" = "X" ]; then
+                flags="$1"
             else
                 usage
                 echo "too many arguments: $1"

--- a/bin/git-sed
+++ b/bin/git-sed
@@ -66,6 +66,7 @@ actual command:
     shift
 done
 
-command="git grep -lz '$search' | xargs -0 sed -i 's/$search/$replacement/$flags'"
-git grep -lz "$search" | xargs -0 sed -i "s/$search/$replacement/$flags"
+r=$(xargs -r false < /dev/null > /dev/null 2>&1 && echo r)
+command="git grep -lz '$search' | xargs -0$r sed -i 's/$search/$replacement/$flags'"
+git grep -lz "$search" | xargs -0"$r" sed -i "s/$search/$replacement/$flags"
 do_commit

--- a/man/git-sed.md
+++ b/man/git-sed.md
@@ -3,12 +3,12 @@ git-sed(1) -- replace patterns in git-controlled files
 
 ## SYNOPSIS
 
-`git-sed` [ -c ] [ -f <flags> ] <search> <replacement>
+`git-sed` [ -c ] [ -f <flags> ] <search> <replacement> [ <flags> ]
 
 ## DESCRIPTION
 
 Run git grep and then send results to sed for replacement with the
-given flags, if -f is provided.
+given flags, if they are provided via -f or as the third argument.
 
 Also runs git commit if -c is provided.
 
@@ -20,6 +20,7 @@ Also runs git commit if -c is provided.
   detailing the exact command ran. will fail if there are unstaged
   changes.
 
+  &lt;flags&gt;
   -f &lt;flags&gt;
 
   will use the given regex flags in the sed command (for example "g"


### PR DESCRIPTION
Discover a separator when the / character is used in arguments.
Prevent running sed when the search pattern does not match any files.
Allow the flags to be passed as a third argument.