### PR TITLE
Fix bugs with git-release --semver

### DIFF
--- a/bin/git-release
+++ b/bin/git-release
@@ -58,7 +58,7 @@ if test $# -gt 0; then
     latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 
     if [[ ! "$latest_tag" =~ \
-        ^([^0-9]*)([0-9]|[1-9][0-9]+)\.([0-9]|[1-9][0-9]+)\.([0-9]|[1-9][0-9]+)(.*) ]]; then
+        ^([^0-9]*)([1-9][0-9]+|[0-9])\.([1-9][0-9]+|[0-9])\.([1-9][0-9]+|[0-9])(.*) ]]; then
       echo "the latest tag doesn't match semver format requirement" 1>&2
       exit 1
     fi

--- a/bin/git-release
+++ b/bin/git-release
@@ -75,8 +75,8 @@ if test $# -gt 0; then
     (( ++version ))
 
     case "$semver" in
-    major ) version="${BASH_REMATCH[1]}$version.${BASH_REMATCH[3]}.${BASH_REMATCH[4]}${BASH_REMATCH[5]}" ;;
-    minor ) version="${BASH_REMATCH[1]}${BASH_REMATCH[2]}.$version.${BASH_REMATCH[4]}${BASH_REMATCH[5]}" ;;
+    major ) version="${BASH_REMATCH[1]}$version.0.0${BASH_REMATCH[5]}" ;;
+    minor ) version="${BASH_REMATCH[1]}${BASH_REMATCH[2]}.$version.0${BASH_REMATCH[5]}" ;;
     patch ) version="${BASH_REMATCH[1]}${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.$version${BASH_REMATCH[5]}" ;;
     esac
   fi


### PR DESCRIPTION
I found 2 bugs when using `git-release --semver`

1. The version regex greedily matches only the first digit for version numbers that contain multiple digits. Matching the multi digit case first solves this problem. 

2. When doing a `major` release, the `minor` and `patch` version numbers should be reset to `0`, and when doing a `minor` release, the `patch` number should be reset to `0`.