### PR TITLE
add: git-ignore -p (private to repo)

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -602,6 +602,7 @@ To show just the global or just the local file's contents, you can use the follo
 
 * `-g` or `--global` to show just the global file
 * `-l` or `--local` to show just the local file
+* `-p` or `--private` to show just the repository's file
 
 ```bash
 $ git ignore -g

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -35,6 +35,16 @@ function add_local {
   add_patterns .gitignore "$@"
 }
 
+function show_private {
+  cd "$(git root)"
+  show_contents Private .git/info/exclude
+}
+
+function add_private {
+  cd "$(git root)"
+  add_patterns .git/info/exclude "$@"
+}
+
 function add_patterns {
   echo "Adding pattern(s) to: $1"
   local file="${1/#~/$HOME}"
@@ -48,6 +58,8 @@ if test $# -eq 0; then
    show_global
    echo "---------------------------------"
    show_local
+   echo "---------------------------------"
+   show_private
 else
   case "$1" in
     -l|--local)
@@ -57,6 +69,10 @@ else
     -g|--global)
       test $# -gt 1 && add_global "${@:2}" && echo
       show_global
+      ;;
+    -p|--private)
+      test $# -gt 1 && add_private "${@:2}" && echo
+      show_private
       ;;
     *)
       add_local "$@"

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -42,6 +42,7 @@ function show_private {
 
 function add_private {
   cd "$(git root)"
+  mkdir -p .git/info
   add_patterns .git/info/exclude "$@"
 }
 

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -42,7 +42,7 @@ function show_private {
 
 function add_private {
   cd "$(git root)"
-  mkdir -p .git/info
+  test -d .git/info || mkdir -p .git/info
   add_patterns .git/info/exclude "$@"
 }
 

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -94,11 +94,11 @@ _git_graft(){
 _git_ignore(){
   case "$cur" in
   --*)
-    __gitcomp "--global --local"
+    __gitcomp "--global --local --private"
     return
     ;;
   -*)
-    __gitcomp "--global --local -g -l"
+    __gitcomp "--global --local --private -g -l -p"
     return
     ;;
   esac

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -329,7 +329,8 @@ _git-guilt() {
 _git-ignore() {
     _arguments  -C \
         '(--local -l)'{--local,-l}'[show local gitignore]' \
-        '(--global -g)'{--global,-g}'[show global gitignore]'
+        '(--global -g)'{--global,-g}'[show global gitignore]' \
+        '(--private -p)'{--private,-p}'[show repo gitignore]'
 }
 
 

--- a/man/git-ignore.1
+++ b/man/git-ignore.1
@@ -28,6 +28,12 @@ Sets the context to the \.gitignore file in the current working directory\. (def
 Sets the context to the global gitignore file for the current user\.
 .
 .P
+\-p, \-\-private
+.
+.P
+Sets the context to the private exclude file for the repository (\fB\.git/info/exclude\fR)\.
+.
+.P
 <pattern>
 .
 .P

--- a/man/git-ignore.html
+++ b/man/git-ignore.html
@@ -94,6 +94,10 @@
 
 <p>  Sets the context to the global gitignore file for the current user.</p>
 
+<p>  -p, --private</p>
+
+<p>  Sets the context to the private exclude file for the repository (<code>.git/info/exclude</code>).</p>
+
 <p>  &lt;pattern&gt;</p>
 
 <p>  A space delimited list of patterns to append to the file in context.</p>

--- a/man/git-ignore.md
+++ b/man/git-ignore.md
@@ -21,6 +21,10 @@ Adds the given _pattern_s to a .gitignore file if it doesn't already exist.
 
   Sets the context to the global gitignore file for the current user.
 
+  -p, --private
+
+  Sets the context to the private exclude file for the repository (`.git/info/exclude`).
+
   &lt;pattern&gt;
 
   A space delimited list of patterns to append to the file in context.


### PR DESCRIPTION
When working in a repo, it's common to create temporary files -- files that are specific to what you're doing at that very time.

Git has a private ignore file `.git/info/exclude` which isn't replicated.
This is a perfect place to ignore those one-off temporary files.

I've added the option to `git-ignore`, updated the docs and the completion scripts.

I hope you find this useful.