### PR TITLE
git-changelog: add missing newline to the plain output

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -160,7 +160,7 @@ _formatCommitPlain() {
   local start_tag="$1"
   local final_tag="$2"
 
-  printf "%s" "$(_fetchCommitRange "false" "$start_tag" "$final_tag")"
+  printf "%s\n" "$(_fetchCommitRange "false" "$start_tag" "$final_tag")"
 }
 
 _formatCommitPretty() {


### PR DESCRIPTION
Previously, running "git changelog -x --start-tag 4.5.0 -p -l" will see
```
* Bump version to 4.6.0-dev.  * Version 4.5.0
```
Because there is no newline in the end of each plain output.