### PR TITLE
Make `git undo -s` restore the staging area

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -168,6 +168,7 @@ Patches and Suggestions
 - Nick Campbell
 - Nick Payne
 - Niklas Fiekas
+- Peter Bittner
 - Prayag Verma
 - R. Martinho Fernandes
 - Raphael Fleischlin

--- a/bin/git-undo
+++ b/bin/git-undo
@@ -23,15 +23,15 @@ EOL
     ;;
   --hard)
     test $2 -gt 1 > /dev/null 2>&1 && back="~$2"
-    git reset --hard HEAD$back && exit 0;
+    git reset --hard HEAD$back
     ;;
   -s|--soft)
     test $2 -gt 1 > /dev/null 2>&1 && back="~$2"
+    git reset --soft HEAD$back
     ;;
   *)
     test $1 -gt 1 > /dev/null 2>&1 && back="~$1"
+    git reset --soft HEAD$back
+    git reset
     ;;
 esac
-
-git reset --soft HEAD$back
-git reset

--- a/man/git-undo.1
+++ b/man/git-undo.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-UNDO" "1" "April 2018" "" "Git Extras"
+.TH "GIT\-UNDO" "1" "June 2018" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-undo\fR \- Remove latest commits
@@ -16,7 +16,7 @@ Removes the latest commits\.
 \-\-soft or \-s
 .
 .P
-This is the default, only rolls back the commit but changes remain un\-staged\.
+Rolls back the commit(s) but leaves the changes in the staging area\.
 .
 .P
 \-\-hard or \-h
@@ -38,6 +38,19 @@ Removes the latest commit\.
 .nf
 
 $ git undo
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Removes the latest commit, restoring the staging area\.
+.
+.IP "" 4
+.
+.nf
+
+$ git undo \-s
 .
 .fi
 .

--- a/man/git-undo.html
+++ b/man/git-undo.html
@@ -86,7 +86,7 @@
 
 <p>  --soft or -s</p>
 
-<p>  This is the default, only rolls back the commit but changes remain un-staged.</p>
+<p>  Rolls back the commit(s) but leaves the changes in the staging area.</p>
 
 <p>  --hard or -h</p>
 
@@ -104,6 +104,11 @@
 <pre><code>$ git undo
 </code></pre>
 
+<p>  Removes the latest commit, restoring the staging area.</p>
+
+<pre><code>$ git undo -s
+</code></pre>
+
 <p>  Remove the latest 3 commits:</p>
 
 <pre><code>$ git undo 3
@@ -111,7 +116,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Kenneth Reitz &lt;<a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#58;&#x6d;&#x65;&#x40;&#107;&#x65;&#x6e;&#110;&#x65;&#x74;&#x68;&#x72;&#101;&#105;&#116;&#x7a;&#46;&#x63;&#x6f;&#109;" data-bare-link="true">&#x6d;&#101;&#64;&#107;&#x65;&#x6e;&#110;&#x65;&#116;&#x68;&#114;&#101;&#x69;&#x74;&#x7a;&#x2e;&#99;&#111;&#x6d;</a>&gt; and Nick Lombard &lt;<a href="&#109;&#97;&#105;&#x6c;&#116;&#x6f;&#x3a;&#x67;&#x69;&#116;&#104;&#117;&#x62;&#64;&#106;&#105;&#x67;&#x73;&#111;&#102;&#x74;&#46;&#99;&#111;&#x2e;&#x7a;&#x61;" data-bare-link="true">&#103;&#105;&#116;&#x68;&#117;&#98;&#64;&#x6a;&#105;&#x67;&#x73;&#x6f;&#102;&#x74;&#x2e;&#99;&#x6f;&#x2e;&#x7a;&#x61;</a>&gt;</p>
+<p>Written by Kenneth Reitz &lt;<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#x3a;&#x6d;&#x65;&#64;&#107;&#101;&#x6e;&#x6e;&#101;&#116;&#104;&#114;&#101;&#105;&#116;&#x7a;&#x2e;&#x63;&#111;&#109;" data-bare-link="true">&#x6d;&#x65;&#x40;&#x6b;&#101;&#110;&#x6e;&#101;&#116;&#x68;&#x72;&#101;&#105;&#116;&#122;&#46;&#99;&#x6f;&#109;</a>&gt; and Nick Lombard &lt;<a href="&#109;&#x61;&#105;&#108;&#x74;&#111;&#x3a;&#x67;&#x69;&#116;&#x68;&#x75;&#x62;&#64;&#x6a;&#105;&#x67;&#x73;&#111;&#x66;&#x74;&#x2e;&#99;&#x6f;&#46;&#122;&#x61;" data-bare-link="true">&#103;&#105;&#x74;&#104;&#117;&#98;&#64;&#x6a;&#105;&#103;&#115;&#x6f;&#102;&#116;&#46;&#x63;&#x6f;&#46;&#122;&#97;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -124,7 +129,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2018</li>
+    <li class='tc'>June 2018</li>
     <li class='tr'>git-undo(1)</li>
   </ol>
 

--- a/man/git-undo.md
+++ b/man/git-undo.md
@@ -13,7 +13,7 @@ git-undo(1) -- Remove latest commits
 
   --soft or -s
 
-  This is the default, only rolls back the commit but changes remain un-staged.
+  Rolls back the commit(s) but leaves the changes in the staging area.
 
   --hard or -h
 
@@ -29,6 +29,10 @@ git-undo(1) -- Remove latest commits
   Removes the latest commit.
 
     $ git undo
+
+  Removes the latest commit, restoring the staging area.
+
+    $ git undo -s
 
   Remove the latest 3 commits:
 


### PR DESCRIPTION
Sometimes it's handy to have the staging area restored when undoing a commit. For example, when you forgot to create a feature branch and accidentally committed to `master`:

```bash
$ git undo -s
$ git checkout -b feature/branch
$ git commit -m 'Use the right branch'
```

The current behavior of "undo [-s|--soft]" is throwing the staging area away. Just like the default without any command line options. With these changes the user is given three distinct choices, listed in the order of destructiveness: 

1. `git undo --soft` (only undo the _commit_)
1. `git undo` (undo both the _commit_ and _staging the changes_) 
1. `git undo --hard` (throw away both the _commit_ and the _related staged changes_)

The implementation is now also straight-forward, more obvious, and easier to understand.

The man page (in all formats) has been updated accordingly.

Fixes #689.