### PR TITLE
Fix: Dev: `/E` option required to install on Win 10 {b17134} or higher

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -108,18 +108,30 @@ SET COMMANDS_WITHOUT_REPO=git-alias git-extras git-fork git-setup
 
 echo Installing binaries...
 FOR /R "%GITEXTRAS%\bin" %%i in (*.*) DO (
+::  Fixation for Windows 10.0.17134 Build 17134 (Won't install without /E)    
+::  Echo file being written for testing
+    IF "%DEBUG%=="true" ( ECHO "Writing File: %PREFIX%\bin\%%~ni" )
+
     ECHO #^^!/usr/bin/env bash > "%PREFIX%\bin\%%~ni"
     TYPE "%GITEXTRAS%\helper\reset-env" >> "%PREFIX%\bin\%%~ni"
     TYPE "%GITEXTRAS%\helper\git-extra-utility" >> "%PREFIX%\bin\%%~ni"
     TYPE "%GITEXTRAS%\helper\is-git-repo" >> "%PREFIX%\bin\%%~ni"
-    MORE +2 "%GITEXTRAS%\bin\%%~ni" >> "%PREFIX%\bin\%%~ni"
+    
+    REM Added /E Option for Installation Fix On Windows 10 Higher Version
+    MORE /E +2 "%GITEXTRAS%\bin\%%~ni" >> "%PREFIX%\bin\%%~ni"
 )
 
 FOR %%i in (%COMMANDS_WITHOUT_REPO%) DO (
+::  Fixation for Windows 10.0.17134 Build 17134 (Won't install without /E) 
+::  Echo file being written for testing
+    IF "%DEBUG%=="true" ( ECHO "Writing File: %PREFIX%\bin\%%i" )
+
     ECHO #^^!/usr/bin/env bash > "%PREFIX%\bin\%%i"
     TYPE "%GITEXTRAS%\helper\reset-env" >> "%PREFIX%\bin\%%i"
     TYPE "%GITEXTRAS%\helper\git-extra-utility" >> "%PREFIX%\bin\%%i"
-    MORE +2 "%GITEXTRAS%\bin\%%i" >> "%PREFIX%\bin\%%i"
+    
+::  Added /E Option for Installation Fix On Windows 10 Higher Version
+    MORE /E +2 "%GITEXTRAS%\bin\%%i" >> "%PREFIX%\bin\%%i"
 )
 
 echo Installing man pages...


### PR DESCRIPTION
Changes:
- Added small text line to debug files being written iff environment variable `%DEBUG%` is `true`
- Added option `/E` to both MORE commands used inside install.cmd for copying files.