### PR TITLE
Improved the 'git-info' command

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -731,7 +731,7 @@ $ git info
 
 ```
 
-If you wish to omit the config section, you may use `--no-config`:
+If you wish to omit the config section, you may use `--no-config` (or `-n`):
 
 ```bash
 $ git info --no-config

--- a/Commands.md
+++ b/Commands.md
@@ -737,6 +737,12 @@ If you wish to omit the config section, you may use `--no-config` (or `-n`):
 $ git info --no-config
 ```
 
+By default, the output is colored to make it easier on the eyes. When this is not desired (if piping the output of `git info` to another command, for example), the `--no-color` option may be used:
+
+```bash
+$ git info --no-color
+```
+
 ## git create-branch
 
 Create local branch `name`:

--- a/Commands.md
+++ b/Commands.md
@@ -743,6 +743,20 @@ By default, the output is colored to make it easier on the eyes. When this is no
 $ git info --no-color
 ```
 
+You can select the number of previous commits to show by using the `-c <N>` option (where `<N>` is any integer). It is important to note, however, that `-c` **must be the FIRST option** you pass to `git info`. For example:
+
+```bash
+$ git info -c 5 --no-config
+```
+
+will display the 5 most recent commits as apart of its output (and omit the configuration section), but
+
+```bash
+$ git info --no-config -c 5
+```
+
+will NOT recognize that the `-c` option was used. Consequently, the output will contain only the single most recent commit (the default action). 
+
 ## git create-branch
 
 Create local branch `name`:

--- a/Commands.md
+++ b/Commands.md
@@ -731,7 +731,7 @@ $ git info
 
 ```
 
-If you wish to omit the config section, you may use `--no-config` (or `-n`):
+If you wish to omit the config section, you may use `--no-config`:
 
 ```bash
 $ git info --no-config

--- a/bin/git-info
+++ b/bin/git-info
@@ -3,6 +3,12 @@
 clear
 
 
+max_count=1
+if [[ "$1" == "-c" ]]; then
+    shift
+    max_count="$1"; shift
+fi
+
 color="--color=always"
 no_color="--no-color"
 if [[ "$1" == "${no_color}" ]]; then
@@ -43,8 +49,14 @@ git_cmd "git branch -r ${color}"
 header "Local Branches:"
 git_cmd "git branch ${color}"
 
-header "Most Recent Commit:"
-git_cmd "git --no-pager log --max-count=1 --pretty=short ${color}"
+if [[ "${max_count}" -ne 1 ]]; then
+    header="Top ${max_count} Commits:"
+else
+    header="Most Recent Commit:"
+fi
+
+header "${header}"
+git_cmd "git --no-pager log --max-count=${max_count} --pretty=short ${color}"
 
 if [[ "$1" != "--no-config" ]]; then
   header "Configuration (.git/config):"

--- a/bin/git-info
+++ b/bin/git-info
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+clear
+
 header() {
     tput setaf 242
     printf "### $1\n"

--- a/bin/git-info
+++ b/bin/git-info
@@ -46,7 +46,7 @@ git_cmd "git branch ${color}"
 header "Most Recent Commit:"
 git_cmd "git --no-pager log --max-count=1 --pretty=short ${color}"
 
-if [[ "$1" != "--no-config" ]] && [[ "$1" != "-n" ]]; then
+if [[ "$1" != "--no-config" ]]; then
   header "Configuration (.git/config):"
   git --no-pager config --list
 fi

--- a/bin/git-info
+++ b/bin/git-info
@@ -2,13 +2,13 @@
 
 header() {
     tput setaf 242
-    printf "## $1\n\n"
+    printf "### $1\n"
     tput sgr0
 }
 
 run() {
     eval "$1"
-    printf "\n\n"
+    printf "\n"
 }
 
 # Show info similar to svn

--- a/bin/git-info
+++ b/bin/git-info
@@ -2,30 +2,49 @@
 
 clear
 
+
+color="--color=always"
+no_color="--no-color"
+if [[ "$1" == "${no_color}" ]]; then
+    color="$1"; shift
+else
+    if [[ "$2" == "${no_color}" ]]; then
+        color="$2"
+    fi
+fi
+
+
 header() {
-    tput setaf 242
+    if [[ "${color}" != "${no_color}" ]]; then
+        tput setaf 242
+    fi
+
     printf "### $1\n"
-    tput sgr0
+
+    if [[ "${color}" != "${no_color}" ]]; then
+        tput sgr0
+    fi
 }
 
-run() {
+git_cmd() {
     eval "$1"
     printf "\n"
 }
 
+
 # Show info similar to svn
 
 header "Remote URLs:"
-run "git remote -v"
+git_cmd "git remote -v"
 
 header "Remote Branches:"
-run "git branch -r --color=always"
+git_cmd "git branch -r ${color}"
 
 header "Local Branches:"
-run "git branch --color=always"
+git_cmd "git branch ${color}"
 
 header "Most Recent Commit:"
-run "git --no-pager log --max-count=1 --pretty=short --color=always"
+git_cmd "git --no-pager log --max-count=1 --pretty=short ${color}"
 
 if [[ "$1" != "--no-config" ]] && [[ "$1" != "-n" ]]; then
   header "Configuration (.git/config):"

--- a/bin/git-info
+++ b/bin/git-info
@@ -1,47 +1,31 @@
 #!/usr/bin/env bash
 
-get_config() {
-  git config --list
+header() {
+    tput setaf 242
+    printf "## $1\n\n"
+    tput sgr0
 }
 
-most_recent_commit() {
-  git log --max-count=1 --pretty=short
-}
-
-local_branches() {
-  git branch
-}
-
-remote_branches() {
-  git branch -r
-}
-
-remote_urls() {
-  git remote -v
-}
-
-echon() {
-    echo "$@"
-    echo
+run() {
+    eval "$1"
+    printf "\n\n"
 }
 
 # Show info similar to svn
 
-echo
-echon "## Remote URLs:"
-echon "$(remote_urls)"
+header "Remote URLs:"
+run "git remote -v"
 
-echon "## Remote Branches:"
-echon "$(remote_branches)"
+header "Remote Branches:"
+run "git branch -r --color=always"
 
-echon "## Local Branches:"
-echon "$(local_branches)"
+header "Local Branches:"
+run "git branch --color=always"
 
-echon "## Most Recent Commit:"
-echon "$(most_recent_commit)"
-echon "Type 'git log' for more commits, or 'git show <commit id>' for full commit details."
+header "Most Recent Commit:"
+run "git --no-pager log --max-count=1 --pretty=short --color=always"
 
-if test "$1" != "--no-config"; then
-  echon "## Configuration (.git/config):"
-  echon "$(get_config)"
+if [[ "$1" != "--no-config" ]] && [[ "$1" != "-n" ]]; then
+  header "Configuration (.git/config):"
+  git --no-pager config --list
 fi


### PR DESCRIPTION
### Added:
* colored output to git-info (can be disabled with the `--no-color` option)
* new `-c <N>` option which allows the user to specify the number of commits to show in the output 