### PR TITLE
git-rename-branch: change branch argument order

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -481,7 +481,7 @@ Rename a branch locally, and sync to remote via `git push`.
 
 ```
 # renames any branch
-$ git rename-branch new-name old-name
+$ git rename-branch old-name new-name
 
 # renames current branch
 $ git rename-branch new-name

--- a/bin/git-rename-branch
+++ b/bin/git-rename-branch
@@ -4,8 +4,14 @@ set -e
 # Assert there is at least one branch provided
 test -z $1 && echo "new branch name required." 1>&2 && exit 1
 
-new_branch="$1"
-old_branch="${2-$(git symbolic-ref --short -q HEAD)}"
+if [ -z $2 ]; then
+    new_branch="$1"
+    old_branch="$(git symbolic-ref --short -q HEAD)"
+else
+    new_branch="$2"
+    old_branch="$1"
+fi
+
 remote=$(git config branch."$old_branch".remote; true)
 
 git branch -m "$old_branch" "$new_branch"

--- a/man/git-rename-branch.1
+++ b/man/git-rename-branch.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-RENAME\-BRANCH" "1" "October 2017" "" "Git Extras"
+.TH "GIT\-RENAME\-BRANCH" "1" "July 2019" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-rename\-branch\fR \- rename local branch and push to remote
 .
 .SH "SYNOPSIS"
-\fBgit\-rename\-branch\fR <new\-branch> <old\-branch>
+\fBgit\-rename\-branch\fR <old\-branch> <new\-branch>
 .
 .SH "DESCRIPTION"
 .
@@ -21,13 +21,13 @@ Rename local branch and push the new branch to remote
 .
 .nf
 
-&lt;new\-branch&gt;
-
-New branch name
-
 &lt;old\-branch&gt;
 
 Old branch whose has to be renamed\. This is an optional parameter\. If no value is supplied then the current branch will be renamed\.
+
+&lt;new\-branch&gt;
+
+New branch name
 .
 .fi
 .
@@ -35,7 +35,7 @@ Old branch whose has to be renamed\. This is an optional parameter\. If no value
 .
 .nf
 
-$ git rename\-branch new\-name old\-name
+$ git rename\-branch old\-name new\-name
 
 $ git rename\-branch new\-name
 .

--- a/man/git-rename-branch.html
+++ b/man/git-rename-branch.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-rename-branch</code> &lt;new-branch&gt; &lt;old-branch&gt;</p>
+<p><code>git-rename-branch</code> &lt;old-branch&gt; &lt;new-branch&gt;</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -85,25 +85,25 @@
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<pre><code>&amp;lt;new-branch&amp;gt;
-
-New branch name
-
-&amp;lt;old-branch&amp;gt;
+<pre><code>&amp;lt;old-branch&amp;gt;
 
 Old branch whose has to be renamed. This is an optional parameter. If no value is supplied then the current branch will be renamed.
+
+&amp;lt;new-branch&amp;gt;
+
+New branch name
 </code></pre>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<pre><code>$ git rename-branch new-name old-name
+<pre><code>$ git rename-branch old-name new-name
 
 $ git rename-branch new-name
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Hozefa Jodiawalla &lt;<a href="&#x6d;&#97;&#105;&#x6c;&#116;&#111;&#58;&#x68;&#x6f;&#x7a;&#x65;&#x66;&#x61;&#114;&#117;&#x6c;&#101;&#x73;&#x40;&#x67;&#x6d;&#97;&#105;&#108;&#x2e;&#99;&#x6f;&#109;" data-bare-link="true">&#104;&#x6f;&#x7a;&#x65;&#x66;&#x61;&#x72;&#x75;&#x6c;&#x65;&#115;&#64;&#103;&#x6d;&#97;&#105;&#x6c;&#46;&#x63;&#111;&#109;</a>&gt;</p>
+<p>Written by Hozefa Jodiawalla &lt;<a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#x3a;&#x68;&#x6f;&#122;&#x65;&#102;&#97;&#114;&#117;&#x6c;&#101;&#x73;&#64;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#99;&#x6f;&#x6d;" data-bare-link="true">&#x68;&#x6f;&#122;&#x65;&#x66;&#x61;&#114;&#117;&#x6c;&#x65;&#x73;&#x40;&#103;&#x6d;&#x61;&#105;&#x6c;&#x2e;&#99;&#x6f;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -116,7 +116,7 @@ $ git rename-branch new-name
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>July 2019</li>
     <li class='tr'>git-rename-branch(1)</li>
   </ol>
 

--- a/man/git-rename-branch.md
+++ b/man/git-rename-branch.md
@@ -3,7 +3,7 @@ git-rename-branch(1) -- rename local branch and push to remote
 
 ## SYNOPSIS
 
-`git-rename-branch` &lt;new-branch&gt; &lt;old-branch&gt;
+`git-rename-branch` &lt;old-branch&gt; &lt;new-branch&gt;
 
 ## DESCRIPTION
 
@@ -11,17 +11,17 @@ git-rename-branch(1) -- rename local branch and push to remote
 
 ## OPTIONS
 
-    &lt;new-branch&gt;
-
-    New branch name
-
     &lt;old-branch&gt;
 
     Old branch whose has to be renamed. This is an optional parameter. If no value is supplied then the current branch will be renamed.
 
+    &lt;new-branch&gt;
+
+    New branch name
+
 ## EXAMPLES
 
-    $ git rename-branch new-name old-name
+    $ git rename-branch old-name new-name
 
     $ git rename-branch new-name
 


### PR DESCRIPTION
Now git-rename-branch has the same order like 'git branch -m', 'git
rename-tag' and other rename command.

Note that this is a break change.

Close #759.