### PR TITLE
Allow git-* scripts to be POSIX shell scripts

### DIFF
--- a/check_integrity.sh
+++ b/check_integrity.sh
@@ -20,7 +20,8 @@ check_bash_script() {
 
     shebang=$(head -n1 "bin/$cmd")
     [[ "$shebang" =~ \#![[:space:]]*/usr/bin/env[[:space:]]+bash ]] \
-        || err "Start git-$1 with '#!/usr/bin/env bash'"
+        || [[ "$shebang" =~ \#![[:space:]]*/bin/sh ]] \
+        || err "Start git-$1 with '#!/usr/bin/env bash' or '#!/bin/sh'"
 }
 
 check_git_extras_cmd_list() {


### PR DESCRIPTION
Not all of the scripts need bash features.

There are more POSIX shells potentially available on more platforms
than the one implementation of bash available on some platforms.

Some of the POSIX shell implementations are faster than bash.