### PR TITLE
Use GIT_DIR environment variable to to set .git directory

### DIFF
--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+: ${GIT_DIR:=.git}
+
 function show_contents {
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
@@ -37,13 +39,13 @@ function add_local {
 
 function show_private {
   cd "$(git root)"
-  show_contents Private .git/info/exclude
+  show_contents Private "${GIT_DIR}/info/exclude"
 }
 
 function add_private {
   cd "$(git root)"
-  test -d .git/info || mkdir -p .git/info
-  add_patterns .git/info/exclude "$@"
+  test -d "${GIT_DIR}/info" || mkdir -p "${GIT_DIR}/info"
+  add_patterns "${GIT_DIR}/info/exclude" "$@"
 }
 
 function add_patterns {


### PR DESCRIPTION
The GIT_DIR environment variable can be used to configure an alternative repository location within GiT. This is very useful i.e. for the management of dotfiles:
```
alias config='GIT_DIR=~/.local/share/dotfiles GIT_WORK_TREE=~ git'
```
This patch replaces the hardcoded `.git` paths in order to make `git ignore -p` command work correctly if GIT_DIR has been set to another location.