### PR TITLE
Delete empty gitmodules

### DIFF
--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
 
-test -z "$1" && echo "submodule required" 1>&2 && exit 1
-cd "$(git root)"
-test ! -f .gitmodules && echo ".gitmodules file not found" 1>&2 && exit 2
+abort() {
+	error="$1" && shift
+	echo "FATAL: $*" 1>&2 && exit "$error"
+}
 
-NAME="$(echo "$1" | sed 's/\/$//g')"
-test -z \
-	"$(   git config --file=.gitmodules submodule."$NAME".url)" \
-	   && echo "submodule not found" 1>&2 && exit 3
+test -z "$1"            && abort 1 'Submodule required'
+cd "$(git root)"        || abort 5 'Cannot change to repository root'
+test ! -f '.gitmodules' && abort 2 '.gitmodules file not found'
+
+NAME="${1%/}"
+test -z "$(git config --file='.gitmodules' "submodule.$NAME.url")" \
+	   && abort 3 'Submodule not found'
 
 # 1. Handle the .git directory
 # 1.a. Delete the relevant section from .git/config
-git submodule deinit -f "$NAME" || exit 4
+git submodule deinit -f "$NAME" || abort 4 "Failed to deinitialize $NAME"
 # 1.b. Delete the submodule .git directory
-rm -rf .git/modules/"$NAME"
+rm -rf ".git/modules/$NAME"
 # 1.c. Delete empty submodule directory
 git rm -f "$NAME"
 
 # 2. Handle .gitignore file
 # 2.a. Delete the relevant line from .gitmodules
-git config --file=.gitmodules --remove-section submodule."$NAME"
+git config --file='.gitmodules' --remove-section "submodule.$NAME"
 # 2.b and stage changes
-git add .gitmodules
+git add '.gitmodules'
 # 2.c. Delete empty .gitmodules
 [  "$(wc -l '.gitmodules' | cut -d' ' -f1)" = '0' ] && git rm -f '.gitmodules'
 
@@ -31,7 +35,7 @@ if git submodule status >/dev/null 2>&1 \
 	&& ! git submodule status | grep "$NAME"; then
 	echo "Successfully deleted $NAME."
 else
-	echo "Failed to delete $NAME." 1>&2 && exit 6
+	abort 6 "Failed to delete $NAME."
 fi
 echo
 git submodule status

--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -33,4 +33,8 @@ if git submodule status >/dev/null 2>&1 \
 else
 	echo "Failed to delete $NAME." 1>&2 && exit 6
 fi
-echo 'Confirm with `git submodule status` and commit the changes for yourself.'
+echo
+git submodule status
+echo
+echo 'Confirm the output of `git submodule status` above' \
+	' and commit the changes for yourself.'

--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -6,7 +6,7 @@ abort() {
 	test -z "$FORCE" && exit "$error"
 }
 
-# Don't abort on failures.  This allows to cleanup after a rpevious failure.
+# Don't abort on failures.  This allows to cleanup after a previous failure.
 [ "$1" = '--force' ] && FORCE=1 && shift
 
 test -z "$1"            && abort 1 'Submodule required'
@@ -25,22 +25,27 @@ rm -rf ".git/modules/$NAME"
 # 1.c. Delete empty submodule directory
 git rm -f "$NAME"
 
-# 2. Handle .gitignore file
+# 2. Handle .gitmodules file
 # 2.a. Delete the relevant line from .gitmodules
-git config --file='.gitmodules' --remove-section "submodule.$NAME"
+git config --file='.gitmodules' --remove-section "submodule.$NAME" 2>/dev/null || :
 # 2.b and stage changes
 git add '.gitmodules'
 # 2.c. Delete empty .gitmodules
 [  "$(wc -l '.gitmodules' | cut -d' ' -f1)" = '0' ] && git rm -f '.gitmodules'
 
 # 3. Need to confirm and commit the changes for yourself
-if git submodule status >/dev/null 2>&1 \
-	&& ! git submodule status | grep "$NAME"; then
+git_status_text="$(git submodule status 2>&1)"
+git_status_exit=$?
+if [ "$git_status_exit" -eq 0 ] \
+	&& printf '%s' "DUMMY$git_status_text" | grep -v "$NAME"; then
+
 	echo "Successfully deleted $NAME."
 else
-	abort 6 "Failed to delete $NAME."
+	abort 6 "Failed to delete $NAME with error:\n$git_status_text"
 fi
-echo
-git submodule status
-echo 'Confirm the output of `git submodule status` above' \
-	' and commit the changes for yourself.'
+printf '\n%s\n' '== git submodule status =='
+printf '%s\n'   "$git_status_text"
+printf '%s\n'   '=========================='
+# shellcheck disable=SC2016
+echo 'Confirm the output of `git submodule status` above (if any)' \
+	'and then commit the changes.'

--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -2,8 +2,12 @@
 
 abort() {
 	error="$1" && shift
-	echo "FATAL: $*" 1>&2 && exit "$error"
+	echo "ERROR: $*" 1>&2
+	test -z "$FORCE" && exit "$error"
 }
+
+# Don't abort on failures.  This allows to cleanup after a rpevious failure.
+[ "$1" = '--force' ] && FORCE=1 && shift
 
 test -z "$1"            && abort 1 'Submodule required'
 cd "$(git root)"        || abort 5 'Cannot change to repository root'
@@ -30,7 +34,6 @@ git add '.gitmodules'
 [  "$(wc -l '.gitmodules' | cut -d' ' -f1)" = '0' ] && git rm -f '.gitmodules'
 
 # 3. Need to confirm and commit the changes for yourself
-echo
 if git submodule status >/dev/null 2>&1 \
 	&& ! git submodule status | grep "$NAME"; then
 	echo "Successfully deleted $NAME."
@@ -39,6 +42,5 @@ else
 fi
 echo
 git submodule status
-echo
 echo 'Confirm the output of `git submodule status` above' \
 	' and commit the changes for yourself.'

--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -6,8 +6,8 @@ test ! -f .gitmodules && echo ".gitmodules file not found" 1>&2 && exit 2
 
 NAME="$(echo "$1" | sed 's/\/$//g')"
 test -z \
-    "$(git config --file=.gitmodules submodule."$NAME".url)" \
-    && echo "submodule not found" 1>&2 && exit 3
+	"$(   git config --file=.gitmodules submodule."$NAME".url)" \
+	   && echo "submodule not found" 1>&2 && exit 3
 
 # 1. Delete the relevant section from .git/config and clean submodule files
 git submodule deinit -f "$NAME" || exit 4
@@ -16,6 +16,8 @@ rm -rf .git/modules/"$NAME"
 # 2. Delete the relevant line from .gitmodules
 git config --file=.gitmodules --remove-section submodule."$NAME"
 git add .gitmodules
+# 2.a Delete empty .gitmodules
+[  "$(wc -l '.gitmodules' | cut -d' ' -f1)" = '0' ] && git rm -f '.gitmodules'
 # 3. Run git rm --cached path_to_submodule
 git rm --cached -rf "$NAME"
 # 4. Need to confirm and commit the changes for yourself

--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -9,18 +9,23 @@ test -z \
 	"$(   git config --file=.gitmodules submodule."$NAME".url)" \
 	   && echo "submodule not found" 1>&2 && exit 3
 
-# 1. Delete the relevant section from .git/config and clean submodule files
+# 1. Handle the .git directory
+# 1.a. Delete the relevant section from .git/config
 git submodule deinit -f "$NAME" || exit 4
-rmdir "$NAME"
+# 1.b. Delete the submodule .git directory
 rm -rf .git/modules/"$NAME"
-# 2. Delete the relevant line from .gitmodules
+# 1.c. Delete empty submodule directory
+git rm -f "$NAME"
+
+# 2. Handle .gitignore file
+# 2.a. Delete the relevant line from .gitmodules
 git config --file=.gitmodules --remove-section submodule."$NAME"
+# 2.b and stage changes
 git add .gitmodules
-# 2.a Delete empty .gitmodules
+# 2.c. Delete empty .gitmodules
 [  "$(wc -l '.gitmodules' | cut -d' ' -f1)" = '0' ] && git rm -f '.gitmodules'
-# 3. Run git rm --cached path_to_submodule
-git rm --cached -rf "$NAME"
-# 4. Need to confirm and commit the changes for yourself
+
+# 3. Need to confirm and commit the changes for yourself
 echo
 echo "Now submodule $NAME is deleted."
 echo 'Confirm with `git submodule status` and commit the changes for yourself.'

--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -27,5 +27,10 @@ git add .gitmodules
 
 # 3. Need to confirm and commit the changes for yourself
 echo
-echo "Now submodule $NAME is deleted."
+if git submodule status >/dev/null 2>&1 \
+	&& ! git submodule status | grep "$NAME"; then
+	echo "Successfully deleted $NAME."
+else
+	echo "Failed to delete $NAME." 1>&2 && exit 6
+fi
 echo 'Confirm with `git submodule status` and commit the changes for yourself.'

--- a/bin/git-delete-submodule
+++ b/bin/git-delete-submodule
@@ -37,7 +37,8 @@ git add '.gitmodules'
 git_status_text="$(git submodule status 2>&1)"
 git_status_exit=$?
 if [ "$git_status_exit" -eq 0 ] \
-	&& printf '%s' "DUMMY$git_status_text" | grep -v "$NAME"; then
+    && printf '%s' "DUMMY$git_status_text" | grep -v "$NAME" > /dev/null; then
+    #  grep fails when piping in an empty string, so we add a DUMMY prefix
 
 	echo "Successfully deleted $NAME."
 else


### PR DESCRIPTION
- Handle case where this is the first submodule, so it leaves the git repository as it was before.
- Handle case where this is the last submodule.
- Check before declaring victory.
- Code reformatting and re-organization. 
- Added option to continue on error to allow cleaning up failed deletions.

NOTE: Not validated on Mac OS X and BSD.