### PR TITLE
Signed release

### DIFF
--- a/bin/git-release
+++ b/bin/git-release
@@ -34,6 +34,17 @@ if test $# -gt 0; then
     -c) need_changelog=true;;
     -r) remote=$2; shift ;;
     -m) msg=$2; shift ;;
+    -s)
+      test -n "$keyid" &&
+          exit_with_msg "Please use '-s' OR '-u'"
+      sign=true
+      ;;
+    -u)
+      test -n "$sign" &&
+          exit_with_msg "Please use '-s' OR '-u'"
+      keyid=$2
+      shift
+      ;;
     --semver)
       test -z "$2" &&
           exit_with_msg "major/minor/patch required for --semver option"
@@ -101,8 +112,17 @@ if test $# -gt 0; then
     git commit -a -m "$msg" --allow-empty
   fi
 
+  declare -a sign_args
+  if [ "$sign" == true ]; then
+    sign_args=("-s")
+  fi
+
+  if [ -n "$keyid" ]; then
+    sign_args=("-u" "$keyid")
+  fi
+
   # shellcheck disable=SC2086
-  git tag $version -a -m "$msg" \
+  git tag "${sign_args[@]}" $version -a -m "$msg" \
     && git push $remote --tags \
     && git push $remote \
     && hook post-release $hook_args \

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -429,6 +429,17 @@ _git-summary() {
     __gitex_commits
 }
 
+_git-release() {
+    _arguments -C \
+        '-c[Generates/populates the changelog with all commit message since the last tag.]'
+        '-r[The "remote" repository that is destination of a push operation.]'
+        '-m[use the custom commit information instead of the default message.]'
+        '-s[Create a signed and annotated tag.]'
+        '-u[Create a tag, annotated and signed with the given key.]'
+        '--semver[If the latest tag in your repo matches the semver format requirement, you could increase part of it as the new release tag.]'
+        '--no-empty-commit[Avoid creating empty commit if nothing could be committed.]'
+        '--[The arguments listed after "--" separator will be passed to pre/post-release hook.]'
+}
 
 _git-undo(){
     _arguments  -C \

--- a/man/git-release.1
+++ b/man/git-release.1
@@ -7,7 +7,7 @@
 \fBgit\-release\fR \- Commit, tag and push changes to the repository
 .
 .SH "SYNOPSIS"
-\fBgit\-release\fR [<tagname> | \-\-semver <name>] [\-r <remote>] [\-m <commit info>] [\-\-no\-empty\-commit] [\-c] [[\-\-] <hook arguments\.\.\.>]
+\fBgit\-release\fR [<tagname> | \-\-semver <name>] [\-r <remote>] [\-m <commit info>] [\-\-no\-empty\-commit] [\-c] [\-s] [\-u <key-id>] [[\-\-] <hook arguments\.\.\.>]
 .
 .SH "DESCRIPTION"
 Commits changes with message "Release <tagname>" or custom commit information, tags with the given <tagname> and pushes the branch / tags\.
@@ -56,6 +56,18 @@ Avoid creating empty commit if nothing could be committed\.
 .
 .P
 Generates or populates the changelog with all commit message since the last tag\. For more info see git\-changelog\.\.
+.
+.P
+\-s
+.
+.P
+Create a signed and annotated tag\.
+.
+.P
+\-u <key ID>
+.
+.P
+Create a tag, annotated and signed with the given key\.
 .
 .P
 [\-\-] hook arguments\.\.\.

--- a/man/git-release.html
+++ b/man/git-release.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-release</code> [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [[--] &lt;hook arguments...&gt;]</p>
+<p><code>git-release</code> [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [-s] [-u &lt;key-id&gt;] [[--] &lt;hook arguments...&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -115,6 +115,14 @@
 <p>  -c</p>
 
 <p>  Generates or populates the changelog with all commit message since the last tag. For more info see git-changelog..</p>
+
+<p>  -s</p>
+
+<p>  Create a signed and annotated tag.</p>
+
+<p>  -u &lt;key-id&gt;</p>
+
+<p>  Create a tag, annotated and signed with the given key.</p>
 
 <p>  [--] hook arguments...</p>
 

--- a/man/git-release.md
+++ b/man/git-release.md
@@ -3,7 +3,7 @@ git-release(1) -- Commit, tag and push changes to the repository
 
 ## SYNOPSIS
 
-`git-release` [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [[--] &lt;hook arguments...&gt;]
+`git-release` [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [-s] [-u &lt;key-id&gt;] [[--] &lt;hook arguments...&gt;]
 
 ## DESCRIPTION
 
@@ -42,6 +42,14 @@ git-release(1) -- Commit, tag and push changes to the repository
   -c
 
   Generates or populates the changelog with all commit message since the last tag. For more info see git-changelog..
+
+  -s
+
+  Create a signed and annotated tag.
+
+  -u &lt;key-id&gt;
+
+  Create a tag, annotated and signed with the given key.
 
   [--] hook arguments...
 


### PR DESCRIPTION
This PR adds support for gpg signed tags for the `git-release` command

```git release -s 1```

Will generate a tag `1` signed by the default gpg key

```git release -u key-id 1```

Will generate a tag `1` signed by `key-id`