### PR TITLE
Separate bulk projects

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -253,12 +253,20 @@ $ git effort bin/* lib/*
 
 ```bash
 usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>
+       git bulk --addproject <project-name>
        git bulk --addworkspace <ws-name> <ws-root-directory>
        git bulk --removeworkspace <ws-name>
        git bulk --addcurrent <ws-name>
        git bulk --purge
        git bulk --listall
 ```
+
+  Add a project name to current repository so that related workspaces can be separated by it:
+
+```bash
+$ git bulk --addproject myproject
+```
+✓ *When adding a workspace, the name of the parent directory will be suggested as the project name if it's not defined yet*
 
   Register a workspace so that `git bulk` knows about it (notice that <ws-root-directory> must be absolute path):
 

--- a/Commands.md
+++ b/Commands.md
@@ -252,7 +252,7 @@ $ git effort bin/* lib/*
   * use the "guarded mode" to check on each execution
 
 ```bash
-usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>
+usage: git bulk [-g] ([-a]|[-p <project-name>]|[-w <ws-name>]) <git command>
        git bulk --addproject <project-name>
        git bulk --addworkspace <ws-name> <ws-root-directory>
        git bulk --removeworkspace <ws-name>
@@ -278,10 +278,10 @@ $ git bulk --addworkspace personal ~/workspaces/personal
 $ git bulk --addcurrent personal
 ```
 
-  List all registered workspaces:
+  List all registered workspaces (Optional filter by <project-name>):
 
 ```bash
-$ git bulk --listall
+$ git bulk --listall [<project-name>]
 bulkws-myproject.personal /Users/niklasschlimm/workspaces/personal
 ```
 
@@ -304,6 +304,12 @@ $ git bulk -w personal fetch
 ```bash
 $ git bulk -a fetch
 ```
+ 
+ Run a git command on all workspaces of a sepcific project and their repositories:
+
+```bash
+$ git bulk -p myproject fetch
+```
 
   Run a git command but ask user for confirmation on every execution (guarded mode):
 
@@ -316,10 +322,10 @@ $ git bulk -g fetch
 ```bash
 $ git bulk --removeworkspace personal
 ```
-  Remove all registered workspaces:
+  Remove all registered workspaces (Or of a specific project):
 
 ```bash
-$ git bulk --purge
+$ git bulk --purge [<project-name>]
 ```
 
 ## git repl

--- a/Commands.md
+++ b/Commands.md
@@ -247,7 +247,7 @@ $ git effort bin/* lib/*
 
 `git bulk` adds convenient support for operations that you want to execute on multiple git repositories.
 
-  * simply register workspaces that contain multiple git repos in their directory structure
+  * simply define a unique project name for all related git repositories then register them as workspaces for bulk git operations
   * run any git command on the repositories of the registered workspaces in one command to `git bulk`
   * use the "guarded mode" to check on each execution
 
@@ -266,8 +266,6 @@ usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>
 ```bash
 $ git bulk --addproject myproject
 ```
-✓ *When adding a workspace, the name of the parent directory will be suggested as the project name if it's not defined yet*
-
   Register a workspace so that `git bulk` knows about it (notice that <ws-root-directory> must be absolute path):
 
 ```bash
@@ -284,10 +282,10 @@ $ git bulk --addcurrent personal
 
 ```bash
 $ git bulk --listall
-bulkworkspaces.personal /Users/niklasschlimm/workspaces/personal
+bulkws-myproject.personal /Users/niklasschlimm/workspaces/personal
 ```
 
-  Run a git command on the repositories of the current workspace:
+  Run a git command on the repositories of the current project:
 
 ```bash
 $ git bulk fetch

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -22,7 +22,7 @@ usage() {
 }
 
 # add project name to current repository
-function addproject { git config --local --add project.name "$projectname"; }
+function addproject { git config --local --replace-all project.name "$projectname"; }
 
 # add another workspace to global git config
 function addworkspace { git config --global bulkworkspaces."$wsname" "$wsdir"; }

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -58,13 +58,13 @@ function addworkspace {
 function addcurrent { wsdir=$(git root); addworkspace; }
 
 # remove workspace from global git config
-function removeworkspace { checkWSName && git config --global --unset bulkworkspaces."$wsname"; }
+function removeworkspace { checkWSName && git config --global --unset bulkws-$(getproject)."$wsname"; }
 
 # remove workspace from global git config
-function purge { git config --global --remove-section bulkworkspaces; }
+function purge { git config --global --remove-section bulkws-$(getproject); }
 
 # list all current workspace locations defined
-function listall { git config --global --get-regexp ${getproject}; }
+function listall { git config --global --get-regexp bulkws-$(getproject); }
 
 # guarded execution of a git command in one specific repository
 function guardedExecution () {

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -20,6 +20,7 @@ usage() {
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
   echo 1>&2 "       git bulk --purge"
   echo 1>&2 "       git bulk --listall"
+  echo 1>&2 "       git bulk --listcurrent"
 }
 
 function to_lowercase { echo $1 | tr [:upper:] [:lower:]; }
@@ -32,9 +33,11 @@ function addproject { git config --local --replace-all project.name $(to_lowerca
 
 # add another workspace to global git config
 function addworkspace {
+	current=$(pwd)
+	cd $wsdir
 	project=$(getproject)
 	if [ -z $project ]; then
-		echo -n "no project name is defined, "
+		echo -n "no project name is defined in this path, "
 		local project=$(to_lowercase $(basename $(dirname $(git root))))
 		local prompt="\e[1m\e[4m$project\e[0m"
 		while true; do
@@ -42,7 +45,8 @@ function addworkspace {
 			case $answer in
 				[Yy])
 					addproject $project
-					sleep 0.3; echo -e "project is called \e[1m$project\e[0m now."
+					cd "$current"
+					sleep 0.1; echo -e "project is called \e[1m$project\e[0m now."
 					break;;
 				[Nn])
 					echo -e "\e[1m\e[31m!\e[0m add a project name first."; usage; exit;;

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -13,7 +13,7 @@ allwsmode=false
 # print usage message
 #
 usage() {
-  echo 1>&2 "usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>"
+  echo 1>&2 "usage: git bulk [-g] ([-a]|[-p <project-name>]|[-w <ws-name>]) <git command>"
   echo 1>&2 "       git bulk --addproject <project-name>"
   echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory>"
   echo 1>&2 "       git bulk --removeworkspace <ws-name>"
@@ -46,7 +46,7 @@ function addworkspace {
 				[Yy])
 					addproject $project
 					cd "$current"
-					sleep 0.1; echo -e "project is called \e[1m$project\e[0m now."
+					echo -e "project is called \e[1m$project\e[0m now."
 					break;;
 				[Nn])
 					echo -e "\e[1m\e[31m!\e[0m add a project name first."; usage; exit;;
@@ -153,7 +153,7 @@ function allowedargcount {
 function executBulkOp () {
   checkGitCommand
   if ! $allwsmode && ! $singlemode; then wsnameToCurrent; fi # by default git bulk works within the 'current' workspace
-  listall | while read workspacespec; do
+  listall $project | while read workspacespec; do
     parseWsName "$workspacespec"
     if [[ -n $wsname ]] && [[ $rwsname != "$wsname" ]]; then continue; fi
     eval cd "\"$rwsdir\""
@@ -189,6 +189,8 @@ while [ "${#}" -ge 1 ] ; do
       guardedmode=true ;;
     -w) 
       singlemode=true && shift && wsname="$1" && checkWSName ;;
+    -p) 
+      allwsmode=true && shift && project="$1" ;;
     -*) 
       usage && echo 1>&2 "error: unknown argument $1" && exit 1 ;;
     --*) 

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -73,7 +73,7 @@ function purge {
 	}
 
 # list all current workspace locations defined
-function listall { git config --global --get-regexp bulkws-$(getproject); }
+function listall { git config --global --get-regexp bulkws-*; }
 
 # guarded execution of a git command in one specific repository
 function guardedExecution () {

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -61,8 +61,16 @@ function addcurrent { wsdir=$(git root); addworkspace; }
 # remove workspace from global git config
 function removeworkspace { checkWSName && git config --global --unset bulkws-$(getproject)."$wsname"; }
 
-# remove workspace from global git config
-function purge { git config --global --remove-section bulkws-$(getproject); }
+# remove workspace from global git config and remove local project name
+function purge {
+	project=$(getproject)
+	if [ -z $project ]; then
+		echo "error: project name not found"
+	else
+		git config --global --remove-section bulkws-$project
+		git config --local --remove-section project
+	fi
+	}
 
 # list all current workspace locations defined
 function listall { git config --global --get-regexp bulkws-$(getproject); }

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -14,6 +14,7 @@ allwsmode=false
 #
 usage() {
   echo 1>&2 "usage: git bulk [-g] ([-a]|[-w <ws-name>]) <git command>"
+  echo 1>&2 "       git bulk --addproject <project-name>"
   echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory>"
   echo 1>&2 "       git bulk --removeworkspace <ws-name>"
   echo 1>&2 "       git bulk --addcurrent <ws-name>"

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -22,8 +22,9 @@ usage() {
   echo 1>&2 "       git bulk --listall"
 }
 
-to_lowercase() { echo $1 | tr [:upper:] [:lower:]; }
+function to_lowercase { echo $1 | tr [:upper:] [:lower:]; }
 
+# helper to get project name
 function getproject { git config --local --get project.name; }
 
 # add project name to current repository, used to separate workspaces in global git config
@@ -125,8 +126,10 @@ function wsnameToCurrent () {
 }
 
 # helper to check number of arguments
-function allowedargcount () {
-  ( test "$paramcount" -ne "$1" ) && ( usage && echo 1>&2 "error: wrong number of arguments" && exit 1 ) 
+function allowedargcount { if test "$paramcount" -ne $1; then
+	echo 1>&2 "error: wrong number of arguments" && usage
+	exit 1;
+fi
 }
 
 # execute the bulk operation

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -25,10 +25,16 @@ usage() {
 function addproject { git config --local --replace-all project.name "$projectname"; }
 
 # add another workspace to global git config
-function addworkspace { git config --global bulkworkspaces."$wsname" "$wsdir"; }
+function addworkspace {
+	projectname=$(git config --local --get project.name)
+	if [ -z $projectname ]; then
+		projectname=$(basename $(dirname $(git root)))
+		addproject $projectname
+	fi
+	git config --global "bulkws"."$projectname"."$wsname" "$wsdir";}
 
 # add current directory
-function addcurrent { git config --global bulkworkspaces."$wsname" "$PWD"; }
+function addcurrent { wsdir=$(git root); addworkspace; }
 
 # remove workspace from global git config
 function removeworkspace { checkWSName && git config --global --unset bulkworkspaces."$wsname"; }
@@ -37,7 +43,7 @@ function removeworkspace { checkWSName && git config --global --unset bulkworksp
 function purge { git config --global --remove-section bulkworkspaces; }
 
 # list all current workspace locations defined
-function listall { git config --global --get-regexp bulkworkspaces; }
+function listall { git config --global --get-regexp $projectname; }
 
 # guarded execution of a git command in one specific repository
 function guardedExecution () {
@@ -133,7 +139,7 @@ if [[ $paramcount -le 0 ]]; then usage; fi
 while [ "${#}" -ge 1 ] ; do
   case "$1" in
     --addproject)
-      butilcommand="${1:2}" && projectname="$2" && break&& break ;;
+      butilcommand="${1:2}" && projectname="$2" && break ;;
     --listall|--purge)
       butilcommand="${1:2}" && break ;;
     --removeworkspace|--addcurrent|--addworkspace)

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -21,6 +21,9 @@ usage() {
   echo 1>&2 "       git bulk --listall"
 }
 
+# add project name to current repository
+function addproject { git config --local --add project.name "$projectname"; }
+
 # add another workspace to global git config
 function addworkspace { git config --global bulkworkspaces."$wsname" "$wsdir"; }
 
@@ -129,6 +132,8 @@ if [[ $paramcount -le 0 ]]; then usage; fi
 # parse command parameters
 while [ "${#}" -ge 1 ] ; do
   case "$1" in
+    --addproject)
+      butilcommand="${1:2}" && projectname="$2" && break&& break ;;
     --listall|--purge)
       butilcommand="${1:2}" && break ;;
     --removeworkspace|--addcurrent|--addworkspace)

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -21,17 +21,37 @@ usage() {
   echo 1>&2 "       git bulk --listall"
 }
 
-# add project name to current repository
-function addproject { git config --local --replace-all project.name "$projectname"; }
+to_lowercase() { echo $1 | tr [:upper:] [:lower:]; }
+
+function getproject { git config --local --get project.name; }
+
+# add project name to current repository, used to separate workspaces in global git config
+function addproject { git config --local --replace-all project.name $(to_lowercase $project); }
 
 # add another workspace to global git config
 function addworkspace {
-	projectname=$(git config --local --get project.name)
-	if [ -z $projectname ]; then
-		projectname=$(basename $(dirname $(git root)))
-		addproject $projectname
+	project=$(getproject)
+	if [ -z $project ]; then
+		echo -n "no project name is defined, "
+		local project=$(to_lowercase $(basename $(dirname $(git root))))
+		local prompt="\e[1m\e[4m$project\e[0m"
+		while true; do
+			read -p "should it be called $(echo -e $prompt)? [y/n]: " answer
+			case $answer in
+				[Yy])
+					addproject $project
+					sleep 0.3; echo -e "project is called \e[1m$project\e[0m now."
+					break;;
+				[Nn])
+					echo -e "\e[1m\e[31m!\e[0m add a project name first."; usage; exit;;
+				* )	echo -e "please answer with \e[1my\e[0m or \e[1mn\e[0m"; continue;
+			esac
+			break
+		done
 	fi
-	git config --global "bulkws"."$projectname"."$wsname" "$wsdir";}
+	git config --global "bulkws-$project"."$wsname" "$wsdir"
+	
+}
 
 # add current directory
 function addcurrent { wsdir=$(git root); addworkspace; }
@@ -43,7 +63,7 @@ function removeworkspace { checkWSName && git config --global --unset bulkworksp
 function purge { git config --global --remove-section bulkworkspaces; }
 
 # list all current workspace locations defined
-function listall { git config --global --get-regexp $projectname; }
+function listall { git config --global --get-regexp ${getproject}; }
 
 # guarded execution of a git command in one specific repository
 function guardedExecution () {
@@ -139,7 +159,7 @@ if [[ $paramcount -le 0 ]]; then usage; fi
 while [ "${#}" -ge 1 ] ; do
   case "$1" in
     --addproject)
-      butilcommand="${1:2}" && projectname="$2" && break ;;
+      butilcommand="${1:2}" && project="$2" && break ;;
     --listall|--purge)
       butilcommand="${1:2}" && break ;;
     --removeworkspace|--addcurrent|--addworkspace)

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -200,7 +200,7 @@ if $singlemode; then echo "Selected single workspace mode in workspace: $wsname"
 # check right number of arguments
 case $butilcommand in
   listall|purge) allowedargcount 1;;
-  addcurrent|removeworkspace) allowedargcount 2;;
+  addproject|addcurrent|removeworkspace) allowedargcount 2;;
   addworkspace) allowedargcount 3;;
 esac
 

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -18,9 +18,8 @@ usage() {
   echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory>"
   echo 1>&2 "       git bulk --removeworkspace <ws-name>"
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
-  echo 1>&2 "       git bulk --purge"
-  echo 1>&2 "       git bulk --listall"
-  echo 1>&2 "       git bulk --listcurrent"
+  echo 1>&2 "       git bulk --purge [<project-name>]"
+  echo 1>&2 "       git bulk --listall [<project-name>]"
 }
 
 function to_lowercase { echo $1 | tr [:upper:] [:lower:]; }
@@ -34,6 +33,7 @@ function addproject { git config --local --replace-all project.name $(to_lowerca
 # add another workspace to global git config
 function addworkspace {
 	current=$(pwd)
+	if [ ! -d $wsdir ]; then echo 1>&2 "error: $wsdir is not a valid path"; exit 1; fi
 	cd $wsdir
 	project=$(getproject)
 	if [ -z $project ]; then
@@ -67,17 +67,21 @@ function removeworkspace { checkWSName && git config --global --unset bulkws-$(g
 
 # remove workspace from global git config and remove local project name
 function purge {
-	project=$(getproject)
 	if [ -z $project ]; then
-		echo "error: project name not found"
+		git config --global --remove-section bulkws-*
 	else
 		git config --global --remove-section bulkws-$project
-		git config --local --remove-section project
 	fi
 	}
 
-# list all current workspace locations defined
-function listall { git config --global --get-regexp bulkws-*; }
+# list all workspace locations defined
+function listall { 
+	if [ -z $project ]; then
+		git config --global --get-regexp bulkws-*
+	else
+		git config --global --get-regexp "bulkws-$project"
+	fi
+}
 
 # guarded execution of a git command in one specific repository
 function guardedExecution () {
@@ -138,10 +142,11 @@ function wsnameToCurrent () {
 }
 
 # helper to check number of arguments
-function allowedargcount { if test "$paramcount" -ne $1; then
-	echo 1>&2 "error: wrong number of arguments" && usage
-	exit 1;
-fi
+function allowedargcount { 
+	if [[ $paramcount -lt $1 || $paramcount -gt $2 ]]; then
+		echo 1>&2 "error: wrong number of arguments" && usage
+		exit 1;
+	fi
 }
 
 # execute the bulk operation
@@ -174,10 +179,8 @@ if [[ $paramcount -le 0 ]]; then usage; fi
 # parse command parameters
 while [ "${#}" -ge 1 ] ; do
   case "$1" in
-    --addproject)
+    --addproject|--listall|--purge)
       butilcommand="${1:2}" && project="$2" && break ;;
-    --listall|--purge)
-      butilcommand="${1:2}" && break ;;
     --removeworkspace|--addcurrent|--addworkspace)
       butilcommand="${1:2}" && wsname="$2" && wsdir="$3" && break ;;
     -a) 
@@ -203,9 +206,9 @@ if $singlemode; then echo "Selected single workspace mode in workspace: $wsname"
 
 # check right number of arguments
 case $butilcommand in
-  listall|purge) allowedargcount 1;;
-  addproject|addcurrent|removeworkspace) allowedargcount 2;;
-  addworkspace) allowedargcount 3;;
+	listall|purge) allowedargcount 1 2;;
+	addproject|addcurrent|removeworkspace) allowedargcount 2 2;;
+	addworkspace) allowedargcount 3 3;;
 esac
 
 $butilcommand # run user command


### PR DESCRIPTION
`git-bulk` as it is now, does not support working on more than one project with multiple repositories simultaneously. Purging and adding all workspaces (repositories) has to be done whenever you'd need to switch between two projects, since all workspaces are added to global git config under the same section.

With the following changes each repository can keep a project name in its own local git config and based on that name there will be a new bulkws-section in the global config with which the list of repositories can be filtered at the time of bulk operations. Adding project name can be done directly via new function (in the git work tree) or interactively while adding workspace if not defined. Purging does also delete the local project name.