### PR TITLE
fix bug in allowedargcount() to not execute command if wrong args count

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -95,8 +95,11 @@ function wsnameToCurrent () {
 }
 
 # helper to check number of arguments
-function allowedargcount () {
-  ( test "$paramcount" -ne "$1" ) && ( usage && echo 1>&2 "error: wrong number of arguments" && exit 1 ) 
+function allowedargcount {
+    if test "$paramcount" -ne $1; then
+        echo 1>&2 "error: wrong number of arguments" && usage
+        exit 1;
+    fi
 }
 
 # execute the bulk operation


### PR DESCRIPTION
This fix is taken from #800.
I did a little modification to resolve conflict.
Thanks @roxchgt for the fix.