### PR TITLE
git-ignore: support non-default .git directory

### DIFF
--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-: ${GIT_DIR:=.git}
+: ${GIT_DIR:=$(git rev-parse --git-dir)}
 
 function show_contents {
   local file="${2/#~/$HOME}"


### PR DESCRIPTION
useful for submodules.

Closes tj/git-extras#807

I'm sorry I don't have much time to test this.

Following CONTRIBUTING.md :
* I cannot test on OSX nor BSD
* I don't know how to check on bash 3.2 that this is valid
* OK for `git 2.1+`