### PR TITLE
build: do not require the nonstandard and unpredictable 'which' utility

### DIFF
--- a/check_dependencies.sh
+++ b/check_dependencies.sh
@@ -5,6 +5,6 @@ err() {
     exit 1
 }
 
-if ! test "$(which column)"; then
+if ! command -v column >/dev/null 2>&1; then
     err "Need to install dependency 'column' before installation"
 fi


### PR DESCRIPTION
This may not be installed on various systems, and it's difficult to test for the availability of the tool you need, if the check program itself does not exist.

The POSIX 2008 specification mandates the `command -v` builtin; bash is a POSIX 2008 compliant shell, and this builtin has worked since bash 1.x anyway.

A side benefit of using the POSIX portable option is that it requires neither an external disk executable, nor (because unlike "which", the exit code is reliable) a subshell fork. This therefore represents a mild speedup.