### PR TITLE
feat(git-clear): add --force and --help flags

### DIFF
--- a/bin/git-clear
+++ b/bin/git-clear
@@ -1,7 +1,52 @@
 #!/usr/bin/env bash
 
-echo -n "Sure? - This command may delete files that cannot be recovered, including those in .gitignore [y/N]: "
-read ans
-if [ "$ans" == "y" ] 
-    then git clean -d -f -x && git reset --hard
+_usage() {
+PROGNAME="git-clear"
+
+cat << EOF
+usage: $PROGNAME [<options>]
+
+Clears the repository to a state that it looks as if it was freshly cloned
+with the current HEAD. Basically it is a git-reset --hard together with
+deletion of all untracked files that reside inside the working directory, including those in .gitignore.
+
+
+OPTIONS:
+    -f, --force               Don't prompt for confirmation to clear
+    -h, --help                Show this message
+
+EOF
+}
+
+
+FORCE=0
+
+while [ "X$1" != "X" ]; do
+	case $1 in
+		-f|--force)
+      FORCE=1
+      shift
+    ;;
+
+    -h|--help|help)
+      _usage
+      exit 0
+    ;;
+	esac
+	shift
+done
+
+
+if [[ $FORCE == 0 ]]; then
+  echo -n "Sure? - This command may delete files that cannot be recovered, including those in .gitignore [y/N]: "
+  read ans
+
+  if [[ "$ans" == "y"  ]]; then
+    FORCE=1
+  fi
+fi
+
+
+if [[ $FORCE == 1  ]]; then
+  git clean -d -f -x && git reset --hard
 fi

--- a/bin/git-clear-soft
+++ b/bin/git-clear-soft
@@ -1,7 +1,51 @@
 #!/usr/bin/env bash
 
-echo -n "Sure? - This command may delete files that cannot be recovered. Files and directories in .gitignore will be preserved [y/N]: "
-read ans
-if [ "$ans" == "y" ] 
-    then git clean -d -f && git reset --hard
+_usage() {
+PROGNAME="git-clear-soft"
+
+cat << EOF
+usage: $PROGNAME [<options>]
+
+Clears the repository to a state that it looks as if it was freshly cloned
+with the current HEAD, however, preserving all changes that are located in files and directories listed in .gitignore. It is a git-reset --hard together with
+deletion of all untracked files that reside inside the working directory, excluding those in .gitignore.
+
+OPTIONS:
+    -f, --force               Don't prompt for confirmation to clear
+    -h, --help                Show this message
+
+EOF
+}
+
+
+FORCE=0
+
+while [ "X$1" != "X" ]; do
+	case $1 in
+		-f|--force)
+      FORCE=1
+      shift
+    ;;
+
+    -h|--help|help)
+      _usage
+      exit 0
+    ;;
+	esac
+	shift
+done
+
+
+if [[ $FORCE == 0 ]]; then
+  echo -n "Sure? - This command may delete files that cannot be recovered. Files and directories in .gitignore will be preserved [y/N]: "
+  read ans
+
+  if [[ "$ans" == "y"  ]]; then
+    FORCE=1
+  fi
+fi
+
+
+if [[ $FORCE == 1  ]]; then
+  git clean -d -f && git reset --hard
 fi

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -158,3 +158,29 @@ _git_undo(){
 _git_browse(){
   __git_complete_remote_or_refspec
 }
+
+_git_clear(){
+  local s_opts=( '-h' '-f' )
+  local l_opts=(
+    '--force'
+    '--help'
+  )
+  local merged_opts_str=""
+  merged_opts_str+="$(printf "%s " "${s_opts[@]}")"
+  merged_opts_str+="$(printf "%s " "${l_opts[@]}")"
+
+  __gitcomp "$merged_opts_str"
+}
+
+_git_clear_soft(){
+  local s_opts=( '-h' '-f' )
+  local l_opts=(
+    '--force'
+    '--help'
+  )
+  local merged_opts_str=""
+  merged_opts_str+="$(printf "%s " "${s_opts[@]}")"
+  merged_opts_str+="$(printf "%s " "${l_opts[@]}")"
+
+  __gitcomp "$merged_opts_str"
+}

--- a/man/git-clear-soft.1
+++ b/man/git-clear-soft.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-CLEAR\-SOFT" "1" "October 2017" "" "Git Extras"
+.TH "GIT\-CLEAR\-SOFT" "1" "April 2020" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-clear\-soft\fR \- Soft clean up a repository
@@ -11,6 +11,18 @@
 .
 .SH "DESCRIPTION"
 Clears the repository to a state that it looks as if it was freshly cloned with the current HEAD, however, preserving all changes that are located in files and directories listed in \.gitignore\. It is a git\-reset \-\-hard together with deletion of all untracked files that reside inside the working directory, excluding those in \.gitignore\.
+.
+.SH "OPTIONS"
+\-f, \-\-force
+.
+.P
+Don\'t prompt for confirmation to clear
+.
+.P
+\-h, \-\-help
+.
+.P
+Show a help message with basic usage information\.
 .
 .SH "EXAMPLES"
 Clears the repo\.

--- a/man/git-clear-soft.html
+++ b/man/git-clear-soft.html
@@ -56,6 +56,7 @@
     <a href="#NAME">NAME</a>
     <a href="#SYNOPSIS">SYNOPSIS</a>
     <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
     <a href="#EXAMPLES">EXAMPLES</a>
     <a href="#AUTHOR">AUTHOR</a>
     <a href="#REPORTING-BUGS">REPORTING BUGS</a>
@@ -83,6 +84,16 @@
   with the current HEAD, however, preserving all changes that are located in files and directories listed in .gitignore. It is a git-reset --hard together with
   deletion of all untracked files that reside inside the working directory, excluding those in .gitignore.</p>
 
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -f, --force</p>
+
+<p>  Don't prompt for confirmation to clear</p>
+
+<p>  -h, --help</p>
+
+<p>  Show a help message with basic usage information.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <p>  Clears the repo.</p>
@@ -92,7 +103,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Modified version of script written by Daniel 'grindhold' Brendle &lt;<a href="&#x6d;&#x61;&#x69;&#x6c;&#x74;&#111;&#58;&#x67;&#x72;&#x69;&#x6e;&#100;&#x68;&#x6f;&#x6c;&#x64;&#x40;&#x67;&#x6d;&#x78;&#x2e;&#x6e;&#101;&#116;" data-bare-link="true">&#x67;&#x72;&#105;&#x6e;&#x64;&#104;&#x6f;&#108;&#x64;&#64;&#x67;&#109;&#120;&#x2e;&#x6e;&#x65;&#116;</a>&gt; by Matiss Treinis &lt;<a href="&#x6d;&#97;&#105;&#108;&#x74;&#x6f;&#x3a;&#x6d;&#x72;&#116;&#114;&#101;&#x69;&#x6e;&#x69;&#115;&#x40;&#103;&#x6d;&#x61;&#x69;&#108;&#x2e;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#109;&#x72;&#x74;&#x72;&#x65;&#105;&#x6e;&#x69;&#115;&#x40;&#x67;&#x6d;&#97;&#105;&#x6c;&#46;&#99;&#111;&#x6d;</a>&gt;</p>
+<p>Modified version of script written by Daniel 'grindhold' Brendle &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#x6f;&#58;&#x67;&#114;&#x69;&#x6e;&#100;&#104;&#x6f;&#108;&#100;&#64;&#103;&#x6d;&#x78;&#x2e;&#110;&#101;&#x74;" data-bare-link="true">&#103;&#114;&#x69;&#x6e;&#100;&#x68;&#111;&#x6c;&#x64;&#x40;&#x67;&#x6d;&#120;&#46;&#110;&#101;&#x74;</a>&gt; by Matiss Treinis &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#x3a;&#x6d;&#x72;&#x74;&#114;&#x65;&#x69;&#110;&#x69;&#x73;&#x40;&#103;&#x6d;&#97;&#105;&#108;&#x2e;&#x63;&#x6f;&#109;" data-bare-link="true">&#x6d;&#x72;&#x74;&#x72;&#101;&#x69;&#x6e;&#105;&#115;&#64;&#103;&#x6d;&#x61;&#x69;&#108;&#x2e;&#99;&#x6f;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -105,7 +116,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>April 2020</li>
     <li class='tr'>git-clear-soft(1)</li>
   </ol>
 

--- a/man/git-clear-soft.md
+++ b/man/git-clear-soft.md
@@ -11,6 +11,16 @@ git-clear-soft(1) -- Soft clean up a repository
   with the current HEAD, however, preserving all changes that are located in files and directories listed in .gitignore. It is a git-reset --hard together with
   deletion of all untracked files that reside inside the working directory, excluding those in .gitignore.
 
+## OPTIONS
+
+  -f, --force
+
+  Don't prompt for confirmation to clear
+
+  -h, --help
+
+  Show a help message with basic usage information.
+
 ## EXAMPLES
 
   Clears the repo.

--- a/man/git-clear.1
+++ b/man/git-clear.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-CLEAR" "1" "May 2018" "" "Git Extras"
+.TH "GIT\-CLEAR" "1" "April 2020" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-clear\fR \- Rigorously clean up a repository
@@ -11,6 +11,18 @@
 .
 .SH "DESCRIPTION"
 Clears the repository to a state that it looks as if it was freshly cloned with the current HEAD\. Basically it is a git\-reset \-\-hard together with deletion of all untracked files that reside inside the working directory, including those in \.gitignore\.
+.
+.SH "OPTIONS"
+\-f, \-\-force
+.
+.P
+Don\'t prompt for confirmation to clear
+.
+.P
+\-h, \-\-help
+.
+.P
+Show a help message with basic usage information\.
 .
 .SH "EXAMPLES"
 Clears the repo\.

--- a/man/git-clear.html
+++ b/man/git-clear.html
@@ -56,6 +56,7 @@
     <a href="#NAME">NAME</a>
     <a href="#SYNOPSIS">SYNOPSIS</a>
     <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
     <a href="#EXAMPLES">EXAMPLES</a>
     <a href="#AUTHOR">AUTHOR</a>
     <a href="#REPORTING-BUGS">REPORTING BUGS</a>
@@ -83,6 +84,16 @@
   with the current HEAD. Basically it is a git-reset --hard together with
   deletion of all untracked files that reside inside the working directory, including those in .gitignore.</p>
 
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -f, --force</p>
+
+<p>  Don't prompt for confirmation to clear</p>
+
+<p>  -h, --help</p>
+
+<p>  Show a help message with basic usage information.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <p>  Clears the repo.</p>
@@ -92,7 +103,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Daniel 'grindhold' Brendle &lt;<a href="&#x6d;&#x61;&#105;&#108;&#x74;&#x6f;&#58;&#103;&#114;&#x69;&#x6e;&#x64;&#x68;&#111;&#x6c;&#100;&#x40;&#x67;&#x6d;&#120;&#46;&#x6e;&#101;&#116;" data-bare-link="true">&#103;&#114;&#x69;&#110;&#100;&#104;&#111;&#x6c;&#x64;&#64;&#x67;&#x6d;&#x78;&#x2e;&#x6e;&#101;&#116;</a>&gt;</p>
+<p>Written by Daniel 'grindhold' Brendle &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#x67;&#114;&#x69;&#x6e;&#x64;&#104;&#111;&#108;&#x64;&#x40;&#x67;&#109;&#120;&#46;&#x6e;&#101;&#x74;" data-bare-link="true">&#103;&#114;&#105;&#110;&#100;&#x68;&#111;&#108;&#100;&#x40;&#103;&#x6d;&#120;&#x2e;&#x6e;&#101;&#116;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -105,7 +116,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>May 2018</li>
+    <li class='tc'>April 2020</li>
     <li class='tr'>git-clear(1)</li>
   </ol>
 

--- a/man/git-clear.md
+++ b/man/git-clear.md
@@ -11,6 +11,16 @@ git-clear(1) -- Rigorously clean up a repository
   with the current HEAD. Basically it is a git-reset --hard together with
   deletion of all untracked files that reside inside the working directory, including those in .gitignore.
 
+## OPTIONS
+
+  -f, --force
+
+  Don't prompt for confirmation to clear
+
+  -h, --help
+
+  Show a help message with basic usage information.
+
 ## EXAMPLES
 
   Clears the repo.


### PR DESCRIPTION
This PR adds the ability to do:
```bash
git-clear --force
git-clear -f
git-clear --help
git-clear -h

git-clear-soft --force
git-clear-soft -f
git-clear-soft --help
git-clear-soft -h
```