### PR TITLE
add a config setting for prefix

### DIFF
--- a/bin/git-feature
+++ b/bin/git-feature
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-branch_prefix=feature
+branch_prefix=$(git config --get git-extras.feature.prefix)
+
+if [ -z "$branch_prefix" ]; then
+   branch_prefix="feature"
+fi
+
 merge_mode="--no-ff"
 declare -a argv
 while test $# != 0


### PR DESCRIPTION
Per feedback on #834 , here is a one-liner change to fetch a default branch prefix from `git config.`