### PR TITLE
add a default for the remote to fetch a pr from

### DIFF
--- a/bin/git-pr
+++ b/bin/git-pr
@@ -59,7 +59,8 @@ if test "$1" = "clean"; then
   done
 
 elif [[ "$1" =~ ^[0-9]+$ ]]; then
-  remote=${2:-origin}
+  remote_pref=${2:-$(git config --get git-extras.pr.remote)}
+  remote=${remote_pref:-origin}
   id=$1
   branch=pr/$id
   pull "$remote" "$id" "$branch"


### PR DESCRIPTION
As discussed in #835, a one-liner to fetch a default remote from config.

Testing: 

```bash
$ git remote
origin
upstream
$ git config git-extras.pr.remote "upstream"
$ cat .git/config
<snip>
[git-extras "pr"]
	remote = upstream
$ ./bin/git-pr 800
remote: Enumerating objects: 44, done.
remote: Counting objects: 100% (44/44), done.
remote: Total 59 (delta 43), reused 43 (delta 43), pack-reused 15
Unpacking objects: 100% (59/59), 24.49 KiB | 338.00 KiB/s, done.
From github.com:tj/git-extras
 * [new ref]         refs/pull/800/head -> pr/800
Switched to branch 'pr/800'
```

