### PR TITLE
git-archive-file: rename invalid chars in the output filename

### DIFF
--- a/bin/git-archive-file
+++ b/bin/git-archive-file
@@ -24,6 +24,9 @@ else
 	fi
 fi
 
+# rename invalid chars for the file path
+FILENAME=${FILENAME//\//-}
+FILENAME=${FILENAME//\\/-}
 # combine path and filename
 OUTPUT=$(pwd)/$FILENAME
 

--- a/man/git-archive-file.1
+++ b/man/git-archive-file.1
@@ -1,37 +1,27 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-ARCHIVE\-FILE" "1" "October 2017" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-ARCHIVE\-FILE" "1" "May 2020" "" "Git Extras"
 .SH "NAME"
 \fBgit\-archive\-file\fR \- Export the current HEAD of the git repository to an archive
-.
 .SH "SYNOPSIS"
 \fBgit\-archive\-file\fR
-.
 .SH "DESCRIPTION"
 Export the current HEAD of the repository into an archive with an identifiable and unique name\.
-.
 .SH "OPTIONS"
 This command does not take any options\.
-.
 .SH "EXAMPLES"
 Archive naming conventions:
-.
 .P
 On any branch: \fBgit\-extras\.1\.7\.0\-110\-gafefba7\.branch\-name\.zip\fR
-.
 .P
 On master branch: \fBgit\-extras\.1\.7\.0\-110\-gafefba7\.zip\fR
-.
 .P
 On a detached HEAD (e\.g\. a tag): \fBgit\-extras\.1\.7\.0\.zip\fR
-.
+.P
+The \'/\' and \'\e\' in the branch name will be converted into \'\-\'\.
 .SH "AUTHOR"
 Written by Philipp Klose <\fIme@thehippo\.de\fR>
-.
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>
-.
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-archive-file.html
+++ b/man/git-archive-file.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-archive-file(1) - Export the current HEAD of the git repository to an archive</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,11 +69,12 @@
     <li class='tr'>git-archive-file(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-archive-file</code> - <span class="man-whatis">Export the current HEAD of the git repository to an archive</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p><code>git-archive-file</code></p>
@@ -96,9 +97,11 @@
 
 <p>On a detached HEAD (e.g. a tag): <code>git-extras.1.7.0.zip</code></p>
 
+<p>The '/' and '\' in the branch name will be converted into '-'.</p>
+
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Philipp Klose &lt;<a href="&#x6d;&#x61;&#105;&#108;&#116;&#111;&#58;&#109;&#x65;&#64;&#x74;&#104;&#x65;&#104;&#x69;&#112;&#x70;&#x6f;&#x2e;&#100;&#x65;" data-bare-link="true">&#x6d;&#x65;&#64;&#x74;&#x68;&#101;&#x68;&#x69;&#x70;&#112;&#111;&#46;&#x64;&#x65;</a>&gt;</p>
+<p>Written by Philipp Klose &lt;<a href="mailto:me@thehippo.de" data-bare-link="true">me@thehippo.de</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -108,10 +111,9 @@
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>May 2020</li>
     <li class='tr'>git-archive-file(1)</li>
   </ol>
 

--- a/man/git-archive-file.md
+++ b/man/git-archive-file.md
@@ -24,6 +24,8 @@ On master branch: `git-extras.1.7.0-110-gafefba7.zip`
 
 On a detached HEAD (e.g. a tag): `git-extras.1.7.0.zip`
 
+The '/' and '\\' in the branch name will be converted into '-'.
+
 ## AUTHOR
 
 Written by Philipp Klose &lt;<me@thehippo.de>&gt;


### PR DESCRIPTION
Fix #838.