### PR TITLE
Remove scripts that are mere alias wrappers for git-feature

### DIFF
--- a/bin/git-bug
+++ b/bin/git-bug
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-ALIAS=bug
-git feature -a $ALIAS "$@"

--- a/bin/git-chore
+++ b/bin/git-chore
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-ALIAS=chore
-git feature -a $ALIAS "$@"

--- a/bin/git-refactor
+++ b/bin/git-refactor
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-ALIAS=refactor
-git feature -a $ALIAS "$@"


### PR DESCRIPTION
Closes #842.

Notably `git-bug` clobbers a very popular other project of the same name.
Having lightweight wrapper scripts clogging up the subcommand namespace
makes it awkward to make use of this project wholesale instead of
piecemeal. These function can be implemented by users with git aliases
very easily.