### PR TITLE
Correct undo documentation to match code order of parameters

### DIFF
--- a/man/git-undo.1
+++ b/man/git-undo.1
@@ -7,7 +7,7 @@
 \fBgit\-undo\fR \- Remove latest commits
 .
 .SH "SYNOPSIS"
-\fBgit\-undo\fR [<commitcount>] [\-s, \-\-soft, \-h, \-\-hard]
+\fBgit\-undo\fR [\-s, \-\-soft, \-h, \-\-hard] [<commitcount>]
 .
 .SH "DESCRIPTION"
 Removes the latest commits\.

--- a/man/git-undo.html
+++ b/man/git-undo.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-undo</code> [&lt;commitcount&gt;] [-s, --soft, -h, --hard]</p>
+<p><code>git-undo</code> [-s, --soft, -h, --hard] [&lt;commitcount&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 

--- a/man/git-undo.md
+++ b/man/git-undo.md
@@ -3,7 +3,7 @@ git-undo(1) -- Remove latest commits
 
 ## SYNOPSIS
 
-`git-undo` [&lt;commitcount&gt;] [-s, --soft, -h, --hard]
+`git-undo` [-s, --soft, -h, --hard] [&lt;commitcount&gt;]
 
 ## DESCRIPTION
 


### PR DESCRIPTION
The undo documentation has commit count as the first parameter and --soft/hard as the second. The code has the order reversed. This corrects the documentation to match the code.