### PR TITLE
Modify to work when only a single commit, add parameter checks

### DIFF
--- a/bin/git-undo
+++ b/bin/git-undo
@@ -64,7 +64,7 @@ EOL
     ;;
 esac
 
-if [[ ! $parm2 =~ [1-9]*([0-9]) ]]; then
+if [[ ! $parm2 =~ ^[1-9][0-9]*$ ]]; then
     echo "Invalid undo count: $parm2"
     exit 1
 fi

--- a/bin/git-undo
+++ b/bin/git-undo
@@ -1,6 +1,28 @@
 #!/usr/bin/env bash
 
 back="^"
+cstr="commits"
+ccnt=$(git rev-list --count HEAD)
+if [ $ccnt -eq 1 ]; then cstr="commit"; fi
+parm3=""
+
+function _undo()
+{
+  type=${1:-soft}
+  undo_cnt=${2:-1}
+  reset=${3:-""}
+echo "type=$type, cnt=$undo_cnt, reset=$reset"
+  if [ $undo_cnt -gt $ccnt ]; then
+    echo "Only $ccnt $cstr, cannot undo $undo_cnt"
+  elif [ "$type" = "hard" -a $ccnt -eq $undo_cnt ]; then
+    echo "Cannot hard undo all commits"
+  elif [ "$type" = "soft" -a $ccnt -eq 1 ]; then
+    git update-ref -d HEAD
+  else
+    git reset --$type HEAD~$undo_cnt
+  fi
+  if [ "$reset" != "" ]; then git reset; fi
+}
 
 case "$1" in
   -h)
@@ -12,9 +34,8 @@ EOL
     read -r res
     case "${res}" in
       "Y" | "y")
-        test $2 -gt 1 > /dev/null 2>&1 && back="~$2"
-        git reset --hard HEAD$back
-        exit $?
+        parm1=hard
+        parm2=${2:-1}
         ;;
       * )
         exit 0
@@ -22,16 +43,31 @@ EOL
     esac
     ;;
   --hard)
-    test $2 -gt 1 > /dev/null 2>&1 && back="~$2"
-    git reset --hard HEAD$back
+    parm1=hard
+    parm2=${2:-1}
     ;;
   -s|--soft)
-    test $2 -gt 1 > /dev/null 2>&1 && back="~$2"
-    git reset --soft HEAD$back
+    parm1=soft
+    parm2=${2:-1}
+    parm3=reset
+    ;;
+  "")
+    parm1=soft
+    parm2=1
+    ;;
+  *[!0-9]*)
+    echo "Invalid parameter: $1"
+    exit 1
     ;;
   *)
-    test $1 -gt 1 > /dev/null 2>&1 && back="~$1"
-    git reset --soft HEAD$back
-    git reset
+    parm1=soft
+    parm2="$1"
     ;;
 esac
+
+if [[ ! $parm2 =~ [0-9]*([0-9]) ]]; then
+    echo "Invalid undo count: $parm2"
+    exit 1
+fi
+
+_undo $parm1 $parm2 $parm3

--- a/bin/git-undo
+++ b/bin/git-undo
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-back="^"
 cstr="commits"
 ccnt=$(git rev-list --count HEAD)
 if [ $ccnt -eq 1 ]; then cstr="commit"; fi
@@ -11,12 +10,12 @@ function _undo()
   type=${1:-soft}
   undo_cnt=${2:-1}
   reset=${3:-""}
-echo "type=$type, cnt=$undo_cnt, reset=$reset"
+
   if [ $undo_cnt -gt $ccnt ]; then
     echo "Only $ccnt $cstr, cannot undo $undo_cnt"
-  elif [ "$type" = "hard" -a $ccnt -eq $undo_cnt ]; then
+  elif [ "$type" = "hard" ] && [ $ccnt -eq $undo_cnt ]; then
     echo "Cannot hard undo all commits"
-  elif [ "$type" = "soft" -a $ccnt -eq 1 ]; then
+  elif [ "$type" = "soft" ] && [ $ccnt -eq 1 ]; then
     git update-ref -d HEAD
   else
     git reset --$type HEAD~$undo_cnt
@@ -65,7 +64,7 @@ EOL
     ;;
 esac
 
-if [[ ! $parm2 =~ [0-9]*([0-9]) ]]; then
+if [[ ! $parm2 =~ [1-9]*([0-9]) ]]; then
     echo "Invalid undo count: $parm2"
     exit 1
 fi


### PR DESCRIPTION
Undo currently does not work when there is only a single commit. There are instances when doing a soft undo on a repository with only a single commit is desired.
In implementing that, I added a few parameter checks, including:
* Cannot specify an undo count greater than the commit count.
* Cannot hard undo all commits, e.g. if commit count is 3, can't hard undo all 3.
* Catch bad parameters, i.e. something other than -s/--soft/-h/--hard as the first parameter or a non-numeric as the second parameter.

Tested on OSX 10.14.6, which is all I have available. I don't believe I used anything that isn't portable, however. (Famous last words.)