### PR TITLE
fix(browse): update sed pattern to work on mac

### DIFF
--- a/bin/git-browse
+++ b/bin/git-browse
@@ -22,7 +22,7 @@ fi
 
 if [[ $remote_url = git@* ]]
 then
-    url=$(echo $remote_url | sed -E -e 's/:/\//' -e 's/\.git$//' -e 's/\w*@(.*)/http:\/\/\1/')
+    url=$(echo $remote_url | sed -E -e 's/:/\//' -e 's/\.git$//' -e 's/.*@(.*)/http:\/\/\1/')
 elif [[ $remote_url = http* ]]
 then
     url=${remote_url%.git}


### PR DESCRIPTION
The `\w` character class on Mac's version of sed (BSD) does not seem to be recognised as "all word characters".

```
echo "foo" | sed -E -e 's/\w*/_/'
_foo
```

I had to update my pattern to `.*` to get it to work correctly. I understand it's not as precise, but I couldn't find a character class that was acknowledged to work the same across all platforms.
