### PR TITLE
Improved the 'git-info' command (color, submodule, config)

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -750,14 +750,19 @@ $ git info
     myBranch
     * master
 
+    ## Submodule(s):
+
+      a234567 path2submodule1/submodule1 (branch/tag)
+    + b234567 path2submodule2/submodule2 (branch/tag)
+    - c234567 path2submodule3/submodule3 (branch/tag)
+      e234567 path2submodule4/submodule4 (branch/tag)
+
     ## Most Recent Commit:
 
     commit e3952df2c172c6f3eb533d8d0b1a6c77250769a7
     Author: Sample Author <sampleAuthor@gmail.com>
 
     Added git-info command.
-
-    Type 'git log' for more commits, or 'git show <commit id>' for full commit details.
 
     ## Configuration (.git/config):
 

--- a/bin/git-info
+++ b/bin/git-info
@@ -48,7 +48,6 @@ fi
 
 echon "## Most Recent Commit:"
 echon "$(most_recent_commit)"
-echon "Type 'git log' for more commits, or 'git show <commit id>' for full commit details."
 
 if test "$1" != "--no-config"; then
   echon "## Configuration (.git/config):"

--- a/bin/git-info
+++ b/bin/git-info
@@ -21,11 +21,9 @@ remote_urls() {
 }
 
 echon() {
-    echo "$@"
-    echo
+  echo "$@"
+  echo
 }
-
-# Show info similar to svn
 
 echo
 echon "## Remote URLs:"

--- a/bin/git-info
+++ b/bin/git-info
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+GREEN="$(tput setaf 2)"
+NORMAL="$(tput sgr0)"
+if [ "$1" = "--color" ] || [ "$2" = "--color" ] || \
+     [ "$1" = "-c" ] || [ "$2" = "-c" ] ; then
+  COLOR_TITLE="$GREEN"
+else
+  COLOR_TITLE="$NORMAL"
+fi
+
+HIDE_CONFIG=
+if [ "$1" != "--no-config" ] && [ "$2" != "--no-config" ]; then
+  HIDE_CONFIG=1
+fi
+
 get_config() {
   cmd_get_config="$(git config --get-all git-extras.info.config-grep)"
   if [ -z "$cmd_get_config" ]; then
@@ -40,15 +54,6 @@ echon() {
   echo
 }
 
-GREEN="$(tput setaf 2)"
-NORMAL="$(tput sgr0)"
-if [ "$1" = "--color" ] || [ "$2" = "--color" ] || \
-     [ "$1" = "-c" ] || [ "$2" = "-c" ] ; then
-  COLOR_TITLE="$GREEN"
-else
-  COLOR_TITLE="$NORMAL"
-fi
-
 echo
 echon "${COLOR_TITLE}## Remote URLs:${NORMAL}"
 echon "$(remote_urls)"
@@ -68,7 +73,7 @@ fi
 echon "${COLOR_TITLE}## Most Recent Commit:${NORMAL}"
 echon "$(most_recent_commit)"
 
-if [ "$1" != "--no-config" ] && [ "$2" != "--no-config" ]; then
+if [ ! -z "$HIDE_CONFIG" ]; then
   echon "${COLOR_TITLE}## Configuration (.git/config):${NORMAL}"
   echon "$(get_config)"
 fi

--- a/bin/git-info
+++ b/bin/git-info
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 
 get_config() {
-  git config --list
+  cmd_get_config="$(git config --get-all extras.info.config-grep)"
+  if [ -z "$cmd_get_config" ]; then
+    git config --list
+  else
+    eval "$cmd_get_config"
+  fi
 }
 
 most_recent_commit() {
-  git log --max-count=1 --pretty=short
+  cmd_get_log="$(git config --get-all extras.info.log)"
+  if [ -z "$cmd_get_log" ]; then
+    git log --max-count=1 --pretty=short
+  else
+    eval "$cmd_get_log"
+  fi
 }
 
 submodules() {

--- a/bin/git-info
+++ b/bin/git-info
@@ -40,26 +40,35 @@ echon() {
   echo
 }
 
+GREEN="$(tput setaf 2)"
+NORMAL="$(tput sgr0)"
+if [ "$1" = "--color" ] || [ "$2" = "--color" ] || \
+     [ "$1" = "-c" ] || [ "$2" = "-c" ] ; then
+  COLOR_TITLE="$GREEN"
+else
+  COLOR_TITLE="$NORMAL"
+fi
+
 echo
-echon "## Remote URLs:"
+echon "${COLOR_TITLE}## Remote URLs:${NORMAL}"
 echon "$(remote_urls)"
 
-echon "## Remote Branches:"
+echon "${COLOR_TITLE}## Remote Branches:${NORMAL}"
 echon "$(remote_branches)"
 
-echon "## Local Branches:"
+echon "${COLOR_TITLE}## Local Branches:${NORMAL}"
 echon "$(local_branches)"
 
 SUBMODULES_LOG=$(submodules)
 if [ ! -z "$SUBMODULES_LOG" ]; then
-  echon "## Submodule(s):"
+  echon "${COLOR_TITLE}## Submodule(s):${NORMAL}"
   echon "$SUBMODULES_LOG"
 fi
 
-echon "## Most Recent Commit:"
+echon "${COLOR_TITLE}## Most Recent Commit:${NORMAL}"
 echon "$(most_recent_commit)"
 
-if test "$1" != "--no-config"; then
-  echon "## Configuration (.git/config):"
+if [ "$1" != "--no-config" ] && [ "$2" != "--no-config" ]; then
+  echon "${COLOR_TITLE}## Configuration (.git/config):${NORMAL}"
   echon "$(get_config)"
 fi

--- a/bin/git-info
+++ b/bin/git-info
@@ -8,6 +8,11 @@ most_recent_commit() {
   git log --max-count=1 --pretty=short
 }
 
+submodules() {
+  # short sha1
+  git submodule status | sed 's/\([^abcdef0-9]\{,2\}\)\([abcdef0-9]\{7\}\)\([abcdef0-9]\{33\}\)\(.*\)/\1\2\4/'
+}
+
 local_branches() {
   git branch
 }
@@ -34,6 +39,12 @@ echon "$(remote_branches)"
 
 echon "## Local Branches:"
 echon "$(local_branches)"
+
+SUBMODULES_LOG=$(submodules)
+if [ ! -z "$SUBMODULES_LOG" ]; then
+  echon "## Submodule(s):"
+  echon "$SUBMODULES_LOG"
+fi
 
 echon "## Most Recent Commit:"
 echon "$(most_recent_commit)"

--- a/bin/git-info
+++ b/bin/git-info
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 get_config() {
-  cmd_get_config="$(git config --get-all extras.info.config-grep)"
+  cmd_get_config="$(git config --get-all git-extras.info.config-grep)"
   if [ -z "$cmd_get_config" ]; then
     git config --list
   else
@@ -10,7 +10,7 @@ get_config() {
 }
 
 most_recent_commit() {
-  cmd_get_log="$(git config --get-all extras.info.log)"
+  cmd_get_log="$(git config --get-all git-extras.info.log)"
   if [ -z "$cmd_get_log" ]; then
     git log --max-count=1 --pretty=short
   else

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -143,6 +143,10 @@ _git_undo(){
    __gitcomp "--hard --soft -h -s"
 }
 
+_git_info(){
+  __gitcomp "--color -c --no-config"
+}
+
 _git_browse(){
   __git_complete_remote_or_refspec
 }

--- a/man/git-info.1
+++ b/man/git-info.1
@@ -51,7 +51,7 @@ You could customize the Most recent commit and Configuration Info format via git
 .
 .nf
 
-$ git config \-\-global \-\-add extras\.info\.log "<log\-command>"
+$ git config \-\-global \-\-add git\-extras\.info\.log "<log\-command>"
 .
 .fi
 .
@@ -64,7 +64,7 @@ the default \fIlog\-command\fR is "git log \-\-max\-count=1 \-\-pretty=short"
 .
 .nf
 
-$ git config \-\-global \-\-add extras\.info\.config\-grep "<config\-grep\-command>"
+$ git config \-\-global \-\-add git\-extras\.info\.config\-grep "<config\-grep\-command>"
 .
 .fi
 .
@@ -83,7 +83,7 @@ to set global configuration to show last commit subject, without sha1
 .
 .nf
 
- $ git config \-\-global \-\-add extras\.info\.log "git log \-\-max\-count=1 \-\-format=\e"Author: %an%nDate:   %ad (%ar)%n%n    %s\e" \-\-date=format:\e"%Y\-%m\-%d %a %H:%M\e""
+ $ git config \-\-global \-\-add git\-extras\.info\.log "git log \-\-max\-count=1 \-\-format=\e"Author: %an%nDate:   %ad (%ar)%n%n    %s\e" \-\-date=format:\e"%Y\-%m\-%d %a %H:%M\e""
 .
 .fi
 .
@@ -96,7 +96,7 @@ to set global configuration to show user\'s name and email
 .
 .nf
 
- $ git config \-\-global \-\-add extras\.info\.config\-grep "git config \-\-list | grep \-\-color=never \-E \e"^user\.name|^user\.email\e""
+ $ git config \-\-global \-\-add git\-extras\.info\.config\-grep "git config \-\-list | grep \-\-color=never \-E \e"^user\.name|^user\.email\e""
 .
 .fi
 .

--- a/man/git-info.1
+++ b/man/git-info.1
@@ -36,7 +36,7 @@ Configuration Info
 \-c, \-\-color
 .
 .P
-Use color output\.
+Use color for information titles\.
 .
 .P
 \-\-no\-config

--- a/man/git-info.1
+++ b/man/git-info.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-INFO" "1" "October 2017" "" "Git Extras"
+.TH "GIT\-INFO" "1" "August 2020" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-info\fR \- Returns information on current repository
 .
 .SH "SYNOPSIS"
-\fBgit\-info\fR
+\fBgit\-info\fR [\-c|\-\-color] [\-\-no\-config]
 .
 .SH "DESCRIPTION"
 Shows the following information about a repository:
@@ -22,15 +22,85 @@ Remote Branches
 Local Branches
 .
 .IP "4." 4
-Most recent commit
+Submodule(s) (if present)
 .
 .IP "5." 4
+Most recent commit
+.
+.IP "6." 4
 Configuration Info
 .
 .IP "" 0
 .
 .SH "OPTIONS"
-N/A
+\-c, \-\-color
+.
+.P
+Use color output\.
+.
+.P
+\-\-no\-config
+.
+.P
+Don\'t show list all variables set in config file, along with their values\.
+.
+.SH "GIT CONFIGS"
+You could customize the Most recent commit and Configuration Info format via git config options
+.
+.IP "" 4
+.
+.nf
+
+$ git config \-\-global \-\-add extras\.info\.log "<log\-command>"
+.
+.fi
+.
+.IP "" 0
+.
+.P
+the default \fIlog\-command\fR is "git log \-\-max\-count=1 \-\-pretty=short"
+.
+.IP "" 4
+.
+.nf
+
+$ git config \-\-global \-\-add extras\.info\.config\-grep "<config\-grep\-command>"
+.
+.fi
+.
+.IP "" 0
+.
+.P
+the default \fIconfig\-grep\-command\fR is "git config \-\-list"
+.
+.P
+For example,
+.
+.P
+to set global configuration to show last commit subject, without sha1
+.
+.IP "" 4
+.
+.nf
+
+ $ git config \-\-global \-\-add extras\.info\.log "git log \-\-max\-count=1 \-\-format=\e"Author: %an%nDate:   %ad (%ar)%n%n    %s\e" \-\-date=format:\e"%Y\-%m\-%d %a %H:%M\e""
+.
+.fi
+.
+.IP "" 0
+.
+.P
+to set global configuration to show user\'s name and email
+.
+.IP "" 4
+.
+.nf
+
+ $ git config \-\-global \-\-add extras\.info\.config\-grep "git config \-\-list | grep \-\-color=never \-E \e"^user\.name|^user\.email\e""
+.
+.fi
+.
+.IP "" 0
 .
 .SH "EXAMPLES"
 Outputs info about a repo:
@@ -56,14 +126,19 @@ origin/myBranch
 myBranch
 * master
 
+## Submodule(s):
+
+  a234567 path2submodule1/submodule1 (branch/tag)
++ b234567 path2submodule2/submodule2 (branch/tag)
+\- c234567 path2submodule3/submodule3 (branch/tag)
+  e234567 path2submodule4/submodule4 (branch/tag)
+
 ## Most Recent Commit:
 
 commit e3952df2c172c6f3eb533d8d0b1a6c77250769a7
 Author: Sample Author <sampleAuthor@gmail\.com>
 
 Added git\-info command\.
-
-Type \'git log\' for more commits, or \'git show <commit id>\' for full commit details\.
 
 ## Configuration (\.git/config):
 

--- a/man/git-info.html
+++ b/man/git-info.html
@@ -107,12 +107,12 @@
 
 <p>  You could customize the Most recent commit and Configuration Info format via git config options</p>
 
-<pre><code>$ git config --global --add extras.info.log "&lt;log-command>"
+<pre><code>$ git config --global --add git-extras.info.log "&lt;log-command>"
 </code></pre>
 
 <p>  the default <var>log-command</var> is "git log --max-count=1 --pretty=short"</p>
 
-<pre><code>$ git config --global --add extras.info.config-grep "&lt;config-grep-command>"
+<pre><code>$ git config --global --add git-extras.info.config-grep "&lt;config-grep-command>"
 </code></pre>
 
 <p>  the default <var>config-grep-command</var> is "git config --list"</p>
@@ -121,12 +121,12 @@
 
 <p>   to set global configuration to show last commit subject, without sha1</p>
 
-<pre><code> $ git config --global --add extras.info.log "git log --max-count=1 --format=\"Author: %an%nDate:   %ad (%ar)%n%n    %s\" --date=format:\"%Y-%m-%d %a %H:%M\""
+<pre><code> $ git config --global --add git-extras.info.log "git log --max-count=1 --format=\"Author: %an%nDate:   %ad (%ar)%n%n    %s\" --date=format:\"%Y-%m-%d %a %H:%M\""
 </code></pre>
 
 <p>   to set global configuration to show user's name and email</p>
 
-<pre><code> $ git config --global --add extras.info.config-grep "git config --list | grep --color=never -E \"^user.name|^user.email\""
+<pre><code> $ git config --global --add git-extras.info.config-grep "git config --list | grep --color=never -E \"^user.name|^user.email\""
 </code></pre>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
@@ -184,7 +184,7 @@ branch.master.merge=refs/heads/master
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#x6f;&#58;&#109;&#117;&#x68;&#116;&#x61;&#x73;&#x69;&#x62;&#x40;&#x67;&#x6d;&#x61;&#x69;&#x6c;&#46;&#99;&#x6f;&#x6d;" data-bare-link="true">&#109;&#117;&#104;&#x74;&#x61;&#x73;&#x69;&#98;&#64;&#x67;&#109;&#x61;&#x69;&#108;&#x2e;&#99;&#111;&#109;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#x3a;&#x6d;&#x75;&#104;&#x74;&#97;&#115;&#105;&#98;&#64;&#x67;&#109;&#97;&#105;&#x6c;&#x2e;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#109;&#x75;&#x68;&#x74;&#97;&#115;&#x69;&#x62;&#64;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-info.html
+++ b/man/git-info.html
@@ -97,7 +97,7 @@
 
 <p>  -c, --color</p>
 
-<p>  Use color output.</p>
+<p>  Use color for information titles.</p>
 
 <p>  --no-config</p>
 
@@ -184,7 +184,7 @@ branch.master.merge=refs/heads/master
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#109;&#97;&#105;&#108;&#x74;&#x6f;&#x3a;&#x6d;&#x75;&#104;&#x74;&#97;&#115;&#105;&#98;&#64;&#x67;&#109;&#97;&#105;&#x6c;&#x2e;&#x63;&#x6f;&#x6d;" data-bare-link="true">&#109;&#x75;&#x68;&#x74;&#97;&#115;&#x69;&#x62;&#64;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#x63;&#111;&#x6d;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#97;&#x69;&#108;&#116;&#x6f;&#58;&#x6d;&#117;&#x68;&#116;&#97;&#115;&#x69;&#98;&#64;&#x67;&#109;&#x61;&#105;&#108;&#46;&#99;&#111;&#x6d;" data-bare-link="true">&#x6d;&#x75;&#x68;&#116;&#97;&#115;&#x69;&#x62;&#64;&#x67;&#x6d;&#x61;&#105;&#x6c;&#x2e;&#x63;&#x6f;&#x6d;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-info.html
+++ b/man/git-info.html
@@ -57,6 +57,7 @@
     <a href="#SYNOPSIS">SYNOPSIS</a>
     <a href="#DESCRIPTION">DESCRIPTION</a>
     <a href="#OPTIONS">OPTIONS</a>
+    <a href="#GIT-CONFIGS">GIT CONFIGS</a>
     <a href="#EXAMPLES">EXAMPLES</a>
     <a href="#AUTHOR">AUTHOR</a>
     <a href="#REPORTING-BUGS">REPORTING BUGS</a>
@@ -76,7 +77,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-info</code></p>
+<p><code>git-info</code> [-c|--color] [--no-config]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -86,6 +87,7 @@
 <li>Remote Url(s)</li>
 <li>Remote Branches</li>
 <li>Local Branches</li>
+<li>Submodule(s) (if present)</li>
 <li>Most recent commit</li>
 <li>Configuration Info</li>
 </ol>
@@ -93,7 +95,39 @@
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>N/A</p>
+<p>  -c, --color</p>
+
+<p>  Use color output.</p>
+
+<p>  --no-config</p>
+
+<p>  Don't show list all variables set in config file, along with their values.</p>
+
+<h2 id="GIT-CONFIGS">GIT CONFIGS</h2>
+
+<p>  You could customize the Most recent commit and Configuration Info format via git config options</p>
+
+<pre><code>$ git config --global --add extras.info.log "&lt;log-command>"
+</code></pre>
+
+<p>  the default <var>log-command</var> is "git log --max-count=1 --pretty=short"</p>
+
+<pre><code>$ git config --global --add extras.info.config-grep "&lt;config-grep-command>"
+</code></pre>
+
+<p>  the default <var>config-grep-command</var> is "git config --list"</p>
+
+<p>  For example,</p>
+
+<p>   to set global configuration to show last commit subject, without sha1</p>
+
+<pre><code> $ git config --global --add extras.info.log "git log --max-count=1 --format=\"Author: %an%nDate:   %ad (%ar)%n%n    %s\" --date=format:\"%Y-%m-%d %a %H:%M\""
+</code></pre>
+
+<p>   to set global configuration to show user's name and email</p>
+
+<pre><code> $ git config --global --add extras.info.config-grep "git config --list | grep --color=never -E \"^user.name|^user.email\""
+</code></pre>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -116,14 +150,19 @@ origin/myBranch
 myBranch
 * master
 
+## Submodule(s):
+
+  a234567 path2submodule1/submodule1 (branch/tag)
++ b234567 path2submodule2/submodule2 (branch/tag)
+- c234567 path2submodule3/submodule3 (branch/tag)
+  e234567 path2submodule4/submodule4 (branch/tag)
+
 ## Most Recent Commit:
 
 commit e3952df2c172c6f3eb533d8d0b1a6c77250769a7
 Author: Sample Author &lt;sampleAuthor@gmail.com&gt;
 
 Added git-info command.
-
-Type 'git log' for more commits, or 'git show &lt;commit id>' for full commit details.
 
 ## Configuration (.git/config):
 
@@ -145,7 +184,7 @@ branch.master.merge=refs/heads/master
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Leila Muhtasib &lt;<a href="&#x6d;&#97;&#105;&#108;&#x74;&#111;&#58;&#109;&#x75;&#x68;&#x74;&#97;&#115;&#105;&#98;&#64;&#x67;&#x6d;&#x61;&#105;&#x6c;&#46;&#99;&#x6f;&#x6d;" data-bare-link="true">&#109;&#117;&#x68;&#116;&#x61;&#x73;&#x69;&#x62;&#64;&#103;&#109;&#97;&#105;&#108;&#46;&#x63;&#111;&#109;</a>&gt;</p>
+<p>Written by Leila Muhtasib &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#x6f;&#58;&#109;&#117;&#x68;&#116;&#x61;&#x73;&#x69;&#x62;&#x40;&#x67;&#x6d;&#x61;&#x69;&#x6c;&#46;&#99;&#x6f;&#x6d;" data-bare-link="true">&#109;&#117;&#104;&#x74;&#x61;&#x73;&#x69;&#98;&#64;&#x67;&#109;&#x61;&#x69;&#108;&#x2e;&#99;&#111;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -158,7 +197,7 @@ branch.master.merge=refs/heads/master
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>August 2020</li>
     <li class='tr'>git-info(1)</li>
   </ol>
 

--- a/man/git-info.md
+++ b/man/git-info.md
@@ -20,7 +20,7 @@ Shows the following information about a repository:
 
   -c, --color
 
-  Use color output.
+  Use color for information titles.
 
   --no-config
 

--- a/man/git-info.md
+++ b/man/git-info.md
@@ -30,11 +30,11 @@ Shows the following information about a repository:
 
   You could customize the Most recent commit and Configuration Info format via git config options
 
-    $ git config --global --add extras.info.log "<log-command>"
+    $ git config --global --add git-extras.info.log "<log-command>"
 
   the default <log-command> is "git log --max-count=1 --pretty=short"
 
-    $ git config --global --add extras.info.config-grep "<config-grep-command>"
+    $ git config --global --add git-extras.info.config-grep "<config-grep-command>"
 
   the default <config-grep-command> is "git config --list"
 
@@ -42,11 +42,11 @@ Shows the following information about a repository:
 
    to set global configuration to show last commit subject, without sha1
 
-     $ git config --global --add extras.info.log "git log --max-count=1 --format=\"Author: %an%nDate:   %ad (%ar)%n%n    %s\" --date=format:\"%Y-%m-%d %a %H:%M\""
+     $ git config --global --add git-extras.info.log "git log --max-count=1 --format=\"Author: %an%nDate:   %ad (%ar)%n%n    %s\" --date=format:\"%Y-%m-%d %a %H:%M\""
 
    to set global configuration to show user's name and email
 
-     $ git config --global --add extras.info.config-grep "git config --list | grep --color=never -E \"^user.name|^user.email\""
+     $ git config --global --add git-extras.info.config-grep "git config --list | grep --color=never -E \"^user.name|^user.email\""
 
 ## EXAMPLES
 

--- a/man/git-info.md
+++ b/man/git-info.md
@@ -3,7 +3,7 @@ git-info(1) -- Returns information on current repository
 
 ## SYNOPSIS
 
-`git-info`
+`git-info` [-c|--color] [--no-config]
 
 ## DESCRIPTION
 
@@ -12,12 +12,41 @@ Shows the following information about a repository:
  1. Remote Url(s)
  2. Remote Branches
  3. Local Branches
- 4. Most recent commit
- 5. Configuration Info
+ 4. Submodule(s) (if present)
+ 5. Most recent commit
+ 6. Configuration Info
 
 ## OPTIONS
 
-N/A
+  -c, --color
+
+  Use color output.
+
+  --no-config
+
+  Don't show list all variables set in config file, along with their values.
+
+## GIT CONFIGS
+
+  You could customize the Most recent commit and Configuration Info format via git config options
+
+    $ git config --global --add extras.info.log "<log-command>"
+
+  the default <log-command> is "git log --max-count=1 --pretty=short"
+
+    $ git config --global --add extras.info.config-grep "<config-grep-command>"
+
+  the default <config-grep-command> is "git config --list"
+
+  For example,
+
+   to set global configuration to show last commit subject, without sha1
+
+     $ git config --global --add extras.info.log "git log --max-count=1 --format=\"Author: %an%nDate:   %ad (%ar)%n%n    %s\" --date=format:\"%Y-%m-%d %a %H:%M\""
+
+   to set global configuration to show user's name and email
+
+     $ git config --global --add extras.info.config-grep "git config --list | grep --color=never -E \"^user.name|^user.email\""
 
 ## EXAMPLES
 
@@ -40,14 +69,19 @@ Outputs info about a repo:
     myBranch
     * master
 
+    ## Submodule(s):
+
+      a234567 path2submodule1/submodule1 (branch/tag)
+    + b234567 path2submodule2/submodule2 (branch/tag)
+    - c234567 path2submodule3/submodule3 (branch/tag)
+      e234567 path2submodule4/submodule4 (branch/tag)
+
     ## Most Recent Commit:
 
     commit e3952df2c172c6f3eb533d8d0b1a6c77250769a7
     Author: Sample Author <sampleAuthor@gmail.com>
 
     Added git-info command.
-
-    Type 'git log' for more commits, or 'git show <commit id>' for full commit details.
 
     ## Configuration (.git/config):
 


### PR DESCRIPTION
Hi,
I see [#755](https://github.com/tj/git-extras/pull/755), but did something similar in another way

added:
- info about submodules
- colorized headers
- extend info commit and repo configuration

note:
- changes checked in MinGW, Debian Linux
- I do not  update git-extras-completion.zsh (I use bash only, and do not have zsh)

I hope this will be useful

