### PR TITLE
Clean up shellcheck warnings

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -24,7 +24,7 @@ usage() {
 # add another workspace to global git config
 function addworkspace {
 	git config --global bulkworkspaces."$wsname" "$wsdir";
-	if [ ! -z "$source" ]; then
+	if [ -n "$source" ]; then
         if [ ! -d "$wsdir" ]; then echo "Path of workspace doesn't exist, make it first."; exit 1; fi
         regex='http(s)?://|ssh://|(git@)?.*:.*/.*'
         if [[ "$source" =~ $regex ]]; then

--- a/bin/git-fresh-branch
+++ b/bin/git-fresh-branch
@@ -13,7 +13,7 @@ clean()
     git clean -fdx
 }
 
-if [ ! -z "$changes" ]; then
+if [ -n "$changes" ]; then
     read -p "All untracked changes will be lost. Continue [y/N]? " res
     case $res in
         [Yy]* ) ;;

--- a/bin/git-info
+++ b/bin/git-info
@@ -65,7 +65,7 @@ echon "${COLOR_TITLE}## Local Branches:${NORMAL}"
 echon "$(local_branches)"
 
 SUBMODULES_LOG=$(submodules)
-if [ ! -z "$SUBMODULES_LOG" ]; then
+if [ -n "$SUBMODULES_LOG" ]; then
   echon "${COLOR_TITLE}## Submodule(s):${NORMAL}"
   echon "$SUBMODULES_LOG"
 fi
@@ -73,7 +73,7 @@ fi
 echon "${COLOR_TITLE}## Most Recent Commit:${NORMAL}"
 echon "$(most_recent_commit)"
 
-if [ ! -z "$HIDE_CONFIG" ]; then
+if [ -n "$HIDE_CONFIG" ]; then
   echon "${COLOR_TITLE}## Configuration (.git/config):${NORMAL}"
   echon "$(get_config)"
 fi

--- a/bin/git-standup
+++ b/bin/git-standup
@@ -166,7 +166,7 @@ GIT_LOG_COMMAND="git --no-pager log \
     --color=$COLOR
     --pretty=format:'$GIT_PRETTY_FORMAT'
     --date='$GIT_DATE_FORMAT'"
-if [[ ! -z "$MAX_COMMIT_NUM" ]]; then
+if [[ -n "$MAX_COMMIT_NUM" ]]; then
     GIT_LOG_COMMAND="$GIT_LOG_COMMAND --max-count=$MAX_COMMIT_NUM"
 fi
 
@@ -177,7 +177,7 @@ git_output() {
         for branch in $branches; do
             # shellcheck disable=SC2086
             if output=$(eval $GIT_LOG_COMMAND "$branch"); then
-                if [[ ! -z "$output" ]] ;  then
+                if [[ -n "$output" ]] ;  then
                     echo "${GREEN}${branch}${NORMAL}"
                     echo "$output"
                     echo ""
@@ -225,7 +225,7 @@ if [[ $in_git_repo != 0 ]]; then
         if [[ -d ".git" || -f ".git" ]] ; then
             if GITOUT=$(git_output); then
                 ## Only output if there is some activities
-                if [[ ! -z "$GITOUT" ]] ;  then
+                if [[ -n "$GITOUT" ]] ;  then
                     echo "${BOLD}${UNDERLINE}${YELLOW}$(basename "$DIR")${NORMAL}"
                     echo "$GITOUT"
                     echo ""
@@ -243,7 +243,7 @@ else
     fi
 
     if GITOUT=$(git_output); then
-        if [[ ! -z "$GITOUT" ]] ;  then
+        if [[ -n "$GITOUT" ]] ;  then
             echo "$GITOUT"
         else
             if [[ $AUTHOR = '.*' ]] ; then


### PR DESCRIPTION
Hi,
I have checked only git-info command in MinGW, Debian Linux,
I do not think we need to check the rest.
