### PR TITLE
Added support for Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 os:
   - linux
   - osx
+arch:
+  - amd64
+  - ppc64le
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/git-extras/builds/187471110
Please have a look.

Regards,
ujjwal