### PR TITLE
git-delete-merged-branches: Ignore checked-out branches on different worktrees

### DIFF
--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-branches=$(git branch --no-color --merged | grep -v "\*" | grep -v $(git_extra_default_branch) | grep -v svn)
+branches=$(git branch --no-color --merged | grep -vE "^(\*|\+)" | grep -v $(git_extra_default_branch) | grep -v svn)
 if [ -n "$branches" ]
 then
     echo "$branches" | xargs -n 1 git branch -d


### PR DESCRIPTION
Hi,

When using [`git-worktree`](https://git-scm.com/docs/git-worktree), if a different worktree has a checked out branch (i.e not in the state of detached HEAD), this is what the `git branch` output looks like:

```bash
$ git branch
* develop
+ i-am-a-checked-out-branch-on-a-different-worktree
  i-am-another-branch
```

Meaning - `develop` is checked out in the current worktree I'm on, and `i-am-a-checked-out-branch-on-a-different-worktree` is checked out elsewhere.

In any case, we would like to _not_ remove the checked out branch. This is why I filter `+` out.


Have a nice rest of your day,
Matan