### PR TITLE
Update install doc: Homebrew is not just for macOS

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -63,7 +63,7 @@ $ nix-env -i git-extras
 [Abdullah](https://github.com/AWAN) has written a [Pkgfile](https://abdullah.today/ports/git-extras/Pkgfile) for his beloved [distro](https://crux.nu).
 
 
-### macOS with Homebrew
+### Homebrew
 
 ```bash
 $ brew install git-extras


### PR DESCRIPTION
I can confirm it also works Linux. I just installed `git-extras` via `Homebrew` on my Ubuntu machine:
```sh
$ uname -srv
Linux 5.8.0-53-generic #60~20.04.1-Ubuntu SMP Thu May 6 09:52:46 UTC 2021

$ brew install git-extras
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/cask and homebrew/core).
==> New Formulae
code-minimap              principalmapper           pywhat
==> Updated Formulae
Updated 70 formulae.
==> Updated Casks
Updated 36 casks.

==> Downloading https://ghcr.io/v2/linuxbrew/core/git-extras/manifests/6.2.0
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/linuxbrew/core/git-extras/blobs/sha256:5a86
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/
######################################################################## 100.0%
==> Pouring git-extras--6.2.0.x86_64_linux.bottle.tar.gz
==> Caveats
To load Zsh completions, add the following to your .zshrc:
  source /home/linuxbrew/.linuxbrew/opt/git-extras/share/git-extras/git-extras-completion.zsh
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/git-extras/6.2.0: 146 files, 388.4KB
```