### PR TITLE
git-fork | update to match REST-API auth standards as of 2021-06

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,3 +237,4 @@ Patches and Suggestions
 - Étienne BERSAC
 - ☃ pitr
 - 单元源
+- Don 'duckunix' Harper

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -14,8 +14,12 @@ test -z "$url" && abort "github repo needs to be specified as an argument"
 echo "Enter your github username"
 read user
 [ -n "$user" ] || abort "git username required"
-echo "Enter github Personal Access Token for user \"$user\""
-read -s passwd
+# personal access token
+# config name is github-personal-access-token '_' is not allowed in git config
+
+github_personal_access_token=$(git config git-extras.github-personal-access-token)
+
+test -z "$github_personal_access_token" && abort "git config git-extras.github-personal-access-token required"
 
 # extract owner + project from repo url
 project=${url##*/}
@@ -33,7 +37,7 @@ fi
 # create fork
 curl -qsf \
   -X POST \
-  -u "$user:$passwd" \
+  -u "$user:$github_personal_access_token" \
   -H "X-GitHub-OTP: $MFA_CODE" \
   "https://api.github.com/repos/$owner/$project/forks"
 

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -14,10 +14,8 @@ test -z "$url" && abort "github repo needs to be specified as an argument"
 echo "Enter your github username"
 read user
 [ -n "$user" ] || abort "git username required"
-echo "Enter github password for user \"$user\""
+echo "Enter github Personal Access Token for user \"$user\""
 read -s passwd
-echo "Enter github two-factor authentication code (leave blank if not set up)"
-read MFA_CODE
 
 # extract owner + project from repo url
 project=${url##*/}

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -40,10 +40,10 @@ adds the forked repo as a remote called \fBorigin\fR
 .P
 Remotes will use ssh if you have it configured with GitHub, if not, https will be used\.
 .
-Create pull request for a project on GitHub via command line\.
+Create a fork a project on GitHub via command line\.
 .
 .P
-A personal access token is required for making the API call to open the pull request(s) in GitHub\. API Documentation here \fIhttps://docs\.github\.com/en/rest/reference/pulls#create\-a\-pull\-request\fR
+A personal access token is required for making the API call to create a new fork in GitHub\. API Documentation here \fIhttps://docs\.github\.com/en/rest/reference/pulls#create\-a\-pull\-request\fR
 .
 .P
 Make sure the personal access token has the right \fBOAuth\fR scopes for the repo(s)

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -40,6 +40,20 @@ adds the forked repo as a remote called \fBorigin\fR
 .P
 Remotes will use ssh if you have it configured with GitHub, if not, https will be used\.
 .
+Create pull request for a project on GitHub via command line\.
+.
+.P
+A personal access token is required for making the API call to open the pull request(s) in GitHub\. API Documentation here \fIhttps://docs\.github\.com/en/rest/reference/pulls#create\-a\-pull\-request\fR
+.
+.P
+Make sure the personal access token has the right \fBOAuth\fR scopes for the repo(s)
+.
+.P
+Use \fBgit config \-\-global \-\-add git\-extras\.github\-personal\-access\-token <your\-personal\-access\-token>\fR
+.
+.P
+If using multiple accounts, override the global value in the specific repo using \fBgit config git\-extras\.github\-personal\-access\-token <other\-acc\-personal\-access\-token>\fR
+.
 .SH "EXAMPLE"
 Fork expect\.js:
 .

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -43,7 +43,7 @@ Remotes will use ssh if you have it configured with GitHub, if not, https will b
 Create a fork a project on GitHub via command line\.
 .
 .P
-A personal access token is required for making the API call to create a new fork in GitHub\. API Documentation here \fIhttps://docs\.github\.com/en/rest/reference/pulls#create\-a\-pull\-request\fR
+A personal access token is required for making the API call to create a new fork in GitHub\. API Documentation here \fIhttps://docs\.github\.com/en/rest/reference/repos#forks\fR
 .
 .P
 Make sure the personal access token has the right \fBOAuth\fR scopes for the repo(s)

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -99,6 +99,16 @@
 
 <p>  Remotes will use ssh if you have it configured with GitHub, if not, https will be used.</p>
 
+<p>Create pull request for a project on GitHub via command line.</p>
+
+<p>A personal access token is required for making the API call to open the pull request(s) in GitHub. <a href="https://docs.github.com/en/rest/reference/pulls#create-a-pull-request">API Documentation here</a></p>
+
+<p>Make sure the personal access token has the right <code>OAuth</code> scopes for the repo(s)</p>
+
+<p>Use <code>git config --global --add git-extras.github-personal-access-token &lt;your-personal-access-token></code></p>
+
+<p>If using multiple accounts, override the global value in the specific repo using <code>git config git-extras.github-personal-access-token &lt;other-acc-personal-access-token></code></p>
+
 <h2 id="EXAMPLE">EXAMPLE</h2>
 
 <p>  Fork expect.js:</p>

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -101,7 +101,7 @@
 
 <p>Create a fork of a project on GitHub via command line.</p>
 
-<p>A personal access token is required for making the API call to create a new fork in GitHub. <a href="https://docs.github.com/en/rest/reference/pulls#create-a-pull-request">API Documentation here</a></p>
+<p>A personal access token is required for making the API call to create a new fork in GitHub. <a href="https://docs.github.com/en/rest/reference/repos#forks">API Documentation here</a></p>
 
 <p>Make sure the personal access token has the right <code>OAuth</code> scopes for the repo(s)</p>
 

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -99,9 +99,9 @@
 
 <p>  Remotes will use ssh if you have it configured with GitHub, if not, https will be used.</p>
 
-<p>Create pull request for a project on GitHub via command line.</p>
+<p>Create a fork of a project on GitHub via command line.</p>
 
-<p>A personal access token is required for making the API call to open the pull request(s) in GitHub. <a href="https://docs.github.com/en/rest/reference/pulls#create-a-pull-request">API Documentation here</a></p>
+<p>A personal access token is required for making the API call to create a new fork in GitHub. <a href="https://docs.github.com/en/rest/reference/pulls#create-a-pull-request">API Documentation here</a></p>
 
 <p>Make sure the personal access token has the right <code>OAuth</code> scopes for the repo(s)</p>
 

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -21,6 +21,16 @@ git-fork(1) -- Fork a repo on github
 
   Remotes will use ssh if you have it configured with GitHub, if not, https will be used.
 
+  Create pull request for a project on GitHub via command line.
+  
+  A personal access token is required for making the API call to open the pull request(s) in GitHub. [API Documentation here](https://docs.github.com/en/rest/reference/pulls#create-a-pull-request)
+  
+  Make sure the personal access token has the right `OAuth` scopes for the repo(s)
+  
+  Use `git config --global --add git-extras.github-personal-access-token <your-personal-access-token>`
+  
+  If using multiple accounts, override the global value in the specific repo using `git config git-extras.github-personal-access-token <other-acc-personal-access-token>`
+
 ## EXAMPLE
 
   Fork expect.js:

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -23,7 +23,7 @@ git-fork(1) -- Fork a repo on github
 
   Create a fork of a project on GitHub via command line.
   
-  A personal access token is required for making the API call to create a fork in GitHub. [API Documentation here](https://docs.github.com/en/rest/reference/pulls#create-a-pull-request)
+  A personal access token is required for making the API call to create a fork in GitHub. [API Documentation here](https://docs.github.com/en/rest/reference/repos#forks)
   
   Make sure the personal access token has the right `OAuth` scopes for the repo(s)
   

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -21,9 +21,9 @@ git-fork(1) -- Fork a repo on github
 
   Remotes will use ssh if you have it configured with GitHub, if not, https will be used.
 
-  Create pull request for a project on GitHub via command line.
+  Create a fork of a project on GitHub via command line.
   
-  A personal access token is required for making the API call to open the pull request(s) in GitHub. [API Documentation here](https://docs.github.com/en/rest/reference/pulls#create-a-pull-request)
+  A personal access token is required for making the API call to create a fork in GitHub. [API Documentation here](https://docs.github.com/en/rest/reference/pulls#create-a-pull-request)
   
   Make sure the personal access token has the right `OAuth` scopes for the repo(s)
   


### PR DESCRIPTION
- Removed prompt for OATH Token
- Change prompt from 'password' to 'GitHub Personal Access Token'