### PR TITLE
Improve branch name handling in git-delete-merged-branches

### DIFF
--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-branches=$(git branch --no-color --merged | grep -vE "^(\*|\+)" | grep -v $(git_extra_default_branch) | grep -v svn)
+branches=$(git branch --no-color --merged | grep -v -P '^\*| ('$(git_extra_default_branch)'|svn)$'
 if [ -n "$branches" ]
 then
     echo "$branches" | xargs -n 1 git branch -d


### PR DESCRIPTION
We have branches whose name contain either svn or the name or extra default branch (e.g. svnner).  Thus,
improving the filter to only drop exact matches.