### PR TITLE
No merge summary

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -35,6 +35,12 @@ if [ -n "$DEDUP_BY_EMAIL" ] && [ -n "$SUMMARY_BY_LINE" ]; then
     exit 1
 fi
 
+if [ -n "$MERGES_ARG" ] && [ -n "$SUMMARY_BY_LINE" ]; then
+    >&2 echo "--no-merges used with --line is not supported"
+    exit 1
+fi
+
+
 commit=""
 test $# -ne 0 && commit=$*
 project=${PWD##*/}

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -5,6 +5,7 @@ cd "$(git root)" || { echo "Can't cd to top level directory";exit 1; }
 
 SUMMARY_BY_LINE=
 DEDUP_BY_EMAIL=
+MERGES_ARG=
 for arg in "$@"; do
     case "$arg" in
         --line)
@@ -12,6 +13,9 @@ for arg in "$@"; do
             ;;
         --dedup-by-email)
             DEDUP_BY_EMAIL=1
+            ;;
+        --no-merges)
+            MERGES_ARG="--no-merges"
             ;;
         -*)
             >&2 echo "unknown argument $arg found"
@@ -42,7 +46,7 @@ project=${PWD##*/}
 date() {
   # the $1 can be empty
   # shellcheck disable=SC2086
-  git log --pretty='format: %ai' $1 | cut -d ' ' -f 2
+  git log $MERGES_ARG --pretty='format: %ai' $1 | cut -d ' ' -f 2
 }
 
 #
@@ -63,7 +67,7 @@ active_days() {
 
 commit_count() {
   # shellcheck disable=SC2086
-  git log --oneline $commit | wc -l | tr -d ' '
+  git log $MERGES_ARG --oneline $commit | wc -l | tr -d ' '
 }
 
 #
@@ -193,9 +197,9 @@ else
   if [ -n "$DEDUP_BY_EMAIL" ]; then
     # the $commit can be empty
     # shellcheck disable=SC2086
-    git shortlog -n -s -e $commit | dedup_by_email | format_authors
+    git shortlog $MERGES_ARG -n -s -e $commit | dedup_by_email | format_authors
   else
     # shellcheck disable=SC2086
-    git shortlog -n -s $commit | format_authors
+    git shortlog $MERGES_ARG -n -s $commit | format_authors
   fi
 fi

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -322,6 +322,7 @@ _git-standup() {
 _git-summary() {
     _arguments '--line[summarize with lines rather than commits]'
     _arguments '--dedup-by-email[remove duplicate users by the email address]'
+    _arguments '--no-merges[exclude merge commits]'
     __gitex_commits
 }
 

--- a/etc/git-extras.fish
+++ b/etc/git-extras.fish
@@ -170,6 +170,7 @@ complete -c git -x -n '__fish_git_using_command standup' -s n -d 'Limit the numb
 # summary
 complete -c git    -n '__fish_git_using_command summary' -l line -d 'summarize with lines rather than commits'
 complete -c git    -n '__fish_git_using_command summary' -l dedup-by-email -d 'remove duplicate users by the email address'
+complete -c git    -n '__fish_git_using_command summary' -l no-merges -d 'exclude merge commits'
 # release
 complete -c git -x -n '__fish_git_using_command release' -s c -d 'Generates/populates the changelog with all commit message since the last tag'
 complete -c git -x -n '__fish_git_using_command release' -s r -d 'The "remote" repository that is destination of a push operation'

--- a/man/git-summary.1
+++ b/man/git-summary.1
@@ -1,68 +1,50 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-SUMMARY" "1" "July 2021" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-SUMMARY" "1" "August 2021" "" "Git Extras"
 .SH "NAME"
 \fBgit\-summary\fR \- Show repository summary
-.
 .SH "SYNOPSIS"
-\fBgit\-summary\fR [\-\-line] [\-\-dedup\-by\-email] [<committish or path>]
-.
+\fBgit\-summary\fR [\-\-line] [\-\-dedup\-by\-email] [\-\-no\-merges] [<committish or path>]
 .SH "DESCRIPTION"
 Shows a summary of the repository\.
-.
 .SH "OPTIONS"
 <committish>
-.
 .P
 Summarize only the range of commits included in the <committish>\.
-.
 .P
 <path>
-.
 .P
 Summarize only the range of files included in the <path>\.
-.
 .P
 \-\-dedup\-by\-email
-.
 .P
 Remove duplicate authors who belong to the same email address\. For example,
-.
 .IP "" 4
-.
 .nf
-
 $ git summary
-\.\.\.
+\|\.\|\.\|\.
 133  TJ Holowaychuk            9\.9%
 115  Tj Holowaychuk            8\.5%
 
 $ git summary \-\-dedup\-by\-email
-\.\.\.
+\|\.\|\.\|\.
 248  TJ Holowaychuk            18\.4%
-.
 .fi
-.
 .IP "" 0
-.
 .P
 This option can not be used together with \fB\-\-line\fR\.
-.
 .P
 \-\-line
-.
 .P
 Summarize with lines other than commits\. When \fB\-\-line\fR is specified, the last argument is treated as <path>\.
-.
+.P
+\-\-no\-merges
+.P
+Exclude merge commits\.
 .SH "EXAMPLES"
 Outputs a repo summary:
-.
 .IP "" 4
-.
 .nf
-
 $ git summary
 
 project  : express
@@ -89,65 +71,42 @@ authors  :
     1 ewoudj
     1 isaacs
     1 Matt Colyer
-.
 .fi
-.
 .IP "" 0
-.
 .P
 This command can also take a committish, and will print a summary for the range of commits included in the committish:
-.
 .IP "" 4
-.
 .nf
-
 $ git summary v42\.\.
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Outputs a repo summary by line:
-.
 .IP "" 4
-.
 .nf
-
 $ git summary \-\-line
 
 project  : git\-extras
 lines    : 26820
 authors  :
-  \.\.\.
-.
+  \|\.\|\.\|\.
 .fi
-.
 .IP "" 0
-.
 .P
 Filter with the path:
-.
 .IP "" 4
-.
 .nf
-
 $ git summary \-\-line bin/
 
 project  : git\-extras
 lines    : 4420
 authors  :
-  \.\.\.
-.
+  \|\.\|\.\|\.
 .fi
-.
 .IP "" 0
-.
 .SH "AUTHOR"
 Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>
-.
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>
-.
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-summary.1
+++ b/man/git-summary.1
@@ -4,7 +4,9 @@
 .SH "NAME"
 \fBgit\-summary\fR \- Show repository summary
 .SH "SYNOPSIS"
-\fBgit\-summary\fR [\-\-line] [\-\-dedup\-by\-email] [\-\-no\-merges] [<committish or path>]
+\fBgit\-summary\fR [\-\-dedup\-by\-email] [\-\-no\-merges] [<committish>]
+.br
+\fBgit\-summary\fR \-\-line [<path>]
 .SH "DESCRIPTION"
 Shows a summary of the repository\.
 .SH "OPTIONS"
@@ -32,15 +34,15 @@ $ git summary \-\-dedup\-by\-email
 .fi
 .IP "" 0
 .P
-This option can not be used together with \fB\-\-line\fR\.
+\-\-no\-merges
+.P
+Exclude merge commits\.
 .P
 \-\-line
 .P
 Summarize with lines other than commits\. When \fB\-\-line\fR is specified, the last argument is treated as <path>\.
 .P
-\-\-no\-merges
-.P
-Exclude merge commits\.
+This option can not be used together with \fB\-\-dedup\-by\-email\fR or \fB\-\-no\-merges\fR\.
 .SH "EXAMPLES"
 Outputs a repo summary:
 .IP "" 4

--- a/man/git-summary.html
+++ b/man/git-summary.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-summary(1) - Show repository summary</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,14 +69,15 @@
     <li class='tr'>git-summary(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-summary</code> - <span class="man-whatis">Show repository summary</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-summary</code> [--line] [--dedup-by-email] [&lt;committish or path&gt;]</p>
+<p><code>git-summary</code> [--line] [--dedup-by-email] [--no-merges] [&lt;committish or path&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -84,17 +85,17 @@
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  &lt;committish&gt;</p>
+<p>&lt;committish&gt;</p>
 
-<p>  Summarize only the range of commits included in the &lt;committish&gt;.</p>
+<p>Summarize only the range of commits included in the &lt;committish&gt;.</p>
 
-<p>  &lt;path&gt;</p>
+<p>&lt;path&gt;</p>
 
-<p>  Summarize only the range of files included in the &lt;path&gt;.</p>
+<p>Summarize only the range of files included in the &lt;path&gt;.</p>
 
-<p>  --dedup-by-email</p>
+<p>--dedup-by-email</p>
 
-<p>  Remove duplicate authors who belong to the same email address.
+<p>Remove duplicate authors who belong to the same email address.
   For example,</p>
 
 <pre><code>$ git summary
@@ -107,16 +108,20 @@ $ git summary --dedup-by-email
 248  TJ Holowaychuk            18.4%
 </code></pre>
 
-<p>  This option can not be used together with <code>--line</code>.</p>
+<p>This option can not be used together with <code>--line</code>.</p>
 
-<p>  --line</p>
+<p>--line</p>
 
-<p>  Summarize with lines other than commits.
+<p>Summarize with lines other than commits.
   When <code>--line</code> is specified, the last argument is treated as &lt;path&gt;.</p>
+
+<p>--no-merges</p>
+
+<p>Exclude merge commits.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p>  Outputs a repo summary:</p>
+<p>Outputs a repo summary:</p>
 
 <pre><code>$ git summary
 
@@ -146,13 +151,13 @@ authors  :
     1 Matt Colyer
 </code></pre>
 
-<p>  This command can also take a committish, and will print a summary for the range
+<p>This command can also take a committish, and will print a summary for the range
   of commits included in the committish:</p>
 
 <pre><code>$ git summary v42..
 </code></pre>
 
-<p>  Outputs a repo summary by line:</p>
+<p>Outputs a repo summary by line:</p>
 
 <pre><code>$ git summary --line
 
@@ -162,7 +167,7 @@ authors  :
   ...
 </code></pre>
 
-<p>  Filter with the path:</p>
+<p>Filter with the path:</p>
 
 <pre><code>$ git summary --line bin/
 
@@ -174,7 +179,7 @@ authors  :
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#x3a;&#116;&#x6a;&#x40;&#118;&#x69;&#x73;&#x69;&#x6f;&#110;&#x2d;&#109;&#101;&#100;&#x69;&#97;&#x2e;&#99;&#x61;" data-bare-link="true">&#116;&#106;&#x40;&#x76;&#105;&#115;&#105;&#111;&#110;&#x2d;&#109;&#101;&#100;&#105;&#x61;&#x2e;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="mailto:tj@vision-media.ca" data-bare-link="true">tj@vision-media.ca</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -184,10 +189,9 @@ authors  :
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2021</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>git-summary(1)</li>
   </ol>
 

--- a/man/git-summary.html
+++ b/man/git-summary.html
@@ -77,7 +77,8 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-summary</code> [--line] [--dedup-by-email] [--no-merges] [&lt;committish or path&gt;]</p>
+<p><code>git-summary</code> [--dedup-by-email] [--no-merges] [&lt;committish&gt;]<br>
+ <code>git-summary</code> --line [&lt;path&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -108,16 +109,16 @@ $ git summary --dedup-by-email
 248  TJ Holowaychuk            18.4%
 </code></pre>
 
-<p>This option can not be used together with <code>--line</code>.</p>
+<p>--no-merges</p>
+
+<p>Exclude merge commits.</p>
 
 <p>--line</p>
 
 <p>Summarize with lines other than commits.
   When <code>--line</code> is specified, the last argument is treated as &lt;path&gt;.</p>
 
-<p>--no-merges</p>
-
-<p>Exclude merge commits.</p>
+<p>This option can not be used together with <code>--dedup-by-email</code> or <code>--no-merges</code>.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 

--- a/man/git-summary.md
+++ b/man/git-summary.md
@@ -3,7 +3,8 @@ git-summary(1) -- Show repository summary
 
 ## SYNOPSIS
 
-`git-summary` [--line] [--dedup-by-email] [--no-merges] [&lt;committish or path&gt;]
+ `git-summary` [--dedup-by-email] [--no-merges] [&lt;committish&gt;]  
+ `git-summary` --line [&lt;path&gt;]
 
 ## DESCRIPTION
 
@@ -33,16 +34,16 @@ Shows a summary of the repository.
     ...
     248  TJ Holowaychuk            18.4%
 
-  This option can not be used together with `--line`.
+  --no-merges
+
+  Exclude merge commits.
 
   --line
 
   Summarize with lines other than commits.
   When `--line` is specified, the last argument is treated as &lt;path&gt;.
 
-  --no-merges
-
-  Exclude merge commits.
+  This option can not be used together with `--dedup-by-email` or `--no-merges`.
 
 ## EXAMPLES
 

--- a/man/git-summary.md
+++ b/man/git-summary.md
@@ -3,7 +3,7 @@ git-summary(1) -- Show repository summary
 
 ## SYNOPSIS
 
-`git-summary` [--line] [--dedup-by-email] [&lt;committish or path&gt;]
+`git-summary` [--line] [--dedup-by-email] [--no-merges] [&lt;committish or path&gt;]
 
 ## DESCRIPTION
 
@@ -39,6 +39,10 @@ Shows a summary of the repository.
 
   Summarize with lines other than commits.
   When `--line` is specified, the last argument is treated as &lt;path&gt;.
+
+  --no-merges
+
+  Exclude merge commits.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Added option --no-merges to git summary, which excludes merges when counting everything. I've only tested it on Linux, I'd appreciate if someone could help with testing on OSX and BSD.