### PR TITLE
fix git (un)lock with spaced filenames

### DIFF
--- a/bin/git-lock
+++ b/bin/git-lock
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-filename=$1
-test -z $filename && echo "filename required." 1>&2 && exit 1
-git update-index --skip-worktree $filename
+filename="$1"
+test -z "$filename" && echo "filename required." 1>&2 && exit 1
+git update-index --skip-worktree "$filename"

--- a/bin/git-unlock
+++ b/bin/git-unlock
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-filename=$1
-test -z $filename && echo "filename required." 1>&2 && exit 1
-git update-index --no-skip-worktree $filename
+filename="$1"
+test -z "$filename" && echo "filename required." 1>&2 && exit 1
+git update-index --no-skip-worktree "$filename"


### PR DESCRIPTION
Before:
```
$ git lock "filename including spaces.oh"
git-lock: line 37: test: too many arguments
fatal: Unable to mark file filename 
```

After:
```
$ git lock "filename including spaces.oh"
$ git unlock "filename including spaces.oh"
```