### PR TITLE
Format fix of Synopsis in manuals

### DIFF
--- a/man/git-alias.1
+++ b/man/git-alias.1
@@ -1,85 +1,58 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-ALIAS" "1" "October 2017" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-ALIAS" "1" "August 2021" "" "Git Extras"
 .SH "NAME"
 \fBgit\-alias\fR \- Define, search and show aliases
-.
 .SH "SYNOPSIS"
-\fBgit\-alias\fR \fBgit\-alias\fR <search\-pattern> \fBgit\-alias\fR <alias\-name> <command>
-.
+\fBgit\-alias\fR
+.br
+\fBgit\-alias\fR <search\-pattern>
+.br
+\fBgit\-alias\fR <alias\-name> <command>
 .SH "DESCRIPTION"
 List all aliases, show one alias, or set one (global) alias\.
-.
 .SH "OPTIONS"
 <search\-pattern>
-.
 .P
 The pattern used to search aliases\.
-.
 .P
 <alias\-name>
-.
 .P
 The name of the alias to create\.
-.
 .P
 <command>
-.
 .P
 The command for which you are creating an alias\.
-.
 .SH "EXAMPLES"
 Defining a new alias:
-.
 .IP "" 4
-.
 .nf
-
 $ git alias last "cat\-file commit HEAD"
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Providing only one argument, \fBgit\-alias\fR searches for aliases matching the given value:
-.
 .IP "" 4
-.
 .nf
-
 $ git alias ^la
 last = cat\-file commit HEAD
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \fBgit\-alias\fR will show all aliases if no argument is given:
-.
 .IP "" 4
-.
 .nf
-
 $ git alias
 s = status
 amend = commit \-\-amend
 rank = shortlog \-sn \-\-no\-merges
 whatis = show \-s \-\-pretty=\'tformat:%h (%s, %ad)\' \-\-date=short
 whois = !sh \-c \'git log \-i \-1 \-\-pretty="format:%an <%ae>
-.
 .fi
-.
 .IP "" 0
-.
 .SH "AUTHOR"
 Written by Jonhnny Weslley <\fIjw@jonhnnyweslley\.net\fR>
-.
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>
-.
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-alias.html
+++ b/man/git-alias.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-alias(1) - Define, search and show aliases</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,61 +69,62 @@
     <li class='tr'>git-alias(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-alias</code> - <span class="man-whatis">Define, search and show aliases</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-alias</code>
-<code>git-alias</code> &lt;search-pattern&gt;
+<p><code>git-alias</code><br>
+<code>git-alias</code> &lt;search-pattern&gt;<br>
 <code>git-alias</code> &lt;alias-name&gt; &lt;command&gt;</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  List all aliases, show one alias, or set one (global) alias.</p>
+<p>List all aliases, show one alias, or set one (global) alias.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  &lt;search-pattern&gt;</p>
+<p>&lt;search-pattern&gt;</p>
 
-<p>  The pattern used to search aliases.</p>
+<p>The pattern used to search aliases.</p>
 
-<p>  &lt;alias-name&gt;</p>
+<p>&lt;alias-name&gt;</p>
 
-<p>  The name of the alias to create.</p>
+<p>The name of the alias to create.</p>
 
-<p>  &lt;command&gt;</p>
+<p>&lt;command&gt;</p>
 
-<p>  The command for which you are creating an alias.</p>
+<p>The command for which you are creating an alias.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p> Defining a new alias:</p>
+<p>Defining a new alias:</p>
 
 <pre><code>$ git alias last "cat-file commit HEAD"
 </code></pre>
 
-<p> Providing only one argument, <code>git-alias</code> searches for aliases matching the given value:</p>
+<p>Providing only one argument, <code>git-alias</code> searches for aliases matching the given value:</p>
 
 <pre><code>$ git alias ^la
 last = cat-file commit HEAD
 </code></pre>
 
-<p> <code>git-alias</code> will show all aliases if no argument is given:</p>
+<p><code>git-alias</code> will show all aliases if no argument is given:</p>
 
 <pre><code>$ git alias
 s = status
 amend = commit --amend
 rank = shortlog -sn --no-merges
 whatis = show -s --pretty='tformat:%h (%s, %ad)' --date=short
-whois = !sh -c 'git log -i -1 --pretty="format:%an &lt;%ae>
+whois = !sh -c 'git log -i -1 --pretty="format:%an &lt;%ae&gt;
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Jonhnny Weslley &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#x6f;&#x3a;&#x6a;&#119;&#x40;&#x6a;&#x6f;&#x6e;&#104;&#x6e;&#x6e;&#121;&#x77;&#101;&#115;&#108;&#108;&#101;&#x79;&#x2e;&#110;&#x65;&#116;" data-bare-link="true">&#x6a;&#x77;&#64;&#106;&#111;&#x6e;&#104;&#x6e;&#x6e;&#x79;&#119;&#x65;&#115;&#108;&#x6c;&#101;&#121;&#46;&#x6e;&#101;&#116;</a>&gt;</p>
+<p>Written by Jonhnny Weslley &lt;<a href="mailto:jw@jonhnnyweslley.net" data-bare-link="true">jw@jonhnnyweslley.net</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -133,10 +134,9 @@ whois = !sh -c 'git log -i -1 --pretty="format:%an &lt;%ae>
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>git-alias(1)</li>
   </ol>
 

--- a/man/git-alias.md
+++ b/man/git-alias.md
@@ -3,9 +3,9 @@ git-alias(1) -- Define, search and show aliases
 
 ## SYNOPSIS
 
-`git-alias`
-`git-alias` &lt;search-pattern&gt;
-`git-alias` &lt;alias-name&gt; &lt;command&gt;
+`git-alias`  
+`git-alias` &lt;search-pattern&gt;  
+`git-alias` &lt;alias-name&gt; &lt;command&gt;  
 
 ## DESCRIPTION
 

--- a/man/git-force-clone.1
+++ b/man/git-force-clone.1
@@ -1,57 +1,42 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-FORCE\-CLONE" "1" "October 2017" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-FORCE\-CLONE" "1" "August 2021" "" "Git Extras"
 .SH "NAME"
 \fBgit\-force\-clone\fR \- overwrite local repositories with clone
-.
 .SH "SYNOPSIS"
-\fBforce\-clone \-\-help\fR \fBforce\-clone {remote_url} {destination_path}\fR \fBforce\-clone \-\-branch {branch_name} {remote_url} {destination_path}\fR
-.
+\fBforce\-clone \-\-help\fR
+.br
+\fBforce\-clone {remote_url} {destination_path}\fR
+.br
+\fBforce\-clone \-\-branch {branch_name} {remote_url} {destination_path}\fR
 .SH "DESCRIPTION"
 Provides the basic functionality of \fBgit clone\fR, but if the destination git repository already exists it will force\-reset it to resemble a clone of the remote\.
-.
 .P
 Because it doesn\'t actually delete the directory, it is usually significantly faster than the alternative of deleting the directory and cloning the repository from scratch\.
-.
 .P
 \fBCAUTION\fR: If the repository exists, this will destroy \fIall\fR local work: changed files will be reset, local branches and other remotes will be removed\.
-.
 .SH "PROCESS"
 If \fBtarget\-directory\fR doesn\'t exist or isn\'t a git repository then the arguments will simply be passed through to \fBgit clone\fR\.
-.
 .P
 If \fBtarget\-directory\fR exists and is a git repository then this will:
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Remove all remotes
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Set the origin remote to \fB{remote_url}\fR and fetch the remote
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Discover the default branch, if no branch was specified
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Check out the selected branch
-.
-.IP "\(bu" 4
+.IP "\[ci]" 4
 Delete all other local branches
-.
 .IP "" 0
-.
 .SH "OPTIONS"
 \fB{remote_url}\fR \- The URL for a git remote repository of which to make a clone\. \fB{destination_path}\fR \- A path to the local git repository location to clone into\. \fB\-\-branch {branch_name}\fR \- After cloning, checkout this branch\.
-.
 .SH "EXAMPLES"
 \fBgit\-force\-clone \-b master git@github\.com:me/repo\.git \./repo_dir\fR
-.
 .SH "AUTHOR"
 Written by Robin Winslow \fIrobin@robinwinslow\.co\.uk\fR\.
-.
 .SH "REPORTING BUGS"
 \fIhttps://github\.com/tj/git\-extras/issues\fR
-.
 .SH "SEE ALSO"
 \fIhttps://github\.com/tj/git\-extras\fR

--- a/man/git-force-clone.html
+++ b/man/git-force-clone.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-force-clone(1) - overwrite local repositories with clone</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -70,15 +70,16 @@
     <li class='tr'>git-force-clone(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-force-clone</code> - <span class="man-whatis">overwrite local repositories with clone</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>force-clone --help</code>
-<code>force-clone {remote_url} {destination_path}</code>
+<p><code>force-clone --help</code><br>
+<code>force-clone {remote_url} {destination_path}</code><br>
 <code>force-clone --branch {branch_name} {remote_url} {destination_path}</code></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
@@ -102,13 +103,12 @@ arguments will simply be passed through to <code>git clone</code>.</p>
 <p>If <code>target-directory</code> exists and is a git repository then this will:</p>
 
 <ul>
-<li>Remove all remotes</li>
-<li>Set the origin remote to <code>{remote_url}</code> and fetch the remote</li>
-<li>Discover the default branch, if no branch was specified</li>
-<li>Check out the selected branch</li>
-<li>Delete all other local branches</li>
+  <li>Remove all remotes</li>
+  <li>Set the origin remote to <code>{remote_url}</code> and fetch the remote</li>
+  <li>Discover the default branch, if no branch was specified</li>
+  <li>Check out the selected branch</li>
+  <li>Delete all other local branches</li>
 </ul>
-
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -122,7 +122,7 @@ arguments will simply be passed through to <code>git clone</code>.</p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Robin Winslow <a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#58;&#x72;&#111;&#98;&#x69;&#x6e;&#x40;&#114;&#111;&#x62;&#105;&#110;&#x77;&#x69;&#110;&#x73;&#x6c;&#111;&#x77;&#46;&#99;&#111;&#46;&#117;&#x6b;" data-bare-link="true">&#x72;&#x6f;&#x62;&#x69;&#110;&#x40;&#114;&#x6f;&#x62;&#105;&#x6e;&#x77;&#x69;&#x6e;&#x73;&#108;&#111;&#x77;&#46;&#x63;&#x6f;&#x2e;&#117;&#x6b;</a>.</p>
+<p>Written by Robin Winslow <a href="mailto:robin@robinwinslow.co.uk" data-bare-link="true">robin@robinwinslow.co.uk</a>.</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -132,10 +132,9 @@ arguments will simply be passed through to <code>git clone</code>.</p>
 
 <p><a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a></p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>git-force-clone(1)</li>
   </ol>
 

--- a/man/git-force-clone.md
+++ b/man/git-force-clone.md
@@ -3,9 +3,9 @@ git-force-clone(1) -- overwrite local repositories with clone
 
 ## SYNOPSIS
 
-`force-clone --help`
-`force-clone {remote_url} {destination_path}`
-`force-clone --branch {branch_name} {remote_url} {destination_path}`
+`force-clone --help`  
+`force-clone {remote_url} {destination_path}`  
+`force-clone --branch {branch_name} {remote_url} {destination_path}`  
 
 ## DESCRIPTION
 

--- a/man/git-psykorebase.1
+++ b/man/git-psykorebase.1
@@ -1,11 +1,11 @@
-.\" generated with Ronn-NG/v0.9.0
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.0
-.TH "GIT\-PSYKOREBASE" "1" "March 2020" "" "Git Extras"
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-PSYKOREBASE" "1" "August 2021" "" "Git Extras"
 .SH "NAME"
 \fBgit\-psykorebase\fR \- Rebase a branch with a merge commit
 .SH "SYNOPSIS"
 \fBgit\-psykorebase\fR <target_branch> [<feature_branch>] [\-\-no\-ff]
-.P
+.br
 \fBgit\-psykorebase\fR \-\-continue
 .SH "DESCRIPTION"
 Rebase the \fBfeature_branch\fR on top of the \fBtarget_branch\fR, the \fBfeature_branch\fR defaults to the current one\.
@@ -35,12 +35,12 @@ $ git psykorebase \-\-continue
 .fi
 .IP "" 0
 .SH "AUTHOR"
-Written by Rémy Hubscher <\fI\%mailto:hubscher\.remy@gmail\.com\fR>
+Written by Rémy Hubscher <\fIhubscher\.remy@gmail\.com\fR>
 .P
-Based on Benoît Bryon <\fI\%mailto:benoit@marmelune\.net\fR> implementation in Python\.
+Based on Benoît Bryon <\fIbenoit@marmelune\.net\fR> implementation in Python\.
 .SH "REPORTING BUGS"
-<\fI\%https://github\.com/tj/git\-extras/issues\fR>
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
 .SH "SEE ALSO"
-<\fI\%https://github\.com/tj/git\-extras\fR>
+<\fIhttps://github\.com/tj/git\-extras\fR>
 .P
-<\fI\%https://github\.com/benoitbryon/psykorebase\fR>
+<\fIhttps://github\.com/benoitbryon/psykorebase\fR>

--- a/man/git-psykorebase.html
+++ b/man/git-psykorebase.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv='content-type' content='text/html;charset=utf8'>
-  <meta name='generator' content='Ronn-NG/v0.9.0 (http://github.com/apjanke/ronn-ng/tree/0.9.0)'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-psykorebase(1) - Rebase a branch with a merge commit</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -77,9 +77,8 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-psykorebase</code> &lt;target_branch&gt; [&lt;feature_branch&gt;] [--no-ff]</p>
-
-<p><code>git-psykorebase</code> --continue</p>
+<p><code>git-psykorebase</code> &lt;target_branch&gt; [&lt;feature_branch&gt;] [--no-ff]<br>
+<code>git-psykorebase</code> --continue</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -128,7 +127,7 @@ Python.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>March 2020</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>git-psykorebase(1)</li>
   </ol>
 

--- a/man/git-psykorebase.md
+++ b/man/git-psykorebase.md
@@ -3,8 +3,7 @@ git-psykorebase(1) -- Rebase a branch with a merge commit
 
 ## SYNOPSIS
 
-`git-psykorebase` &lt;target_branch&gt; [&lt;feature_branch&gt;] [--no-ff]
-
+`git-psykorebase` &lt;target_branch&gt; [&lt;feature_branch&gt;] [--no-ff]  
 `git-psykorebase` --continue
 
 ## DESCRIPTION

--- a/man/git-standup.1
+++ b/man/git-standup.1
@@ -1,105 +1,69 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-STANDUP" "1" "November 2019" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-STANDUP" "1" "August 2021" "" "Git Extras"
 .SH "NAME"
 \fBgit\-standup\fR \- Recall the commit history
-.
 .SH "SYNOPSIS"
 \fBgit\-standup\fR [\-a author] [\-m depth] [\-d days ago] [\-D date format] [\-g] [\-L] [\-f] [\-B] [\-n number of commits]
-.
-.P
+.br
 \fBgit\-standup\fR \-h
-.
 .SH "DESCRIPTION"
 Recall what you did on the last working day \.\.or be nosy and find what someone else did\.
-.
 .SH "OPTIONS"
 \-a author
-.
 .P
 The author of commits\. Use "all" means specifying "all authors"\. Defaults to \fB$(git config user\.name)\fR\.
-.
 .P
 \-m depth
-.
 .P
 The depth of recursive directory search\. Defaults to 1\.
-.
 .P
 \-L
-.
 .P
 Enable the inclusion of symbolic links in recursive directory search\.
-.
 .P
 \-d 1
-.
 .P
 The start of commit history\. Defaults to 1, means "1 days ago"\.
-.
 .P
 \-D relative
-.
 .P
 The date format displayed in commit history\. Defaults to "relative"\.
-.
 .P
 \-h
-.
 .P
 Display help message\.
-.
 .P
 \-g
-.
 .P
 Display if commit is GPG signed (G) or not (N) in commit message\.
-.
 .P
 \-f
-.
 .P
 Fetch the latest commits before showing commit history\.
-.
 .P
 The former version of \fBgit standup\fR accepted \fB<author> <since> <until>\fR as options\. This interface is deprecated now, and please avoid to use it!
-.
 .P
 \-B
-.
 .P
 Display the commits in branch groups\.
-.
 .P
 \-n number\-of\-commits
-.
 .P
-Limit the number of commits displayed per group\. By default, the limitation is applied in the repository level\. For example, if you have 3 repositories under the current directory, \fBgit standup \.\.\. \-n 1\fR will show you 3 commits at most\. When \fB\-B\fR is specific, the limitation is applied in the branch level\. For instance, if each of your 3 repositories have 2 branches, \fBgit standup \.\.\. \-B \-n 1\fR will display 6 commits at most\.
-.
+Limit the number of commits displayed per group\. By default, the limitation is applied in the repository level\. For example, if you have 3 repositories under the current directory, \fBgit standup \|\.\|\.\|\. \-n 1\fR will show you 3 commits at most\. When \fB\-B\fR is specific, the limitation is applied in the branch level\. For instance, if each of your 3 repositories have 2 branches, \fBgit standup \|\.\|\.\|\. \-B \-n 1\fR will display 6 commits at most\.
 .SH "EXAMPLES"
 This shows your commits since yesterday:
-.
 .IP "" 4
-.
 .nf
-
 $ git standup
 
 a26d1f9 \- add profile hook (69 minutes ago) <spacewander>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 This shows the author\'s commits since last week:
-.
 .IP "" 4
-.
 .nf
-
 $ git standup \-a spacewander \-d 7
 
 a26d1f9 \- add profile hook (70 minutes ago) <spacewander>
@@ -107,18 +71,12 @@ a26d1f9 \- add profile hook (70 minutes ago) <spacewander>
 36da84e \- fix rename over bound (7 days ago) <spacewander>
 8e4182a \- add watermark\.png (7 days ago) <spacewander>
 46fef1d \- use tinyXML to configure (7 days ago) <spacewander>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 If current directory is not a git repo, git\-standup will fetch data from all top\-level git repos under it:
-.
 .IP "" 4
-.
 .nf
-
 $ cd \.\.
 $ git standup \-a spacewander \-d 7
 
@@ -127,18 +85,12 @@ someProject/
 36da84e \- fix rename over bound (7 days ago) <spacewander>
 8e4182a \- add watermark\.png (7 days ago) <spacewander>
 46fef1d \- use tinyXML to configure (7 days ago) <spacewander>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 By specifying the \fB\-B\fR option, git\-standuo will group the commits in branches:
-.
 .IP "" 4
-.
 .nf
-
 $ git standup \-B \-a spacewander \-d 7
 
 git\-summary\-cleanup
@@ -149,19 +101,13 @@ ff991ac \- git\-summary: remove useless result function\. (23 hours ago) <spacew
 
 master
 203f5b4 \- git\-summary: add \-\-dedup\-by\-email to remove duplicate users (5 days ago) <spacewander>
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Note that the same commit can be seen in different branches\.
-.
 .SH "AUTHOR"
 Originally from https://github\.com/kamranahmedse/git\-standup
-.
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>
-.
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-standup.html
+++ b/man/git-standup.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-standup(1) - Recall the commit history</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,16 +69,16 @@
     <li class='tr'>git-standup(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-standup</code> - <span class="man-whatis">Recall the commit history</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-standup</code> [-a author] [-m depth] [-d days ago] [-D date format] [-g] [-L] [-f] [-B] [-n number of commits]</p>
-
-<p><code>git-standup</code> -h</p>
+<p><code>git-standup</code> [-a author] [-m depth] [-d days ago] [-D date format] [-g] [-L] [-f] [-B] [-n number of commits]<br>
+<code>git-standup</code> -h</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -119,7 +119,7 @@ Defaults to <code>$(git config user.name)</code>.</p>
 
 <p>Fetch the latest commits before showing commit history.</p>
 
-<p>The former version of <code>git standup</code> accepted <code>&lt;author> &lt;since> &lt;until></code> as options.
+<p>The former version of <code>git standup</code> accepted <code>&lt;author&gt; &lt;since&gt; &lt;until&gt;</code> as options.
 This interface is deprecated now, and please avoid to use it!</p>
 
 <p>-B</p>
@@ -142,18 +142,18 @@ display 6 commits at most.</p>
 
 <pre><code>$ git standup
 
-a26d1f9 - add profile hook (69 minutes ago) &lt;spacewander>
+a26d1f9 - add profile hook (69 minutes ago) &lt;spacewander&gt;
 </code></pre>
 
 <p>This shows the author's commits since last week:</p>
 
 <pre><code>$ git standup -a spacewander -d 7
 
-a26d1f9 - add profile hook (70 minutes ago) &lt;spacewander>
-4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander>
-36da84e - fix rename over bound (7 days ago) &lt;spacewander>
-8e4182a - add watermark.png (7 days ago) &lt;spacewander>
-46fef1d - use tinyXML to configure (7 days ago) &lt;spacewander>
+a26d1f9 - add profile hook (70 minutes ago) &lt;spacewander&gt;
+4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander&gt;
+36da84e - fix rename over bound (7 days ago) &lt;spacewander&gt;
+8e4182a - add watermark.png (7 days ago) &lt;spacewander&gt;
+46fef1d - use tinyXML to configure (7 days ago) &lt;spacewander&gt;
 </code></pre>
 
 <p>If current directory is not a git repo, git-standup will fetch data from all top-level git repos under it:</p>
@@ -162,10 +162,10 @@ a26d1f9 - add profile hook (70 minutes ago) &lt;spacewander>
 $ git standup -a spacewander -d 7
 
 someProject/
-4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander>
-36da84e - fix rename over bound (7 days ago) &lt;spacewander>
-8e4182a - add watermark.png (7 days ago) &lt;spacewander>
-46fef1d - use tinyXML to configure (7 days ago) &lt;spacewander>
+4e19859 - fix getTotalSize return value error (6 days ago) &lt;spacewander&gt;
+36da84e - fix rename over bound (7 days ago) &lt;spacewander&gt;
+8e4182a - add watermark.png (7 days ago) &lt;spacewander&gt;
+46fef1d - use tinyXML to configure (7 days ago) &lt;spacewander&gt;
 </code></pre>
 
 <p>By specifying the <code>-B</code> option, git-standuo will group the commits in branches:</p>
@@ -173,13 +173,13 @@ someProject/
 <pre><code>$ git standup -B -a spacewander -d 7
 
 git-summary-cleanup
-f788c78 - git-summary: clean up other shellcheck warnings (23 hours ago) &lt;spacewander>
-3e8c3ab - git-summary: fix incorrect active days when commits range is given (23 hours ago) &lt;spacewander>
-ff991ac - git-summary: remove useless result function. (23 hours ago) &lt;spacewander>
-203f5b4 - git-summary: add --dedup-by-email to remove duplicate users (5 days ago) &lt;spacewander>
+f788c78 - git-summary: clean up other shellcheck warnings (23 hours ago) &lt;spacewander&gt;
+3e8c3ab - git-summary: fix incorrect active days when commits range is given (23 hours ago) &lt;spacewander&gt;
+ff991ac - git-summary: remove useless result function. (23 hours ago) &lt;spacewander&gt;
+203f5b4 - git-summary: add --dedup-by-email to remove duplicate users (5 days ago) &lt;spacewander&gt;
 
 master
-203f5b4 - git-summary: add --dedup-by-email to remove duplicate users (5 days ago) &lt;spacewander>
+203f5b4 - git-summary: add --dedup-by-email to remove duplicate users (5 days ago) &lt;spacewander&gt;
 </code></pre>
 
 <p>Note that the same commit can be seen in different branches.</p>
@@ -196,10 +196,9 @@ master
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>November 2019</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>git-standup(1)</li>
   </ol>
 

--- a/man/git-standup.md
+++ b/man/git-standup.md
@@ -3,8 +3,7 @@ git-standup(1) -- Recall the commit history
 
 ## SYNOPSIS
 
-`git-standup` [-a author] [-m depth] [-d days ago] [-D date format] [-g] [-L] [-f] [-B] [-n number of commits]
-
+`git-standup` [-a author] [-m depth] [-d days ago] [-D date format] [-g] [-L] [-f] [-B] [-n number of commits]  
 `git-standup` -h
 
 ## DESCRIPTION


### PR DESCRIPTION
Fixed issues where the synopsis was split in to several paragraphs, or when several command variants was garbled into one line.