### PR TITLE
Compare email adresses case insensitive in --dedup-by-email

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -87,11 +87,11 @@ dedup_by_email() {
     LC_ALL=C awk '
     {
         sum += $1
-        lastField = tolower($NF)
-        if (lastField in emails) {
-            emails[lastField] += $1
+        last_field = tolower($NF)
+        if (last_field in emails) {
+            emails[last_field] += $1
         } else {
-            email = lastField
+            email = last_field
             emails[email] = $1
             # set commits/email to empty
             $1=$NF=""

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -80,17 +80,18 @@ file_count() {
 
 dedup_by_email() {
     # in:
-    # 27  luo zexuan <luozexuan@xxx.com>
+    # 27  luo zexuan <LuoZexuan@xxx.com>
     #  7  罗泽轩 <luozexuan@xxx.com>
     # out:
     # 34 luo zexuan
     LC_ALL=C awk '
     {
         sum += $1
-        if ($NF in emails) {
-            emails[$NF] += $1
+        lastField = tolower($NF)
+        if (lastField in emails) {
+            emails[lastField] += $1
         } else {
-            email = $NF
+            email = lastField
             emails[email] = $1
             # set commits/email to empty
             $1=$NF=""


### PR DESCRIPTION
SMTP adresses are case insensitive, so --dedup-by-email should treat them as that.