### PR TITLE
git-clear: add force option

### DIFF
--- a/bin/git-clear
+++ b/bin/git-clear
@@ -1,7 +1,43 @@
 #!/usr/bin/env bash
+PROGNAME="git-clear"
+FORCE=0
 
-echo -n "Sure? - This command may delete files that cannot be recovered, including those in .gitignore [y/N]: "
-read ans
-if [ "$ans" == "y" ] 
-    then git clean -d -f -x && git reset --hard
+function _usage() {
+cat << EOF
+usage: $PROGNAME options
+usage: $PROGNAME -h|help|?
+
+clear git repository
+
+OPTIONS:
+  -f, --force               Force clear without questioning user
+  -h, --help, ?             Show this message
+EOF
+}
+
+# Read arguments
+while [ "$1" != "" ]; do
+    case $1 in
+        -f|--force)
+            FORCE=1
+        ;;
+        -h|--help|?)
+            _usage
+            exit 1
+        ;;
+    esac
+
+    shift
+done
+
+# Only wait for answer if not forced by user
+if [[ $FORCE == 0 ]]; then
+    echo -n "Sure? - This command may delete files that cannot be recovered, including those in .gitignore [y/N]: "
+    read clean
+else
+    clean=y
+fi
+
+if [ "$clean" == "y" ]; then
+    git clean -d -f -x && git reset --hard
 fi

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -114,6 +114,12 @@ _git-changelog() {
         '(-l --list)'{-l,--list}'[list commits]' \
 }
 
+_git-clear() {
+    _arguments \
+        '(-f --force)'{-f,--force}'[force clear]' \
+        '(-h --help)'{-h,--help}'[help message]' \
+}
+
 _git-coauthor() {
     _arguments \
         ':co-author[co-author to add]' \
@@ -160,7 +166,7 @@ _git-delete-branch() {
 
 _git-delete-squashed-branches() {
     _arguments \
-        ':branch-name:__gitex_branch_names'    
+        ':branch-name:__gitex_branch_names'
 }
 
 

--- a/man/git-clear.1
+++ b/man/git-clear.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-CLEAR" "1" "May 2018" "" "Git Extras"
+.TH "GIT\-CLEAR" "1" "September 2021" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-clear\fR \- Rigorously clean up a repository
@@ -12,16 +12,31 @@
 .SH "DESCRIPTION"
 Clears the repository to a state that it looks as if it was freshly cloned with the current HEAD\. Basically it is a git\-reset \-\-hard together with deletion of all untracked files that reside inside the working directory, including those in \.gitignore\.
 .
+.SH "OPTIONS"
+\-f, \-\-force
+.
+.P
+Force the clean, with no warning to the user
+.
+.P
+\-h, \-\-help, ?
+.
+.P
+Display usage
+.
 .SH "EXAMPLES"
-Clears the repo\.
 .
-.IP "" 4
+.IP "\(bu" 4
+Clears the repo, with user confirmation required\.
 .
-.nf
-
+.IP
 $ git clear
 .
-.fi
+.IP "\(bu" 4
+Clears the repo, without user confirmation\.
+.
+.IP
+$ git clear \-f
 .
 .IP "" 0
 .

--- a/man/git-clear.html
+++ b/man/git-clear.html
@@ -56,6 +56,7 @@
     <a href="#NAME">NAME</a>
     <a href="#SYNOPSIS">SYNOPSIS</a>
     <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
     <a href="#EXAMPLES">EXAMPLES</a>
     <a href="#AUTHOR">AUTHOR</a>
     <a href="#REPORTING-BUGS">REPORTING BUGS</a>
@@ -83,16 +84,31 @@
   with the current HEAD. Basically it is a git-reset --hard together with
   deletion of all untracked files that reside inside the working directory, including those in .gitignore.</p>
 
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -f, --force</p>
+
+<p>  Force the clean, with no warning to the user</p>
+
+<p>  -h, --help, ?</p>
+
+<p>  Display usage</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p>  Clears the repo.</p>
+<ul>
+<li><p>Clears the repo, with user confirmation required.</p>
 
-<pre><code>$ git clear
-</code></pre>
+<p>$ git clear</p></li>
+<li><p>Clears the repo, without user confirmation.</p>
+
+<p>$ git clear -f</p></li>
+</ul>
+
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Daniel 'grindhold' Brendle &lt;<a href="&#x6d;&#x61;&#105;&#108;&#x74;&#x6f;&#58;&#103;&#114;&#x69;&#x6e;&#x64;&#x68;&#111;&#x6c;&#100;&#x40;&#x67;&#x6d;&#120;&#46;&#x6e;&#101;&#116;" data-bare-link="true">&#103;&#114;&#x69;&#110;&#100;&#104;&#111;&#x6c;&#x64;&#64;&#x67;&#x6d;&#x78;&#x2e;&#x6e;&#101;&#116;</a>&gt;</p>
+<p>Written by Daniel 'grindhold' Brendle &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#x6f;&#x3a;&#103;&#x72;&#x69;&#x6e;&#x64;&#104;&#x6f;&#x6c;&#x64;&#64;&#103;&#109;&#x78;&#46;&#x6e;&#101;&#116;" data-bare-link="true">&#x67;&#x72;&#105;&#x6e;&#100;&#104;&#111;&#x6c;&#100;&#64;&#103;&#109;&#x78;&#x2e;&#110;&#101;&#116;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -105,7 +121,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>May 2018</li>
+    <li class='tc'>September 2021</li>
     <li class='tr'>git-clear(1)</li>
   </ol>
 

--- a/man/git-clear.md
+++ b/man/git-clear.md
@@ -11,11 +11,25 @@ git-clear(1) -- Rigorously clean up a repository
   with the current HEAD. Basically it is a git-reset --hard together with
   deletion of all untracked files that reside inside the working directory, including those in .gitignore.
 
+## OPTIONS
+
+  -f, --force
+
+  Force the clean, with no warning to the user
+
+  -h, --help, ?
+
+  Display usage
+
 ## EXAMPLES
 
-  Clears the repo.
+  * Clears the repo, with user confirmation required.
 
     $ git clear
+
+  * Clears the repo, without user confirmation.
+
+    $ git clear -f
 
 ## AUTHOR
 


### PR DESCRIPTION
Add a new -f/--force option to git-clear to allow usage in scripts,
or without user input.

Add -h/--help/? for help

Also update the manual for git-clear for these changes.