### PR TITLE
git-release: Add prefix to semver

### DIFF
--- a/bin/git-release
+++ b/bin/git-release
@@ -51,6 +51,12 @@ if test $# -gt 0; then
       semver=$2
       shift
       ;;
+    --prefix)
+      test -z "$2" &&
+          exit_with_msg "prefix string required for --prefix option"
+      prefix="$2"
+      shift
+      ;;
     --no-empty-commit) no_empty_commit=true;;
     --) shift; hook_args="$hook_args $*"; break;;
     *) test -z "$version" && version=$1 ;;
@@ -69,7 +75,7 @@ if test $# -gt 0; then
     latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 
     if [[ ! "$latest_tag" =~ \
-        ^([^0-9]*)([1-9][0-9]+|[0-9])\.([1-9][0-9]+|[0-9])\.([1-9][0-9]+|[0-9])(.*) ]]; then
+        ^$prefix([^0-9]*)([1-9][0-9]+|[0-9])\.([1-9][0-9]+|[0-9])\.([1-9][0-9]+|[0-9])(.*) ]]; then
       echo "the latest tag doesn't match semver format requirement" 1>&2
       exit 1
     fi
@@ -86,9 +92,9 @@ if test $# -gt 0; then
     (( ++version ))
 
     case "$semver" in
-    major ) version="${BASH_REMATCH[1]}$version.0.0${BASH_REMATCH[5]}" ;;
-    minor ) version="${BASH_REMATCH[1]}${BASH_REMATCH[2]}.$version.0${BASH_REMATCH[5]}" ;;
-    patch ) version="${BASH_REMATCH[1]}${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.$version${BASH_REMATCH[5]}" ;;
+    major ) version="$prefix${BASH_REMATCH[1]}$version.0.0${BASH_REMATCH[5]}" ;;
+    minor ) version="$prefix${BASH_REMATCH[1]}${BASH_REMATCH[2]}.$version.0${BASH_REMATCH[5]}" ;;
+    patch ) version="$prefix${BASH_REMATCH[1]}${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.$version${BASH_REMATCH[5]}" ;;
     esac
   fi
 

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -291,6 +291,7 @@ _git-release() {
         '-s[Create a signed and annotated tag.]' \
         '-u[Create a tag, annotated and signed with the given key.]' \
         '--semver[If the latest tag in your repo matches the semver format requirement, you could increase part of it as the new release tag.]' \
+        '--prefix[Add a prefix string to semver to allow more complex tags.]' \
         '--no-empty-commit[Avoid creating empty commit if nothing could be committed.]' \
         '--[The arguments listed after "--" separator will be passed to pre/post-release hook.]'
 }

--- a/man/git-release.1
+++ b/man/git-release.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-RELEASE" "1" "April 2018" "" "Git Extras"
+.TH "GIT\-RELEASE" "1" "April 2022" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-release\fR \- Commit, tag and push changes to the repository
 .
 .SH "SYNOPSIS"
-\fBgit\-release\fR [<tagname> | \-\-semver <name>] [\-r <remote>] [\-m <commit info>] [\-\-no\-empty\-commit] [\-c] [\-s] [\-u <key-id>] [[\-\-] <hook arguments\.\.\.>]
+\fBgit\-release\fR [<tagname> | \-\-semver <name>] [\-r <remote>] [\-m <commit info>] [\-\-no\-empty\-commit] [\-c] [\-s] [\-u <key\-id>] [\-\-prefix <tag prefix>] [[\-\-] <hook arguments\.\.\.>]
 .
 .SH "DESCRIPTION"
 Commits changes with message "Release <tagname>" or custom commit information, tags with the given <tagname> and pushes the branch / tags\.
@@ -25,13 +25,19 @@ If \fB\.git/hook/pre\-release\fR or \fB\.git/hook/post\-release\fR exist, they w
 \-\-semver <name>
 .
 .P
-If the latest tag in your repo matches the semver format requirement, you could increase part of it as the new release tag with this option\. The name must be one of the \fBmajor\fR, \fBminor\fR, \fBpatch\fR\. For example, assumed the latest tag is \fB4\.4\.0\fR, with \fBgit release \-\-semver minor\fR you will make a new release with tag \fB4\.5\.0\fR\.
+If the latest tag in your repo matches the semver format requirement, you could increase part of it as the new release tag with this option\. The name must be one of the \fBmajor\fR, \fBminor\fR, \fBpatch\fR\. For example, assumed the latest tag is \fB4\.4\.0\fR, with \fBgit release \-\-semver minor\fR you will make a new release with tag \fB4\.5\.0\fR\. Use \fB\-\-prefix\fR if tag has a character before semver\.
 .
 .P
 <tagname>
 .
 .P
 The name of the newly created tag\. Also used in tag comment\.
+.
+.P
+\-\-prefix <tag prefix>
+.
+.P
+Use a prefix with a semver tag\. \fBgit release \-\-semver minor \-\-prefix r\fR would increment the latest tag r4\.4\.0 to r4\.5\.0\. This prefix can be any length, without spaces\.
 .
 .P
 \-r <remote>
@@ -64,7 +70,7 @@ Generates or populates the changelog with all commit message since the last tag\
 Create a signed and annotated tag\.
 .
 .P
-\-u <key ID>
+\-u <key\-id>
 .
 .P
 Create a tag, annotated and signed with the given key\.

--- a/man/git-release.html
+++ b/man/git-release.html
@@ -76,7 +76,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-release</code> [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [-s] [-u &lt;key-id&gt;] [[--] &lt;hook arguments...&gt;]</p>
+<p><code>git-release</code> [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [-s] [-u &lt;key-id&gt;] [--prefix &lt;tag prefix&gt;] [[--] &lt;hook arguments...&gt;]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -94,11 +94,16 @@
 
 <p>  If the latest tag in your repo matches the semver format requirement, you could increase part of it as the new release tag
   with this option. The name must be one of the <code>major</code>, <code>minor</code>, <code>patch</code>. For example, assumed the latest tag is <code>4.4.0</code>, with
-  <code>git release --semver minor</code> you will make a new release with tag <code>4.5.0</code>.</p>
+  <code>git release --semver minor</code> you will make a new release with tag <code>4.5.0</code>. Use <code>--prefix</code> if tag has a character before semver.</p>
 
 <p>  &lt;tagname&gt;</p>
 
 <p>  The name of the newly created tag. Also used in tag comment.</p>
+
+<p>  --prefix &lt;tag prefix&gt;</p>
+
+<p>  Use a prefix with a semver tag. <code>git release --semver minor --prefix r</code> would increment the latest tag r4.4.0 to r4.5.0. This prefix
+  can be any length, without spaces.</p>
 
 <p>  -r &lt;remote&gt;</p>
 
@@ -155,8 +160,8 @@ populate changelog, and push to specific remote.</p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#x6f;&#x3a;&#x74;&#106;&#x40;&#118;&#x69;&#115;&#105;&#x6f;&#110;&#45;&#x6d;&#x65;&#x64;&#105;&#x61;&#x2e;&#99;&#97;" data-bare-link="true">&#116;&#x6a;&#64;&#118;&#105;&#115;&#105;&#111;&#x6e;&#45;&#x6d;&#x65;&#x64;&#105;&#x61;&#46;&#99;&#x61;</a>&gt;
-Extended by David Hartmann &lt;<a href="&#x6d;&#x61;&#105;&#x6c;&#x74;&#111;&#58;&#100;&#104;&#x40;&#116;&#115;&#108;&#46;&#x69;&#111;" data-bare-link="true">&#100;&#x68;&#64;&#116;&#x73;&#108;&#46;&#105;&#x6f;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#x61;&#x69;&#108;&#116;&#x6f;&#x3a;&#116;&#106;&#x40;&#x76;&#105;&#115;&#x69;&#111;&#x6e;&#x2d;&#109;&#x65;&#x64;&#105;&#x61;&#46;&#99;&#97;" data-bare-link="true">&#x74;&#106;&#64;&#118;&#x69;&#115;&#105;&#111;&#x6e;&#45;&#109;&#x65;&#x64;&#105;&#x61;&#x2e;&#99;&#x61;</a>&gt;
+Extended by David Hartmann &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#116;&#x6f;&#x3a;&#100;&#104;&#x40;&#116;&#115;&#x6c;&#x2e;&#105;&#x6f;" data-bare-link="true">&#100;&#x68;&#64;&#116;&#x73;&#x6c;&#x2e;&#x69;&#111;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -169,7 +174,7 @@ Extended by David Hartmann &lt;<a href="&#x6d;&#x61;&#105;&#x6c;&#x74;&#111;&#58
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2018</li>
+    <li class='tc'>April 2022</li>
     <li class='tr'>git-release(1)</li>
   </ol>
 

--- a/man/git-release.md
+++ b/man/git-release.md
@@ -3,7 +3,7 @@ git-release(1) -- Commit, tag and push changes to the repository
 
 ## SYNOPSIS
 
-`git-release` [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [-s] [-u &lt;key-id&gt;] [[--] &lt;hook arguments...&gt;]
+`git-release` [&lt;tagname&gt; | --semver &lt;name&gt;] [-r &lt;remote&gt;] [-m &lt;commit info&gt;] [--no-empty-commit] [-c] [-s] [-u &lt;key-id&gt;] [--prefix &lt;tag prefix&gt;] [[--] &lt;hook arguments...&gt;]
 
 ## DESCRIPTION
 
@@ -21,11 +21,16 @@ git-release(1) -- Commit, tag and push changes to the repository
 
   If the latest tag in your repo matches the semver format requirement, you could increase part of it as the new release tag
   with this option. The name must be one of the `major`, `minor`, `patch`. For example, assumed the latest tag is `4.4.0`, with
-  `git release --semver minor` you will make a new release with tag `4.5.0`.
+  `git release --semver minor` you will make a new release with tag `4.5.0`. Use `--prefix` if tag has a character before semver.
 
   &lt;tagname&gt;
 
   The name of the newly created tag. Also used in tag comment.
+
+  --prefix &lt;tag prefix&gt;
+
+  Use a prefix with a semver tag. `git release --semver minor --prefix r` would increment the latest tag r4.4.0 to r4.5.0. This prefix
+  can be any length, without spaces.
 
   -r &lt;remote&gt;
 


### PR DESCRIPTION
To allow different release names other than specifically mm.vv.pp, this
adds the ability to use a prefix too.

For example, you can use:

```
$ git release --semver minor --prefix "prefix-"
```

This would allow the previous tags to be in the form `prefix-0.1.0`. A more obvious use case for this would be a single letter, such as `v` or `r` to use tags like: `r0.1.0` or `v0.1.0`.