### PR TITLE
feat: implement git-browse-ci

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -4,6 +4,7 @@
  - [`git archive-file`](#git-archive-file)
  - [`git authors`](#git-authors)
  - [`git browse`](#git-browse)
+ - [`git browse-ci`](#git-browse-ci)
  - [`git bulk`](#git-bulk)
  - [`git brv`](#git-brv)
  - [`git changelog`](#git-changelog)
@@ -1502,6 +1503,19 @@ Opens the current git repository website in your default web browser.
 
 ```bash
 $ git browse
+
+$ git browse upstream
+```
+
+## git browse-ci
+
+Opens the current git repository CI website (e.g. GitHub Actions, GitLab CI,
+Bitbucket Pipelines) in your default web browser.
+
+```bash
+$ git browse-ci
+
+$ git browse-ci upstream
 ```
 
 ## git utimes

--- a/bin/git-browse-ci
+++ b/bin/git-browse-ci
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "" ]]
+then
+    branch=$(git rev-parse --abbrev-ref HEAD 2&> /dev/null)
+    remote=$(git config branch."${branch}".remote || echo "origin")
+else
+    remote=$1
+fi
+
+if [[ $remote == "" ]]
+then
+    echo "Remote not found"
+    exit 1
+fi
+
+remote_url=$(git remote get-url "${remote}")
+
+if [[ $? -ne 0 ]]
+then
+    exit $?
+fi
+
+if [[ $remote_url = git@* ]]
+then
+    url=$(echo "${remote_url}" | sed -E -e 's/:/\//' -e 's/\.git$//' -e 's/.*@(.*)/http:\/\/\1/')
+elif [[ $remote_url = http* ]]
+then
+    url=${remote_url%.git}
+fi
+
+if [[ $url =~ github ]]
+then
+    ci_url=${url}/actions
+elif [[ $url =~ gitlab ]]
+then
+    ci_url=${url}/-/pipelines
+elif [[ $url =~ bitbucket ]]
+then
+    ci_url=${url}/addon/pipelines/home
+fi
+case "$OSTYPE" in
+    darwin*)
+        # MacOS
+        open "${ci_url}"
+        ;;
+    msys)
+        # Git-Bash on Windows
+        start "${ci_url}"
+        ;;
+    linux*)
+        # Handle WSL on Windows
+        if uname -a | grep -i -q Microsoft
+        then
+            powershell.exe -NoProfile start "${ci_url}"
+        else
+            xdg-open "${ci_url}"
+        fi
+        ;;
+    *)
+        # fall back to xdg-open for BSDs, etc.
+        xdg-open "${ci_url}"
+        ;;
+esac

--- a/bin/git-browse-ci
+++ b/bin/git-browse-ci
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e -o pipefail
+
 if [[ $1 == "" ]]
 then
     branch=$(git rev-parse --abbrev-ref HEAD 2&> /dev/null)

--- a/bin/git-browse-ci
+++ b/bin/git-browse-ci
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 set -e -o pipefail
-
 if [[ $1 == "" ]]
 then
-    branch=$(git rev-parse --abbrev-ref HEAD 2&> /dev/null)
+    branch=$(git rev-parse --abbrev-ref HEAD &> /dev/null)
     remote=$(git config branch."${branch}".remote || echo "origin")
 else
     remote=$1

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -154,3 +154,7 @@ _git_info(){
 _git_browse(){
   __git_complete_remote_or_refspec
 }
+
+_git_browse_ci(){
+  __git_complete_remote_or_refspec
+}

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -346,6 +346,7 @@ zstyle ':completion:*:*:git:*' user-commands $existing_user_commands \
     archive-file:'export the current head of the git repository to an archive' \
     authors:'generate authors report' \
     browse:'open repo website in browser' \
+    browse-ci:'open repo CI page in browser' \
     bug:'create bug branch' \
     bulk:'run bulk commands' \
     brv:'list branches sorted by their last commit date'\

--- a/etc/git-extras.fish
+++ b/etc/git-extras.fish
@@ -4,6 +4,7 @@ set __fish_git_extras_commands \
     "archive-file:Export the current HEAD of the git repository to an archive" \
     "authors:Generate authors report" \
     "browse:View the web page for the current repository" \
+    "browse-ci:View the CI page for the current repository" \
     "brv:List branches sorted by their last commit date" \
     "bulk:Run git commands on multiple repositories" \
     "changelog:Generate a changelog report" \

--- a/man/git-browse-ci.1
+++ b/man/git-browse-ci.1
@@ -7,10 +7,10 @@
 \fBgit\-browse\-ci\fR \-
 .
 .SH "SYNOPSIS"
-\fBgit\-browse\fR [remote_name]
+\fBgit\-browse\-ci\fR [remote_name]
 .
 .SH "DESCRIPTION"
-Opens the current git repository website in your default web browser\.
+Opens the current git repository CI page in your default web browser\.
 .
 .SH "OPTIONS"
 <remote_name>
@@ -19,13 +19,13 @@ Opens the current git repository website in your default web browser\.
 The name of the remote you wish to browse to\. Defaults to the first remote if not specified\.
 .
 .SH "EXAMPLES"
-$ git browse
+$ git browse\-ci
 .
 .P
-$ git browse upstream
+$ git browse\-ci upstream
 .
 .SH "AUTHOR"
-Written by Mark Pitman <\fIhttps://github\.com/mapitman\fR>
+Written by Peter Benjamin <\fIhttps://github\.com/pbnj\fR>
 .
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>

--- a/man/git-browse-ci.1
+++ b/man/git-browse-ci.1
@@ -1,0 +1,34 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-BROWSE\-CI" "1" "March 2022" "" "Git Extras"
+.
+.SH "NAME"
+\fBgit\-browse\-ci\fR \-
+.
+.SH "SYNOPSIS"
+\fBgit\-browse\fR [remote_name]
+.
+.SH "DESCRIPTION"
+Opens the current git repository website in your default web browser\.
+.
+.SH "OPTIONS"
+<remote_name>
+.
+.P
+The name of the remote you wish to browse to\. Defaults to the first remote if not specified\.
+.
+.SH "EXAMPLES"
+$ git browse
+.
+.P
+$ git browse upstream
+.
+.SH "AUTHOR"
+Written by Mark Pitman <\fIhttps://github\.com/mapitman\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-browse-ci.html
+++ b/man/git-browse-ci.html
@@ -76,11 +76,11 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-browse</code> [remote_name]</p>
+<p><code>git-browse-ci</code> [remote_name]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>Opens the current git repository website in your default web browser.</p>
+<p>Opens the current git repository CI page in your default web browser.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -91,13 +91,13 @@ the first remote if not specified.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p>  $ git browse</p>
+<p>  $ git browse-ci</p>
 
-<p>  $ git browse upstream</p>
+<p>  $ git browse-ci upstream</p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Mark Pitman &lt;<a href="https://github.com/mapitman" data-bare-link="true">https://github.com/mapitman</a>&gt;</p>
+<p>Written by Peter Benjamin &lt;<a href="https://github.com/pbnj" data-bare-link="true">https://github.com/pbnj</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-browse-ci.html
+++ b/man/git-browse-ci.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-browse-ci(1) - &lt;View the web page for the current repository&gt;</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-browse-ci(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-browse-ci(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-browse-ci</code> - <span class="man-whatis"><view the web page for current repository /></span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-browse</code> [remote_name]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>Opens the current git repository website in your default web browser.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>&lt;remote_name&gt;</p>
+
+<p>The name of the remote you wish to browse to. Defaults to
+the first remote if not specified.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>  $ git browse</p>
+
+<p>  $ git browse upstream</p>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Mark Pitman &lt;<a href="https://github.com/mapitman" data-bare-link="true">https://github.com/mapitman</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>March 2022</li>
+    <li class='tr'>git-browse-ci(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-browse-ci.md
+++ b/man/git-browse-ci.md
@@ -1,0 +1,35 @@
+git-browse-ci(1) -- <View the web page for the current repository>
+================================
+
+## SYNOPSIS
+
+`git-browse` [remote_name]
+
+## DESCRIPTION
+
+Opens the current git repository website in your default web browser.
+
+## OPTIONS
+
+&lt;remote_name&gt;
+
+The name of the remote you wish to browse to. Defaults to
+the first remote if not specified.
+
+## EXAMPLES
+
+  $ git browse
+
+  $ git browse upstream
+
+## AUTHOR
+
+Written by Mark Pitman &lt;<https://github.com/mapitman>&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;

--- a/man/git-browse-ci.md
+++ b/man/git-browse-ci.md
@@ -3,11 +3,11 @@ git-browse-ci(1) -- <View the web page for the current repository>
 
 ## SYNOPSIS
 
-`git-browse` [remote_name]
+`git-browse-ci` [remote_name]
 
 ## DESCRIPTION
 
-Opens the current git repository website in your default web browser.
+Opens the current git repository CI page in your default web browser.
 
 ## OPTIONS
 
@@ -18,13 +18,13 @@ the first remote if not specified.
 
 ## EXAMPLES
 
-  $ git browse
+  $ git browse-ci
 
-  $ git browse upstream
+  $ git browse-ci upstream
 
 ## AUTHOR
 
-Written by Mark Pitman &lt;<https://github.com/mapitman>&gt;
+Written by Peter Benjamin &lt;<https://github.com/pbnj>&gt;
 
 ## REPORTING BUGS
 

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -31,6 +31,7 @@ git-extras(1) -- Awesome GIT utilities
    - **git-alias(1)** Define, search and show aliases
    - **git-archive-file(1)** Export the current HEAD of the git repository to an archive
    - **git-authors(1)** Generate authors report
+   - **git-browse-ci(1)** <View the web page for the current repository>
    - **git-browse(1)** <View the web page for the current repository>
    - **git-brv(1)** List branches sorted by their last commit date
    - **git-bulk(1)** Run git commands on multiple repositories

--- a/man/index.txt
+++ b/man/index.txt
@@ -3,6 +3,7 @@ git-abort(1) git-abort
 git-alias(1) git-alias
 git-archive-file(1) git-archive-file
 git-authors(1) git-authors
+git-browse-ci(1) git-browse-ci
 git-browse(1) git-browse
 git-brv(1) git-brv
 git-bulk(1) git-bulk


### PR DESCRIPTION
This is a proposal and an implementation to open repo's CI page (e.g. GitHub Actions, GitLab CI, Bitbucket Pipelines) in default browser.

Feedback is welcome, even if feedback is "thanks, but no thanks".