### PR TITLE
docs(instllation): replace `git.io`

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -155,7 +155,7 @@ See the Makefile for details on advanced configuration options.
 One-liner:
 
 ```bash
-curl -sSL https://git.io/git-extras-setup | sudo bash /dev/stdin
+curl -sSL https://raw.githubusercontent.com/tj/git-extras/master/install.sh | sudo bash /dev/stdin
 ```
 
 ## Installing as Zsh plugin


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

> We will be removing all existing link redirection from git.io on April 29, 2022.

Replace all git.io links with their actual URLs.