### PR TITLE
Add git-pseudo-version

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -72,6 +72,7 @@
  - [`git undo`](#git-undo)
  - [`git unlock`](#git-unlock)
  - [`git utimes`](#git-utimes)
+ - [`git pseudo-version`](#git-pesudo-version)
 
 ## git extras
 
@@ -1570,3 +1571,7 @@ Abort current rebase, merge or cherry-pick, without the need to find exact comma
 ## git magic
 
 Commits changes with a generated message.
+
+## git pseudo-version
+
+View go pesudo version of current repository.

--- a/bin/git-pseudo-version
+++ b/bin/git-pseudo-version
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+TZ=UTC git --no-pager show --quiet \
+  --abbrev=12 \
+  --date='format-local:%Y%m%d%H%M%S' \
+  --format="%cd-%h"

--- a/man/git-pseudo-version.md
+++ b/man/git-pseudo-version.md
@@ -1,0 +1,26 @@
+git-pseudo-version(1) -- <View go pesudo version of current repository>
+================================
+
+## SYNOPSIS
+
+`git-pseudo-version`
+
+## DESCRIPTION
+
+View go pesudo version of current repository.
+
+## EXAMPLES
+
+  $ git pseudo-version
+
+## AUTHOR
+
+Written by
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;


### PR DESCRIPTION
It can be used to print pesudo-version of go module of current repository.