### PR TITLE
fix(git-effort):fork: retry: Resource temporarily unavailable #979

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -140,10 +140,12 @@ sort_effort() {
 }
 
 #
-# get processor count
+# get processor count, default 8
 #
 procs() {
-  (nproc --all || getconf NPROCESSORS_ONLN || getconf _NPROCESSORS_ONLN || grep -c processor /proc/cpuinfo) 2>/dev/null
+  if ! (nproc --all || getconf NPROCESSORS_ONLN || getconf _NPROCESSORS_ONLN || grep -c processor /proc/cpuinfo) 2>/dev/null; then
+      echo 8
+  fi
 }
 
 declare -a paths=()
@@ -214,7 +216,7 @@ heading
 
 # send paths to effort
 nPaths=${#paths[@]}
-nProcs=${$(procs):-8}
+nProcs=$(procs)
 nJobs="\j"
 for ((i=0; i<nPaths; ++i))
 do

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -139,6 +139,13 @@ sort_effort() {
   < $tmp sort -rn -k 2
 }
 
+#
+# get processor count
+#
+procs() {
+  (nproc --all || getconf NPROCESSORS_ONLN || getconf _NPROCESSORS_ONLN || grep -c processor /proc/cpuinfo) 2>/dev/null
+}
+
 declare -a paths=()
 while [ "${#}" -ge 1 ] ; do
 
@@ -207,7 +214,7 @@ heading
 
 # send paths to effort
 nPaths=${#paths[@]}
-nProcs=$(getconf NPROCESSORS_ONLN)
+nProcs=${$(procs):-8}
 nJobs="\j"
 for ((i=0; i<nPaths; ++i))
 do

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -207,11 +207,15 @@ heading
 
 # send paths to effort
 nPaths=${#paths[@]}
+nProcs=$(getconf NPROCESSORS_ONLN)
+nJobs="\j"
 for ((i=0; i<nPaths; ++i))
 do
+    while (( ${nJobs@P} >= nProcs )); do
+        wait -n
+    done
     effort "${paths[i]}" &
 done|tee $tmp
-wait
 
 # if more than one path, sort and print
 test "$(wc -l $tmp | awk '{print $1}')" -gt 1 && sort_effort


### PR DESCRIPTION
- use wait -n to limit number of processes

requirements:
- OSX, Linux, BSD (You may need to browse their man page)*: 
  - use `nproc --all`, `getconf NPROCESSORS_ONLN`, `getconf __NPROCESSORS_ONLN`, `grep -c processor /proc/cpuinfo` to get processor counts.
  - provide a fallback value `8`
- Bash 3.2+ (If you aren't sure, see [the Bash changelog](https://www.tldp.org/LDP/abs/html/bash2.html)): 
  - `wait -n` was introduced in Bash 4.0
