### PR TITLE
Include revert conflicts in git abort

### DIFF
--- a/bin/git-abort
+++ b/bin/git-abort
@@ -3,7 +3,7 @@
 gitdir="$(git rev-parse --git-dir)" || exit
 opfound=
 fcnt=
-for i in cherry-pick merge rebase; do
+for i in cherry-pick merge rebase revert; do
   f=${i^^}
   f=${f/-/_}
   test -f "${gitdir}/${f}_HEAD" && fcnt=1$fcnt && opfound=$i

--- a/man/git-abort.1
+++ b/man/git-abort.1
@@ -6,7 +6,7 @@
 .SH "SYNOPSIS"
 \fBgit\-abort\fR
 .SH "DESCRIPTION"
-Abort current git rebase, merge or cherry\-pick process\.
+Abort current git revert, rebase, merge or cherry\-pick process\.
 .SH "OPTIONS"
 There are no options, it just aborts current operation\.
 .SH "EXAMPLES"

--- a/man/git-abort.html
+++ b/man/git-abort.html
@@ -81,7 +81,7 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Abort current git rebase, merge or cherry-pick process.</p>
+<p>  Abort current git revert, rebase, merge or cherry-pick process.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 

--- a/man/git-abort.md
+++ b/man/git-abort.md
@@ -7,7 +7,7 @@ git-abort(1) -- Abort current git operation
 
 ## DESCRIPTION
 
-  Abort current git rebase, merge or cherry-pick process.
+  Abort current git revert, rebase, merge or cherry-pick process.
 
 ## OPTIONS
 


### PR DESCRIPTION
If running `git revert <SHA>` results in a conflict, `git abort` will say `I don't know what to abort` because it's not checking `REVERT_HEAD`