### PR TITLE
fix base branch in the pull-request command

### DIFF
--- a/bin/git-pull-request
+++ b/bin/git-pull-request
@@ -72,7 +72,7 @@ echo
 
 if [ -z "$base" ]
 then
-    base="master"
+    base="$(git_extra_default_branch)"
 fi
 
 body=$(json "$title" "$body" "$branch" "$base")


### PR DESCRIPTION
We don't actually use the default branch that we print in the prompt (see line 67)

```
printf "  base [%s]: " "$(git_extra_default_branch)" && read -r base
```