### PR TITLE
Make git-summary accept multiple paths for the --lines argument

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -41,8 +41,12 @@ if [ -n "$MERGES_ARG" ] && [ -n "$SUMMARY_BY_LINE" ]; then
 fi
 
 
-commit=""
-test $# -ne 0 && commit=$*
+if [ -n "$SUMMARY_BY_LINE" ]; then
+  paths=$@
+else
+  commit=""
+  test $# -ne 0 && commit=$*
+fi
 project=${PWD##*/}
 
 #
@@ -167,18 +171,14 @@ single_file() {
 # list the author for all file
 #
 lines() {
-  if [ -n "$1" ]; then
-    git ls-files -- $1 | single_file
-  else
-    git ls-files | single_file
-  fi
+  git ls-files -- $@ | single_file
 }
 
 #
 # get the number of the lines
 #
 line_count() {
-  lines $1 | wc -l
+  lines $@ | wc -l
 }
 
 # summary
@@ -187,9 +187,9 @@ echo
 echo " project  : $project"
 
 if [ -n "$SUMMARY_BY_LINE" ]; then
-  echo " lines    : $(line_count $commit)"
+  echo " lines    : $(line_count $paths)"
   echo " authors  :"
-  lines $commit | sort | uniq -c | sort -rn | format_authors
+  lines $paths | sort | uniq -c | sort -rn | format_authors
 else
 
   # shellcheck disable=SC2046

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -42,7 +42,7 @@ fi
 
 
 if [ -n "$SUMMARY_BY_LINE" ]; then
-  paths=$@
+  paths=( "$@" )
 else
   commit=""
   test $# -ne 0 && commit=$*
@@ -171,14 +171,14 @@ single_file() {
 # list the author for all file
 #
 lines() {
-  git ls-files -- $@ | single_file
+  git ls-files -- "$@" | single_file
 }
 
 #
 # get the number of the lines
 #
 line_count() {
-  lines $@ | wc -l
+  lines "$@" | wc -l
 }
 
 # summary
@@ -187,18 +187,18 @@ echo
 echo " project  : $project"
 
 if [ -n "$SUMMARY_BY_LINE" ]; then
-  echo " lines    : $(line_count $paths)"
+  echo " lines    : $(line_count "${paths[@]}")"
   echo " authors  :"
-  lines $paths | sort | uniq -c | sort -rn | format_authors
+  lines "${paths[@]}" | sort | uniq -c | sort -rn | format_authors
 else
 
-  # shellcheck disable=SC2046
-  echo " repo age :" $(repository_age)
+  echo " repo age : $(repository_age)"
   # shellcheck disable=SC2086
-  echo " active   :"  "$(active_days $commit)" days
-  echo " commits  :" "$(commit_count)"
+  echo " active   : $(active_days $commit) days"
+  # shellcheck disable=SC2086
+  echo " commits  : $(commit_count $commit)"
   if test "$commit" = ""; then
-    echo " files    :" "$(file_count)"
+    echo " files    : $(file_count)"
   fi
   echo " authors  : "
   if [ -n "$DEDUP_BY_EMAIL" ]; then


### PR DESCRIPTION
Currently only the first provided path is processed (`$1`). Therefore it gives incorrect results when multiple paths are given, or even for single bash globs such as `*.py`.