### PR TITLE
Allow to run git-extras within git-bulk

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -133,12 +133,15 @@ function executBulkOp () {
     eval cd "\"$rwsdir\""
     local actual=$(pwd)
     [ "${quiet?}" != "false" ] && echo 1>&2 "Executing bulk operation in workspace ${inverse}$actual${reset}"
-    eval find -L . -name ".git" | while read line; do
+
+    allGitFolders=( $(eval find -L . -name ".git") )
+
+    for line in ${allGitFolders[@]}; do
       local gitrepodir=${line::${#line}-5} # cut the .git part of find results to have the root git directory of that repository
       eval cd "\"$gitrepodir\"" # into git repo location
       local curdir=$(pwd)
       local leadingpath=${curdir#${actual}}
-     [ "${quiet?}" != "false" ] && echo 1>&2 "Current repository: ${leadingpath%/*}/${bldred}${curdir##*/}${reset}"
+      [ "${quiet?}" != "false" ] && echo 1>&2 "Current repository: ${leadingpath%/*}/${bldred}${curdir##*/}${reset}"
       guardedExecution "$@"
       eval cd "\"$rwsdir\"" # back to origin location of last find command
     done

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -44,8 +44,8 @@ fi
 if [ -n "$SUMMARY_BY_LINE" ]; then
   paths=( "$@" )
 else
-  commit=""
-  test $# -ne 0 && commit=$*
+  commit="HEAD"
+  [ $# -ne 0 ] && commit=$*
 fi
 project=${PWD##*/}
 
@@ -191,13 +191,14 @@ if [ -n "$SUMMARY_BY_LINE" ]; then
   echo " authors  :"
   lines "${paths[@]}" | sort | uniq -c | sort -rn | format_authors
 else
-
   echo " repo age : $(repository_age)"
   # shellcheck disable=SC2086
   echo " active   : $(active_days $commit) days"
   # shellcheck disable=SC2086
   echo " commits  : $(commit_count $commit)"
-  if test "$commit" = ""; then
+
+  # The file count doesn't support passing a git ref so ignore it if a ref is given
+  if [ "$commit" == "HEAD" ]; then
     echo " files    : $(file_count)"
   fi
   echo " authors  : "


### PR DESCRIPTION
When you execute

```
git bulk summary
```

it only summarizes the first found repo. 
The reason for it seems to be some stdin ... read ... blah stuff (https://stackoverflow.com/a/13800476/5247292) 

Therefore I changed the way the single repos of the bulk operation are worked off to avoid stdin when in the loop

Fix https://github.com/tj/git-extras/issues/1007