### PR TITLE
git-summary: remove stray \ in grep call

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -162,7 +162,7 @@ single_file() {
   while read -r data
   do
     if [[ $(file "$data") = *text* ]]; then
-      git blame --line-porcelain "$data" 2>/dev/null | grep "^author\ " | LC_ALL=C sed -n 's/^author //p';
+      git blame --line-porcelain "$data" 2>/dev/null | grep "^author " | LC_ALL=C sed -n 's/^author //p';
     fi
   done
 }


### PR DESCRIPTION
Grep 3.8 warns about stray backslashes, so `git summary --line` produces a lot of warnings:

> grep: warning: stray \ before white space

Remove the backslash to get rid of this warning.
