### PR TITLE
chore: Improve quoting and builtin usage

### DIFF
--- a/bin/git-archive-file
+++ b/bin/git-archive-file
@@ -5,7 +5,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD 2> /dev/null)
 
 # get name of the most top folder of current directory, used for the
 # output filename
-ARCHIVE_NAME=$(basename $(pwd))
+ARCHIVE_NAME=$(basename "$(pwd)")
 
 if [[ $BRANCH = tags* ]]; then
     BRANCH=$(git describe)
@@ -31,7 +31,7 @@ FILENAME=${FILENAME//\\/-}
 OUTPUT=$(pwd)/$FILENAME
 
 # building archive
-git archive --format zip --output $OUTPUT $BRANCH
+git archive --format zip --output "$OUTPUT" $BRANCH
 
 # also display size of the resulting file
-echo Saved to \"$FILENAME\" \(`du -h $OUTPUT | cut -f1`\)
+echo Saved to \""$FILENAME"\" \("$(du -h "$OUTPUT" | cut -f1)"\)

--- a/bin/git-authors
+++ b/bin/git-authors
@@ -23,7 +23,7 @@ done
 if ! $LIST; then
   FILE=$1
   if test "$FILE" = ""; then
-    FILE=$(ls | egrep 'authors|contributors' -i|head -n1)
+    FILE=$(ls | grep -E 'authors|contributors' -i|head -n1)
     if test "$FILE" = ""; then
       FILE='AUTHORS'
     fi
@@ -51,6 +51,6 @@ authors() {
 if $LIST; then
   authors
 else
-  authors >> $FILE
-  test -n "$EDITOR" && $EDITOR $FILE
+  authors >> "$FILE"
+  test -n "$EDITOR" && $EDITOR "$FILE"
 fi

--- a/bin/git-browse
+++ b/bin/git-browse
@@ -25,7 +25,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 if [[ $remote_url = git@* ]]; then
-    url=$(echo $remote_url | sed -E -e 's/:/\//' -e 's/\.git$//' -e 's/.*@(.*)/http:\/\/\1/')
+    url=$(echo "$remote_url" | sed -E -e 's/:/\//' -e 's/\.git$//' -e 's/.*@(.*)/http:\/\/\1/')
 elif [[ $remote_url = http* ]]; then
     url=${remote_url%.git}
 fi
@@ -76,22 +76,22 @@ fi
 case "$OSTYPE" in
 darwin*)
     # MacOS
-    open $url
+    open "$url"
     ;;
 msys)
     # Git-Bash on Windows
-    start $url
+    start "$url"
     ;;
 linux*)
     # Handle WSL on Windows
     if uname -a | grep -i -q Microsoft && command -v powershell.exe; then
-        powershell.exe -NoProfile start $url
+        powershell.exe -NoProfile start "$url"
     else
-        xdg-open $url
+        xdg-open "$url"
     fi
     ;;
 *)
     # fall back to xdg-open for BSDs, etc.
-    xdg-open $url
+    xdg-open "$url"
     ;;
 esac

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -127,7 +127,7 @@ function allowedargcount () {
 function executBulkOp () {
   checkGitCommand
   if ! $allwsmode && ! $singlemode; then wsnameToCurrent; fi # by default git bulk works within the 'current' workspace
-  listall | while read workspacespec; do
+  listall | while read -r workspacespec; do
     parseWsName "$workspacespec"
     if [[ -n $wsname ]] && [[ $rwsname != "$wsname" ]]; then continue; fi
     eval cd "\"$rwsdir\""

--- a/bin/git-clear
+++ b/bin/git-clear
@@ -33,7 +33,7 @@ done
 # Only wait for answer if not forced by user
 if [[ $FORCE == 0 ]]; then
     echo -n "Sure? - This command may delete files that cannot be recovered, including those in .gitignore [y/N]: "
-    read clean
+    read -r clean
 else
     clean=y
 fi


### PR DESCRIPTION
- Uses $() instead of \`\`
- Qutoes variables like paths (branches are skipped over for now because they are forbidden to include whitespace)
- Use `grep -E` instead of deprecated `egrep`