### PR TITLE
chore: More Bash improvements and removing deprecations

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -550,7 +550,7 @@ main() {
   fi
 
   if [[ -z "$changelog" ]]; then
-    changelog="$(ls | egrep 'change|history' -i | head -n1)"
+    changelog="$(ls | grep -E 'change|history' -i | head -n1)"
     if [[ -z "$changelog" ]]; then
       changelog="History.md";
     fi

--- a/bin/git-commits-since
+++ b/bin/git-commits-since
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 SINCE="last week"
-test $# -ne 0 && SINCE=$@
+test $# -ne 0 && SINCE=$*
 echo "... commits since $SINCE" >&2
 git log --pretty='%an - %s' --after="@{$SINCE}"

--- a/bin/git-count
+++ b/bin/git-count
@@ -5,4 +5,4 @@ if test "$1" = "--all"; then
   echo
 fi
 
-echo total `git rev-list --count HEAD`
+echo total "$(git rev-list --count HEAD)"

--- a/bin/git-create-branch
+++ b/bin/git-create-branch
@@ -3,7 +3,7 @@
 test $# -eq 0 && echo "branch argument required." 1>&2 && exit 1
 
 # preference takes lowest priority; look for remote from prefs first
-REMOTE_PREF=`git config git-extras.create-branch.remote`
+REMOTE_PREF=$(git config git-extras.create-branch.remote)
 if [ -n "$REMOTE_PREF" ]; then
 	REMOTE=$REMOTE_PREF
 fi
@@ -70,7 +70,7 @@ fi
 
 if [[ -n $START_POINT ]]
 then
-    git checkout -b $BRANCH $START_POINT
+    git checkout -b $BRANCH "$START_POINT"
 else
     git checkout -b $BRANCH
 fi

--- a/bin/git-delete-squashed-branches
+++ b/bin/git-delete-squashed-branches
@@ -6,13 +6,13 @@ if [[ $# -eq 0 ]]; then
   targetBranch=$(git rev-parse --abbrev-ref HEAD)
 else
   targetBranch=$1
-  git checkout $targetBranch
+  git checkout "$targetBranch"
 fi
 
-git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do
-    mergeBase=$(git merge-base $targetBranch $branch)
+git for-each-ref refs/heads/ "--format=%(refname:short)" | while read -r branch; do
+    mergeBase=$(git merge-base "$targetBranch" "$branch")
 
     if [[ $(git cherry $targetBranch $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]]; then
-        git branch -D $branch
+        git branch -D "$branch"
     fi
 done

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -84,36 +84,36 @@ effort() {
     local color reset_color commits len dot f_dot i msg active
     reset_color=""
     test "$to_tty" = true && reset_color="$(tputq sgr0)"
-    commit_dates=`dates "$path"`
+    commit_dates=$(dates "$path")
     [ $? -gt 0 ] && exit 255
 
     # Ensure it's not just an empty line
-    if [ -z "`head -c 1 <<<$(echo $commit_dates)`" ]
+    if [ -z "$(head -c 1 <<<$(echo $commit_dates))" ]
     then
       exit 0
     fi
 
-    commits=`wc -l <<<"$(echo "$commit_dates")"`
+    commits=$(wc -l <<<"$(echo "$commit_dates")")
     color='90'
 
     # ignore <= --above
     test $commits -le $above && exit 0
 
     # commits
-    color_for $(( $commits - $above ))
+    color_for $(( commits - above ))
     len=${#path}
     dot="."
     f_dot="$path"
-    i=0 ; while test $i -lt $(( $columns - $len )) ; do
+    i=0 ; while test $i -lt $(( columns - len )) ; do
       f_dot=$f_dot$dot
-      i=$(($i+1))
+      i=$((i+1))
     done
 
     msg=$(printf "  ${color}%s %-10d" "$f_dot" $commits)
 
     # active days
-    active=`active_days "$commit_dates"`
-    color_for $(( $active - $above ))
+    active=$(active_days "$commit_dates")
+    color_for $(( active - above ))
     msg="$msg $(printf "${color} %d${reset_color}\n" $active)"
     echo "$msg"
 }
@@ -136,7 +136,7 @@ sort_effort() {
   clear
   echo " "
   heading
-  < $tmp sort -rn -k 2
+  < "$tmp" sort -rn -k 2
 }
 
 #
@@ -190,8 +190,8 @@ export args_to_git_log
 
 if test "${#paths}" -eq 0; then
   save_ifs=$IFS
-  IFS=`echo -en "\n\b"`
-  paths=(`git ls-files`)
+  IFS=$(echo -en "\n\b")
+  paths=($(git ls-files))
   IFS=$save_ifs
   unset save_ifs
 fi
@@ -224,10 +224,10 @@ do
         wait -n
     done
     effort "${paths[i]}" &
-done|tee $tmp
+done|tee "$tmp"
 
 # if more than one path, sort and print
-test "$(wc -l $tmp | awk '{print $1}')" -gt 1 && sort_effort
+test "$(wc -l "$tmp" | awk '{print $1}')" -gt 1 && sort_effort
 echo
 
 show_cursor_and_cleanup

--- a/bin/git-extras
+++ b/bin/git-extras
@@ -4,7 +4,7 @@ VERSION="6.6.0-dev"
 INSTALL_SCRIPT="https://raw.githubusercontent.com/tj/git-extras/master/install.sh"
 
 update() {
-  local bin="$(which git-extras)"
+  local bin="$(command -v git-extras)"
   local prefix=${bin%/*/*}
   local orig=$PWD
 
@@ -14,7 +14,7 @@ update() {
 }
 
 updateForWindows() {
-  local bin="$(which git-extras)"
+  local bin="$(command -v git-extras)"
   local prefix=${bin%/*/*}
   local orig=$PWD
   

--- a/bin/git-force-clone
+++ b/bin/git-force-clone
@@ -63,10 +63,10 @@ main() {
 
   if [ -d "${destination_path}/.git" ]; then
     (
-      cd ${destination_path}
+      cd "${destination_path}"
 
       # Delete all remotes
-      for remote in `git remote`; do
+      for remote in $(git remote); do
         git remote rm ${remote}
       done
 
@@ -76,7 +76,7 @@ main() {
 
       # Set default branch
       if [ -z "${branch:-}" ]; then
-        branch=`LC_ALL=C git remote show origin | grep -oP '(?<=HEAD branch: )[^ ]+$'`
+        branch=$(LC_ALL=C git remote show origin | grep -oP '(?<=HEAD branch: )[^ ]+$')
         git remote set-head origin ${branch}
       else
         git remote set-head origin -a
@@ -91,15 +91,15 @@ main() {
       git reset --hard origin/${branch}
 
       # Delete all other branches
-      branches=`git branch | grep -v \* | xargs`
+      branches=$(git branch | grep -v \* | xargs)
       if [ -n "${branches}" ]; then
-        git branch -D ${branches}
+        git branch -D "${branches}"
       fi
     )
   elif [ -n "${branch:-}" ]; then
-    git clone -b ${branch} ${remote_url} ${destination_path}
+    git clone -b ${branch} "${remote_url}" "${destination_path}"
   else
-    git clone ${remote_url} ${destination_path}
+    git clone "${remote_url}" "${destination_path}"
   fi
 }
 

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -12,7 +12,7 @@ test -z "$url" && abort "github repo needs to be specified as an argument"
 
 # validate user
 echo "Enter your github username"
-read user
+read -r user
 [ -n "$user" ] || abort "git username required"
 # personal access token
 # config name is github-personal-access-token '_' is not allowed in git config
@@ -23,7 +23,7 @@ test -z "$github_personal_access_token" && abort "git config git-extras.github-p
 
 # extract owner + project from repo url
 project=${url##*/}
-owner=${url%/$project}
+owner=${url%/"$project"}
 project=${project%.git}
 if [[ $owner == git@* ]]; then
   owner=${owner##*:}
@@ -32,7 +32,7 @@ else
 fi
 
 # validate
-[ -z "$project" -o -z "$owner" ] && abort "github repo needs to be specified as an argument"
+[[ -z "$project" || -z "$owner" ]] && abort "github repo needs to be specified as an argument"
 
 # create fork
 curl -qsf \
@@ -44,7 +44,7 @@ curl -qsf \
 [ $? = 0 ] || abort "fork failed"
 
 echo "Add GitHub remote branch via SSH (you will be prompted to verify the server's credentials)? (y/n)"
-read use_ssh
+read -r use_ssh
 # Check if user has ssh configured with GitHub
 if [ -n "$use_ssh" ] && ssh -T git@github.com 2>&1 | grep -qi 'success'; then
   remote_prefix="git@github.com:"

--- a/bin/git-standup
+++ b/bin/git-standup
@@ -35,7 +35,7 @@ in_git_repo=$?
 
 # Use colors, but only if connected to a terminal, and that terminal
 # supports them.
-if which tput >/dev/null 2>&1; then
+if command -v tput >/dev/null 2>&1; then
     ncolors=$(tput colors)
 fi
 if [[ -t 1 ]] && [[ -n "$ncolors" ]] && [[ "$ncolors" -ge 8 ]] ; then
@@ -240,7 +240,7 @@ if [[ $in_git_repo != 0 ]]; then
     ## Set delimiter to newline for the loop
     IFS=$'\n'
     ## Recursively search for git repositories
-    PROJECT_DIRS=$(find $INCLUDE_LINKS . -maxdepth "$MAXDEPTH" -mindepth 0 -name .git)
+    PROJECT_DIRS=$(find "$INCLUDE_LINKS" . -maxdepth "$MAXDEPTH" -mindepth 0 -name .git)
 
     # Fetch the latest commits, if required
     if [ "$FETCH_LAST_COMMIT" = true ]; then

--- a/bin/git-sync
+++ b/bin/git-sync
@@ -59,14 +59,14 @@ function main()
   done
 
   local remote_branch
-  if [ "${remote}" = "" ]; then
+  if [ -z "${remote}" ]; then
     if ! remote_branch="$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)"; then
       echo "There is no upstream information of local branch."
       exit 1
     fi
     local branch="$(git rev-parse --abbrev-ref --symbolic-full-name @)"
     local remote=$(git config "branch.${branch}.remote")
-  elif [ "${branch}" = "" ]; then
+  elif [ -z "${branch}" ]; then
     echo -e "Error: too few arguments.\n"
     _usage
     exit 1
@@ -81,7 +81,7 @@ function main()
       echo -n "Are you sure you want to clean all changes & sync with '${remote_branch}'? [y/N]: "
     fi
     local force
-    read force
+    read -r force
   fi
   case "${force}" in
     "Y" | "y" | "yes" | "Yes" | "YES" )

--- a/brew-release.patch
+++ b/brew-release.patch
@@ -6,7 +6,7 @@ index e49cd24..4ae28b5 100755
  INSTALL_SCRIPT="https://raw.githubusercontent.com/tj/git-extras/master/install.sh"
 
  update() {
--  local bin="$(which git-extras)"
+-  local bin="$(command -v git-extras)"
 -  local prefix=${bin%/*/*}
 -  local orig=$PWD
 -


### PR DESCRIPTION
- Improve quoting, especially in places where filepaths are used
- No longer use `which`, which is deprecated in Debian and has issues - use `command -v` instead
  - This ends up **modifying** `brew-release.path` to match (just to note)
- No longer use deprecated `egrep`
- No longer use deprecated `[ -o` or ``