### PR TITLE
Repo status overview

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -221,6 +221,13 @@ project  : git-extras
 
 The `--line` option can also take a path, which will print a filtered summary for that folder or file.
 
+The option `--oneline` tries to put as much summary information of the repo into a single output line
+
+```bash
+$ git summary --oneline
+git-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
+```
+
 ## git effort
 
   Displays "effort" statistics, currently just the number of commits per file, showing highlighting where the most activity is. The "active days" column is the total number of days which contributed modifications to this file.

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -70,7 +70,8 @@ function guardedExecution () {
 
 # atomic git command execution with log
 function atomicExecution () {
-  echo 1>&2 "${bldred}->${reset} executing ${inverse}git $gitcommand${reset}" && git "$@"
+  [ "${quiet?}" != "true" ] && echo 1>&2 "${bldred}->${reset} executing ${inverse}git $gitcommand${reset}"
+  git "$@"
 }
 
 # check if the passed command is known as a core git command

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -149,7 +149,7 @@ format_authors() {
 # fetch repository age from oldest commit
 #
 repository_age() {
-  git log --reverse --pretty=oneline --format="%ar" -n 1 | LC_ALL=C sed 's/ago//'
+  git log --reverse --pretty=oneline --format="%ar" | head -n 1 | LC_ALL=C sed 's/ago//'
 }
 
 #

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -6,6 +6,7 @@ cd "$(git root)" || { echo "Can't cd to top level directory";exit 1; }
 SUMMARY_BY_LINE=
 DEDUP_BY_EMAIL=
 MERGES_ARG=
+SUMMARY_ONELINE=
 for arg in "$@"; do
     case "$arg" in
         --line)
@@ -16,6 +17,9 @@ for arg in "$@"; do
             ;;
         --no-merges)
             MERGES_ARG="--no-merges"
+            ;;
+        --oneline)
+            SUMMARY_ONELINE=1
             ;;
         -*)
             >&2 echo "unknown argument $arg found"
@@ -186,14 +190,19 @@ uncommitted_changes_count() {
 }
 
 # summary
-echo
-echo " project     : $project"
-
-if [ -n "$SUMMARY_BY_LINE" ]; then
+if [ -n "$SUMMARY_BY_LINE" ] && [ -n "$SUMMARY_ONELINE" ]; then
+  echo "$project / lines: $(line_count "${paths[@]}")"
+elif [ -n "$SUMMARY_BY_LINE" ]; then
+  echo
+  echo " project     : $project"
   echo " lines       : $(line_count "${paths[@]}")"
   echo " authors     :"
   lines "${paths[@]}" | sort | uniq -c | sort -rn | format_authors
+elif [ -n "$SUMMARY_ONELINE" ]; then
+  echo "$project / age: $(repository_age) / last active: $(last_active) / active on $(active_days $commit) days / commits: $(commit_count $commit) / uncommitted: $(uncommitted_changes_count)"
 else
+  echo
+  echo " project     : $project"
   echo " repo age    : $(repository_age)"
   echo " last active : $(last_active)"
   # shellcheck disable=SC2086

--- a/man/git-summary.1
+++ b/man/git-summary.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SUMMARY" "1" "December 2022" "" "Git Extras"
+.TH "GIT\-SUMMARY" "1" "January 2023" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-summary\fR \- Show repository summary
@@ -64,6 +64,12 @@ Summarize with lines other than commits\. When \fB\-\-line\fR is specified, the 
 .
 .P
 This option can not be used together with \fB\-\-dedup\-by\-email\fR or \fB\-\-no\-merges\fR\.
+.
+.P
+\-\-oneline
+.
+.P
+Summarizes the repository within one line\. Some information like the authors cannot be displayed in this mode\.
 .
 .SH "EXAMPLES"
 Outputs a repo summary:
@@ -149,6 +155,20 @@ project  : git\-extras
 lines    : 4420
 authors  :
   \.\.\.
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Oneline summary
+.
+.IP "" 4
+.
+.nf
+
+$ git summary \-\-oneline
+git\-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
 .
 .fi
 .

--- a/man/git-summary.html
+++ b/man/git-summary.html
@@ -119,6 +119,10 @@ $ git summary --dedup-by-email
 
 <p>  This option can not be used together with <code>--dedup-by-email</code> or <code>--no-merges</code>.</p>
 
+<p>  --oneline</p>
+
+<p>  Summarizes the repository within one line. Some information like the authors cannot be displayed in this mode.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <p>  Outputs a repo summary:</p>
@@ -179,9 +183,15 @@ authors  :
   ...
 </code></pre>
 
+<p>  Oneline summary</p>
+
+<pre><code>$ git summary --oneline
+git-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
+</code></pre>
+
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#x61;&#105;&#108;&#x74;&#111;&#x3a;&#116;&#x6a;&#x40;&#118;&#x69;&#x73;&#105;&#111;&#110;&#45;&#x6d;&#101;&#100;&#x69;&#x61;&#x2e;&#x63;&#x61;" data-bare-link="true">&#116;&#x6a;&#x40;&#118;&#x69;&#x73;&#x69;&#111;&#110;&#x2d;&#x6d;&#101;&#100;&#x69;&#x61;&#x2e;&#x63;&#x61;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#116;&#x6a;&#64;&#118;&#105;&#115;&#105;&#x6f;&#x6e;&#x2d;&#109;&#x65;&#100;&#x69;&#97;&#46;&#x63;&#97;" data-bare-link="true">&#x74;&#x6a;&#x40;&#118;&#105;&#x73;&#105;&#111;&#110;&#45;&#x6d;&#x65;&#x64;&#105;&#97;&#x2e;&#99;&#97;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -194,7 +204,7 @@ authors  :
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2022</li>
+    <li class='tc'>January 2023</li>
     <li class='tr'>git-summary(1)</li>
   </ol>
 

--- a/man/git-summary.md
+++ b/man/git-summary.md
@@ -45,6 +45,10 @@ Shows a summary of the repository or a path within it.
 
   This option can not be used together with `--dedup-by-email` or `--no-merges`.
 
+  --oneline
+
+  Summarizes the repository within one line. Some information like the authors cannot be displayed in this mode.
+
 ## EXAMPLES
 
   Outputs a repo summary:
@@ -100,6 +104,11 @@ Shows a summary of the repository or a path within it.
     lines    : 4420
     authors  :
       ...
+
+  Oneline summary
+
+    $ git summary --oneline
+    git-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
 
 ## AUTHOR
 


### PR DESCRIPTION
Fix #1006

This changes allow to print the summary of all the repositories in a table like this:

```
git bulk -q summary --oneline | column -t -s /                                                                                                                                   
Core command "summary" accepted.
keycloak-cxf-admin-client            age: 6 years                last active: 1 year, 2 months ago    active on 4 days      commits: 16      uncommitted: 0
dev-infrastructure-automation        age: 5 weeks                last active: 2 hours ago             active on 8 days      commits: 13      uncommitted: 0
gitlab-project-settings-corrector    age: 3 months               last active: 3 months ago            active on 1 days      commits: 2       uncommitted: 0
gitlab-k8s-cleaner                   age: 3 months               last active: 3 months ago            active on 2 days      commits: 7       uncommitted: 0
ci-docker-images                     age: 3 months               last active: 3 months ago            active on 3 days      commits: 8       uncommitted: 0
fid-python                           age: 7 weeks                last active: 3 weeks ago             active on 11 days     commits: 22      uncommitted: 0
deployment-management                age: 3 months               last active: 3 weeks ago             active on 28 days     commits: 140     uncommitted: 0
```

--- 

Additionally, the age info was fixed in the summary command. Using `git log --reversed -n 1` actually gives the latest commit, not the oldest.