### PR TITLE
chore: Fix more Bash inconsistencies

### DIFF
--- a/bin/git-archive-file
+++ b/bin/git-archive-file
@@ -9,15 +9,15 @@ ARCHIVE_NAME=$(basename "$(pwd)")
 
 if [[ $BRANCH = tags* ]]; then
     BRANCH=$(git describe)
-    echo Building for tag \"$BRANCH\"
+    echo Building for tag "\"$BRANCH\""
     FILENAME=$ARCHIVE_NAME.$BRANCH.zip
 else
-    echo Building archive on branch \"$BRANCH\"
+    echo Building archive on branch "\"$BRANCH\""
     # get a version string, so archives will not be overwritten when creating
     # many of them
     VERSION=$(git describe --always --long)
     # if not on master append branch name into the filename
-    if [ "$BRANCH" = $(git_extra_default_branch) ]; then
+    if [ "$BRANCH" = "$(git_extra_default_branch)" ]; then
         FILENAME=$ARCHIVE_NAME.$VERSION.zip
     else
         FILENAME=$ARCHIVE_NAME.$VERSION.$BRANCH.zip
@@ -31,7 +31,7 @@ FILENAME=${FILENAME//\\/-}
 OUTPUT=$(pwd)/$FILENAME
 
 # building archive
-git archive --format zip --output "$OUTPUT" $BRANCH
+git archive --format zip --output "$OUTPUT" "$BRANCH"
 
 # also display size of the resulting file
 echo Saved to \""$FILENAME"\" \("$(du -h "$OUTPUT" | cut -f1)"\)

--- a/bin/git-browse
+++ b/bin/git-browse
@@ -18,7 +18,7 @@ if [[ $remote == "" ]]; then
 fi
 
 # get remote url
-remote_url=$(git remote get-url $remote)
+remote_url=$(git remote get-url "$remote")
 
 if [[ $? -ne 0 ]]; then
     exit $?

--- a/bin/git-browse-ci
+++ b/bin/git-browse-ci
@@ -9,7 +9,7 @@ else
     remote=$1
 fi
 
-if [[ $remote == "" ]]
+if [[ -z $remote ]]
 then
     echo "Remote not found"
     exit 1

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -89,10 +89,10 @@ function checkGitCommand () {
 
 # check if workspace name is registered
 function checkWSName () {
-  while read workspace; do
+  while read -r workspace; do
     parseWsName "$workspace"
     if [[ $rwsname == "$wsname" ]]; then return; fi
-  done <<< "$(echo "$(listall)")"
+  done <<< "$(listall)"
   # when here the ws name was not found
   usage && echo 1>&2 "error: unknown workspace name: $wsname" && exit 1
 }
@@ -106,14 +106,14 @@ function parseWsName () {
 
 # detects the wsname of the current directory
 function wsnameToCurrent () {
-  while read workspace; do
+  while read -r workspace; do
     if [ -z "$workspace" ]; then continue; fi
     parseWsName "$workspace"
     if echo "$PWD" | grep -o -q "$rwsdir"; then wsname="$rwsname" && return; fi
-  done <<< "$(echo "$(listall)")"
+  done <<< "$(listall)"
   # when here then not in workspace dir
   echo 1>&2 "error: you are not in a workspace directory. your registered workspaces are:" && \
-    wslist="$(echo "$(listall)")" && echo 1>&2 "${wslist:-'<no workspaces defined yet>'}" && exit 1
+    wslist="$(listall)" && echo 1>&2 "${wslist:-'<no workspaces defined yet>'}" && exit 1
 }
 
 # helper to check number of arguments.

--- a/bin/git-create-branch
+++ b/bin/git-create-branch
@@ -44,20 +44,20 @@ test -z $BRANCH && echo "branch argument required." 1>&2 && exit 1
 if [[ -n $REMOTE ]]
 then
 	stderr=$(git_extra_mktemp)
-	git ls-remote --exit-code $REMOTE 1>/dev/null 2>"$stderr"
+	git ls-remote --exit-code "$REMOTE" 1>/dev/null 2>"$stderr"
 	REMOTE_EXIT=$?
 	REMOTE_ERROR=$(<"$stderr")
 	rm -f "$stderr"
 	if [ $REMOTE_EXIT -eq 0 ]
 	then
 		if [[ -n $START_POINT ]]; then
-			git fetch $REMOTE
-			git checkout --track -b $BRANCH $START_POINT
-			git push $REMOTE HEAD:refs/heads/$BRANCH
+			git fetch "$REMOTE"
+			git checkout --track -b "$BRANCH" "$START_POINT"
+			git push "$REMOTE" "HEAD:refs/heads/$BRANCH"
 		else
-			git push $REMOTE HEAD:refs/heads/$BRANCH
-			git fetch $REMOTE
-			git checkout --track -b $BRANCH $REMOTE/$BRANCH
+			git push "$REMOTE" "HEAD:refs/heads/$BRANCH"
+			git fetch "$REMOTE"
+			git checkout --track -b "$BRANCH" "$REMOTE/$BRANCH"
 		fi
 		exit $?
 	else
@@ -70,7 +70,7 @@ fi
 
 if [[ -n $START_POINT ]]
 then
-    git checkout -b $BRANCH "$START_POINT"
+    git checkout -b "$BRANCH" "$START_POINT"
 else
-    git checkout -b $BRANCH
+    git checkout -b "$BRANCH"
 fi

--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -2,16 +2,16 @@
 set -e
 
 # Assert there is at least one branch provided
-test -z $1 && echo "branch required." 1>&2 && exit 1
+test -z "$1" && echo "branch required." 1>&2 && exit 1
 
 for branch in "$@"
 do
-  remote=$(git config branch.$branch.remote || echo "origin")
-  ref=$(git config branch.$branch.merge || echo "refs/heads/$branch")
+  remote=$(git config "branch.$branch.remote" || echo "origin")
+  ref=$(git config "branch.$branch.merge" || echo "refs/heads/$branch")
 
-  git branch -D $branch || true
+  git branch -D "$branch" || true
   # Avoid deleting local upstream
-  [ "$remote" == "." ] && continue
-  git branch -d -r $remote/$branch || continue
-  git push $remote :$ref
+  [ "$remote" = "." ] && continue
+  git branch -d -r "$remote/$branch" || continue
+  git push "$remote" ":$ref"
 done

--- a/bin/git-delete-squashed-branches
+++ b/bin/git-delete-squashed-branches
@@ -12,7 +12,7 @@ fi
 git for-each-ref refs/heads/ "--format=%(refname:short)" | while read -r branch; do
     mergeBase=$(git merge-base "$targetBranch" "$branch")
 
-    if [[ $(git cherry $targetBranch $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]]; then
+    if [[ $(git cherry "$targetBranch" $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]]; then
         git branch -D "$branch"
     fi
 done

--- a/bin/git-delete-tag
+++ b/bin/git-delete-tag
@@ -22,5 +22,5 @@ do
 done
 
 # Delete all the tags
-git tag -d $local_tags
-git push $origin $origin_refs
+git tag -d "$local_tags"
+git push "$origin" "$origin_refs"

--- a/bin/git-delta
+++ b/bin/git-delta
@@ -12,4 +12,4 @@ else
   fi
 fi
 
-git diff --name-only --diff-filter=$filter $branch
+git diff --name-only --diff-filter="$filter" "$branch"

--- a/bin/git-gh-pages
+++ b/bin/git-gh-pages
@@ -4,10 +4,10 @@ echo 'setting up gh-pages'
 echo '-------------------'
  
 echo 'Tell me your github account username: '
-read username
+read -r username
  
 echo 'Now, tell me your repository name: '
-read repository
+read -r repository
  
 git stash \
 && git checkout -b 'gh-pages' \

--- a/bin/git-merge-repo
+++ b/bin/git-merge-repo
@@ -5,7 +5,7 @@ branch=$2
 prefix=$3
 flat=0
 
-if test $prefix = "."; then
+if test "$prefix" = "."; then
 	prefix=$(mktemp -u 'git-merge-repo.XXXXXXX')
 	flat=1
 fi
@@ -16,10 +16,10 @@ message=$(git log -1 --pretty=%B)
 
 if test $flat -eq 1; then
 	git stash -u
-	mv -i $prefix/* ./
+	mv -i "$prefix"/* ./
 	git undo
 	git add .
 	git commit -am "$message"
 	git stash apply
-	rm -drf $prefix
+	rm -drf "$prefix"
 fi

--- a/bin/git-mr
+++ b/bin/git-mr
@@ -8,8 +8,8 @@ if [  -z "${1-}" ] ; then
 fi
 
 if test "$1" = "clean"; then
-  git for-each-ref refs/heads/mr/* --format='%(refname)' | while read ref; do
-    git branch -D ${ref#refs/heads/}
+  git for-each-ref refs/heads/mr/* --format='%(refname)' | while read -r ref; do
+    git branch -D "${ref#refs/heads/}"
   done
   exit 0
 elif [[ $1 =~ ^(https?://[^/]+/(.+))/merge_requests/([0-9]+).*$ ]]; then
@@ -22,7 +22,7 @@ fi
 
 branch=mr/$id
 remote_ref=refs/merge-requests/$id/head
-git fetch -fu $remote $remote_ref:$branch
-git checkout $branch
-git config --local --replace branch.$branch.merge $remote_ref
-git config --local --replace branch.$branch.remote $remote
+git fetch -fu "$remote" "$remote_ref:$branch"
+git checkout "$branch"
+git config --local --replace "branch.$branch.merge" "$remote_ref"
+git config --local --replace "branch.$branch.remote" "$remote"

--- a/bin/git-psykorebase
+++ b/bin/git-psykorebase
@@ -19,7 +19,7 @@ function usage()
     echo "  -c|--continue:		Continue after the user updates conflicts."
 }
 
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
   key="$1"
   

--- a/bin/git-release
+++ b/bin/git-release
@@ -4,17 +4,17 @@ set -e
 hook() {
   local hook=.git/hooks/$1.sh
   # compat without extname
-  if test ! -f $hook; then
+  if test ! -f "$hook"; then
     hook=.git/hooks/$1
   fi
 
-  if test -f $hook; then
+  if test -f "$hook"; then
     echo "... $1"
     shift
-    if test -x $hook; then
+    if test -x "$hook"; then
       $hook "$@"
     else
-      . $hook "$@"
+      . "$hook" "$@"
     fi
   fi
 }

--- a/bin/git-rename-tag
+++ b/bin/git-rename-tag
@@ -3,10 +3,10 @@
 old=$1
 new=$2
 
-test -z $old && echo "old tag name required." 1>&2 && exit 1
-test -z $new && echo "new tag name required." 1>&2 && exit 1
+test -z "$old" && echo "old tag name required." 1>&2 && exit 1
+test -z "$new" && echo "new tag name required." 1>&2 && exit 1
 
-git tag $new $old
-git tag -d $old
-git push origin $new
-git push origin :refs/tags/$old
+git tag "$new" "$old"
+git tag -d "$old"
+git push origin "$new"
+git push origin ":refs/tags/$old"

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -6,7 +6,7 @@ echo "type 'ls' to ls files below current directory, '!command' to execute any c
 
 while true; do
   # Current branch
-  cur=`git symbolic-ref HEAD 2> /dev/null | cut -d/ -f3-`
+  cur=$(git symbolic-ref HEAD 2> /dev/null | cut -d/ -f3-)
 
   # Prompt
   if test -n "$cur"; then

--- a/bin/git-reset-file
+++ b/bin/git-reset-file
@@ -4,14 +4,14 @@ file="$1"
 commit="$2"
 
 if [[ -f $file ]]; then
-	git rm --cached -q -f -- $file
+	git rm --cached -q -f -- "$file"
 	if [[ -z $commit ]]; then	
-		git checkout HEAD -- $file
+		git checkout HEAD -- "$file"
 		echo "Reset '$1' to HEAD"
 	else
-		git checkout $commit -- $file
+		git checkout "$commit" -- "$file"
 		echo "Reset '$1' to $commit"
 	fi
 else 
-	echo "File '$1' not found in `pwd`"
+	echo "File '$1' not found in $(pwd)"
 fi

--- a/bin/git-scp
+++ b/bin/git-scp
@@ -161,16 +161,16 @@ function _error()
 	[ $# -eq 0 ] && _usage && exit 0
 
 	echo
-	echo ERROR: "$@"
+	echo "ERROR: $*"
 	echo
 	exit 1
 }
 
 ### OPTIONS ###
-case $(basename $0) in
+case $(basename "$0") in
 	git-scp)
 		case $1 in
-			''|-h|'?'|help|--help) shift; _test_git_scp; _usage $@;;
+			''|-h|'?'|help|--help) shift; _test_git_scp; _usage "$@";;
 			*)                   scp_and_stage $@;;
 		esac
 	;;

--- a/bin/git-stamp
+++ b/bin/git-stamp
@@ -22,8 +22,7 @@ EOF
 
 error() {
   if [[ -n "$1" ]]; then
-    local msg=$( echo "error: $1" )
-    echo -e "${msg}" >&2
+    echo "error: $1" >&2
   fi
   usage
   exit 1

--- a/bin/git-touch
+++ b/bin/git-touch
@@ -7,7 +7,7 @@ USAGE(){
 
 test $# -lt 1 && USAGE
 
-for filename in $@; do
+for filename in "$@"; do
   touch "$filename" \
     && git add "$filename"
 done


### PR DESCRIPTION
This mainly fixes the following:
- Not only are more path-related variables quoted (ie. `git-touch`, `git-scp`), but variables like `$BRANCH` are.
- Add more `-r` to `read` invocations
- Stuff like `$(echo $(printf '%s\n' 'thing'))` is changed to `$(printf '%s\n' 'thing')`