### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.patch]
+insert_final_newline = false
+
+[*.md,*.patch]
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,41 @@
 name: ci
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 jobs:
+  lint:
+    runs-on: 'ubuntu-22.04'
+    steps:
+      - name: 'Get Changed Files'
+        id: 'files'
+        uses: 'masesgroup/retrieve-changed-files@v2'
+        with:
+          format: 'json'
+      - name: Check out code.
+        uses: actions/checkout@v2
+      - name: 'Check EditorConfig Lint'
+        run: |
+          sudo apt install -y jq golang
+          go install 'github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest'
+
+          readarray -t changed_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.added_modified }}')"
+          ~/go/bin/editorconfig-checker ${changed_files[@]}
+
   build:
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-18.04
+          - ubuntu-22.04
           - macos-latest
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out code.
         uses: actions/checkout@v2
       - name: Linux Install
-        if: matrix.platform == 'ubuntu-18.04'
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get install -y bsdmainutils
       - name: Script


### PR DESCRIPTION
While working on #1021, I noticed that some files like [git-delta](https://github.com/tj/git-extras/blob/master/bin/git-delta) don't end in a newline. As a result, that last "line" (`git diff --name-only --diff-filter=$filter $branch`) is not considered part of the text file, according to POSIX.

To fix this, I propose adding an [EditorConfig](https://editorconfig.org) file. When editors read this (some require a plugin like VSCode) file, it adjusts the formatting based on the rules. One thing to note is that rules that specify whitespace are only take affect to each inserted text. For example, with `indent_style = space`, when editing a file that predominately uses tabs, only the spaces will be inserted on each `<tab>` - other characters are not modified.

It seems both 2 and 4-space shell scripts are used in this repository, so I decided to omit that constraint from the `.editorconfig` file.