### PR TITLE
Update gitignore.io urls to Toptal urls

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -693,14 +693,14 @@ build
 
 ## git ignore-io
 
-Generate sample gitignore file from [gitignore.io](https://www.gitignore.io)
+Generate sample gitignore file from [gitignore.io](https://www.toptal.com/developers/gitignore)
 
 Without option, `git ignore-io <type>` shows the sample gitignore of specified types on screen.
 
 ```bash
 $ git ignore-io vim
 
-    # Created by https://www.gitignore.io/api/vim
+    # Created by https://www.toptal.com/developers/gitignore/api/vim
 
     ### Vim ###
     [._]*.s[a-w][a-z]

--- a/bin/git-ignore-io
+++ b/bin/git-ignore-io
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-gitignore_io_url="https://www.gitignore.io/api/"
+gitignore_io_url="https://www.toptal.com/developers/gitignore/api/"
 default_path="$HOME/.gi_list"
 if [[ -n "$XDG_CACHE_HOME" ]]; then
   default_path="$XDG_CACHE_HOME/git-extras/gi_list"

--- a/man/git-ignore-io.1
+++ b/man/git-ignore-io.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-IGNORE\-IO" "1" "October 2017" "" "Git Extras"
+.TH "GIT\-IGNORE\-IO" "1" "January 2023" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-ignore\-io\fR \- Get sample gitignore file
@@ -10,7 +10,7 @@
 \fBgit ignore\-io\fR [<OPTIONS>]
 .
 .SH "DESCRIPTION"
-Get sample gitignore file from gitignore\.io \fIhttps://www\.gitignore\.io\fR
+Get sample gitignore file from gitignore\.io \fIhttps://www\.toptal\.com/developers/gitignore/\fR
 .
 .SH "OPTIONS"
 <OPTIONS>
@@ -66,7 +66,7 @@ Show sample gitignore file for vim
 
 $ git ignore\-io vim
 
-    # Created by https://www\.gitignore\.io/api/vim
+    # Created by https://www\.toptal\.com/developers/gitignore/api/vim
 
     ### Vim ###
     [\._]*\.s[a\-w][a\-z]
@@ -81,7 +81,7 @@ $ git ignore\-io vim
 .IP "" 0
 .
 .P
-Append sample gitignore for vim and python to \.gitignore in current directory\.
+Append sample gitignore for Vim and Python to \.gitignore in current directory\.
 .
 .IP "" 4
 .
@@ -131,7 +131,7 @@ $ git ignore\-io \-s ja
 .IP "" 0
 .
 .SH "AUTHOR"
-Written by Lee\-W \fIcl87654321@gmail\.com\fR
+Written by Lee\-W \fIweilee\.rx@gmail\.com\fR
 .
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>

--- a/man/git-ignore-io.html
+++ b/man/git-ignore-io.html
@@ -80,7 +80,7 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>Get sample gitignore file from <a href="https://www.toptal.com/developers/gitignore">gitignore.io</a></p>
+<p>Get sample gitignore file from <a href="https://www.toptal.com/developers/gitignore/">gitignore.io</a></p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -124,7 +124,7 @@
     *~
 </code></pre>
 
-<p>Append sample gitignore for vim and python to .gitignore in current directory.</p>
+<p>Append sample gitignore for Vim and Python to .gitignore in current directory.</p>
 
 <pre><code class="bash">$ git ignore-io -a vim python
 </code></pre>
@@ -152,7 +152,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Lee-W <a href="&#x6d;&#x61;&#105;&#x6c;&#x74;&#x6f;&#x3a;&#x63;&#x6c;&#56;&#x37;&#54;&#x35;&#52;&#x33;&#x32;&#49;&#x40;&#x67;&#x6d;&#x61;&#x69;&#108;&#46;&#x63;&#x6f;&#109;" data-bare-link="true">&#x63;&#108;&#56;&#55;&#x36;&#53;&#52;&#51;&#x32;&#x31;&#x40;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#99;&#111;&#109;</a></p>
+<p>Written by Lee-W <a href="&#x6d;&#x61;&#105;&#108;&#116;&#111;&#58;&#119;&#101;&#105;&#108;&#101;&#101;&#x2e;&#114;&#x78;&#64;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#x63;&#111;&#x6d;" data-bare-link="true">&#x77;&#x65;&#105;&#108;&#x65;&#x65;&#x2e;&#x72;&#x78;&#x40;&#103;&#109;&#x61;&#105;&#108;&#x2e;&#99;&#111;&#x6d;</a></p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -165,7 +165,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>January 2023</li>
     <li class='tr'>git-ignore-io(1)</li>
   </ol>
 

--- a/man/git-ignore-io.html
+++ b/man/git-ignore-io.html
@@ -80,7 +80,7 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>Get sample gitignore file from <a href="https://www.gitignore.io">gitignore.io</a></p>
+<p>Get sample gitignore file from <a href="https://www.toptal.com/developers/gitignore">gitignore.io</a></p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -113,7 +113,7 @@
 
 <pre><code class="bash">$ git ignore-io vim
 
-    # Created by https://www.gitignore.io/api/vim
+    # Created by https://www.toptal.com/developers/gitignore/api/vim
 
     ### Vim ###
     [._]*.s[a-w][a-z]

--- a/man/git-ignore-io.md
+++ b/man/git-ignore-io.md
@@ -7,7 +7,7 @@ git-ignore-io(1) -- Get sample gitignore file
 
 ## DESCRIPTION
 
-Get sample gitignore file from [gitignore.io](https://www.gitignore.io)
+Get sample gitignore file from [gitignore.io](https://www.toptal.com/developers/gitignore/)
 
 ## OPTIONS
 
@@ -41,7 +41,7 @@ Show sample gitignore file for vim
 ```bash
 $ git ignore-io vim
 
-    # Created by https://www.gitignore.io/api/vim
+    # Created by https://www.toptal.com/developers/gitignore/api/vim
 
     ### Vim ###
     [._]*.s[a-w][a-z]

--- a/man/git-ignore-io.md
+++ b/man/git-ignore-io.md
@@ -84,7 +84,8 @@ $ git ignore-io -s ja
 
 ## AUTHOR
 
-Written by Lee-W <cl87654321@gmail.com> 
+Written by Lee-W <weilee.rx@gmail.com> 
+
 ## REPORTING BUGS
 
 &lt;<https://github.com/tj/git-extras/issues>&gt;


### PR DESCRIPTION
The original links are now redirected to [Toptal](https://www.toptal.com/developers/gitignore/)
Making this change can save users time redirecting