### PR TITLE
tweak editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,14 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.patch]
-insert_final_newline = false
+[Makefile]
+indent_style = tab
 
-[*.md,*.patch]
+[*.patch]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.html]
 trim_trailing_whitespace = false


### PR DESCRIPTION
1. an entry contains multiple filetypes are not supported in some situation
2. our patch already has a newline at the end
3. Makefile should use tab to indent
Signed-off-by: spacewander <spacewanderlzx@gmail.com>