### PR TITLE
fix: No longer pollute env with `GREP_OPTIONS`

### DIFF
--- a/helper/reset-env
+++ b/helper/reset-env
@@ -1,2 +1,2 @@
 # reset environment variables that could interfere with normal usage
-export GREP_OPTIONS=
+unset -v GREP_OPTIONS


### PR DESCRIPTION
By doing `export GREP_OPTIONS=`, this still creates an environment variable, `GREP_OPTIONS` in all subprocesses called by any of the git-extras scripts.

The `unset -v` has the same effect of removing `GREP_OPTIONS`, without cluttering up the environment table.