### PR TITLE
Change the oneline option to a tebular version in the git summary

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -221,11 +221,16 @@ project  : git-extras
 
 The `--line` option can also take a path, which will print a filtered summary for that folder or file.
 
-The option `--oneline` tries to put as much summary information of the repo into a single output line
+The option `--output-style` tries to put as much summary information of the repo into defined styled way as possible.
+This is how the `tebular` output style and `oneline` output style look like
 
 ```bash
-$ git summary --oneline
-git-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
+$ git summary --output-style tabular
+# Repo     | Age       | Last active | Active on | Commits | Uncommitted
+git-extras | 13 years  | 7 hours ago | 807 days  | 1703    | 3
+
+$ git summary --output-style oneline
+git-extras / age: 13 years / last active: 7 hours ago / active on 807 days / commits: 1703 / uncommitted: 3
 ```
 
 ## git effort

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -6,7 +6,7 @@ cd "$(git root)" || { echo "Can't cd to top level directory";exit 1; }
 SUMMARY_BY_LINE=
 DEDUP_BY_EMAIL=
 MERGES_ARG=
-SUMMARY_ONELINE=
+OUTPUT_STYLE=
 for arg in "$@"; do
     case "$arg" in
         --line)
@@ -18,8 +18,9 @@ for arg in "$@"; do
         --no-merges)
             MERGES_ARG="--no-merges"
             ;;
-        --oneline)
-            SUMMARY_ONELINE=1
+        --output-style)
+            OUTPUT_STYLE="$2"
+            shift
             ;;
         -*)
             >&2 echo "unknown argument $arg found"
@@ -189,39 +190,60 @@ uncommitted_changes_count() {
   git status --porcelain | wc -l
 }
 
-# summary
-if [ -n "$SUMMARY_BY_LINE" ] && [ -n "$SUMMARY_ONELINE" ]; then
-  echo "$project / lines: $(line_count "${paths[@]}")"
-elif [ -n "$SUMMARY_BY_LINE" ]; then
-  echo
-  echo " project     : $project"
-  echo " lines       : $(line_count "${paths[@]}")"
-  echo " authors     :"
-  lines "${paths[@]}" | sort | uniq -c | sort -rn | format_authors
-elif [ -n "$SUMMARY_ONELINE" ]; then
-  echo "$project / age: $(repository_age) / last active: $(last_active) / active on $(active_days "$commit") days / commits: $(commit_count "$commit") / uncommitted: $(uncommitted_changes_count)"
-else
-  echo
-  echo " project     : $project"
-  echo " repo age    : $(repository_age)"
-  echo " last active : $(last_active)"
-  # shellcheck disable=SC2086
-  echo " active on   : $(active_days $commit) days"
-  # shellcheck disable=SC2086
-  echo " commits     : $(commit_count $commit)"
 
-  # The file count doesn't support passing a git ref so ignore it if a ref is given
-  if [ "$commit" == "HEAD" ]; then
-    echo " files       : $(file_count)"
+COLUMN_CMD_DELIMTER="¬" # Hopefully, this symbol is not used in branch names... I use it as a seperator for columns
+SP="$COLUMN_CMD_DELIMTER|"
+
+print_summary_by_line() {
+  if [ "$OUTPUT_STYLE" == "tabular" ]; then
+    tabular_headers="# Repo $SP Lines"
+    echo -e "$tabular_headers\n$project $SP $(line_count "${paths[@]}")" | column -t -s "$COLUMN_CMD_DELIMTER"
+  elif [ "$OUTPUT_STYLE" == "oneline" ]; then
+    echo "$project / lines: $(line_count "${paths[@]}")"
+  elif [ -n "$SUMMARY_BY_LINE" ]; then
+    echo
+    echo " project     : $project"
+    echo " lines       : $(line_count "${paths[@]}")"
+    echo " authors     :"
+    lines "${paths[@]}" | sort | uniq -c | sort -rn | format_authors
   fi
-  echo " uncommitted : $(uncommitted_changes_count)"
-  echo " authors     : "
-  if [ -n "$DEDUP_BY_EMAIL" ]; then
-    # the $commit can be empty
-    # shellcheck disable=SC2086
-    git shortlog $MERGES_ARG -n -s -e $commit | dedup_by_email | format_authors
+}
+
+print_summary() {
+  if [ "$OUTPUT_STYLE" == "tabular" ]; then
+    tabular_headers="# Repo $SP Age $SP Last active $SP Active on $SP Commits $SP Uncommitted"
+    echo -e "$tabular_headers\n$project $SP $(repository_age) $SP $(last_active) $SP $(active_days $commit) days $SP $(commit_count $commit) $SP $(uncommitted_changes_count)" | column -t -s "$COLUMN_CMD_DELIMTER"
+  elif [ "$OUTPUT_STYLE" == "oneline" ]; then
+    echo "$project / age: $(repository_age) / last active: $(last_active) / active on $(active_days $commit) days / commits: $(commit_count $commit) / uncommitted: $(uncommitted_changes_count)"
   else
+    echo
+    echo " project     : $project"
+    echo " repo age    : $(repository_age)"
+    echo " last active : $(last_active)"
     # shellcheck disable=SC2086
-    git shortlog $MERGES_ARG -n -s $commit | format_authors
+    echo " active on   : $(active_days $commit) days"
+    # shellcheck disable=SC2086
+    echo " commits     : $(commit_count $commit)"
+
+    # The file count doesn't support passing a git ref so ignore it if a ref is given
+    if [ "$commit" == "HEAD" ]; then
+      echo " files       : $(file_count)"
+    fi
+    echo " uncommitted : $(uncommitted_changes_count)"
+    echo " authors     : "
+    if [ -n "$DEDUP_BY_EMAIL" ]; then
+      # the $commit can be empty
+      # shellcheck disable=SC2086
+      git shortlog $MERGES_ARG -n -s -e $commit | dedup_by_email | format_authors
+    else
+      # shellcheck disable=SC2086
+      git shortlog $MERGES_ARG -n -s $commit | format_authors
+    fi
   fi
+}
+
+if [ -n "$SUMMARY_BY_LINE" ]; then
+  print_summary_by_line
+else
+  print_summary
 fi

--- a/man/git-summary.1
+++ b/man/git-summary.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-SUMMARY" "1" "January 2023" "" "Git Extras"
+.TH "GIT\-SUMMARY" "1" "February 2023" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-summary\fR \- Show repository summary
@@ -66,10 +66,13 @@ Summarize with lines other than commits\. When \fB\-\-line\fR is specified, the 
 This option can not be used together with \fB\-\-dedup\-by\-email\fR or \fB\-\-no\-merges\fR\.
 .
 .P
-\-\-oneline
+\-\-output\-style <style>
 .
 .P
-Summarizes the repository within one line\. Some information like the authors cannot be displayed in this mode\.
+Summarizes the repository and print the output accoring to the specified style\. Styles: * \fBtabular\fR: Prints the summary in a tabular form having a header in the first line and the values in the second * \fBoneline\fR: Prints the summary in a single line
+.
+.P
+Some information like the authors cannot be displayed in this mode\.
 .
 .SH "EXAMPLES"
 Outputs a repo summary:
@@ -161,14 +164,29 @@ authors  :
 .IP "" 0
 .
 .P
+Tabular summary
+.
+.IP "" 4
+.
+.nf
+
+$ git summary \-\-output\-style tabular
+# Repo     | Age       | Last active | Active on | Commits | Uncommitted
+git\-extras | 13 years  | 7 hours ago | 807 days  | 1703    | 3
+.
+.fi
+.
+.IP "" 0
+.
+.P
 Oneline summary
 .
 .IP "" 4
 .
 .nf
 
-$ git summary \-\-oneline
-git\-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
+$ git summary \-\-output\-style oneline
+git\-extras / age: 13 years / last active: 7 hours ago / active on 807 days / commits: 1703 / uncommitted: 3
 .
 .fi
 .

--- a/man/git-summary.html
+++ b/man/git-summary.html
@@ -119,9 +119,15 @@ $ git summary --dedup-by-email
 
 <p>  This option can not be used together with <code>--dedup-by-email</code> or <code>--no-merges</code>.</p>
 
-<p>  --oneline</p>
+<p>  --output-style &lt;style&gt;</p>
 
-<p>  Summarizes the repository within one line. Some information like the authors cannot be displayed in this mode.</p>
+<p>  Summarizes the repository and print the output accoring to the specified style.
+  Styles:
+  * <code>tabular</code>: Prints the summary in a tabular form having a header in the
+               first line and the values in the second
+  * <code>oneline</code>: Prints the summary in a single line</p>
+
+<p>  Some information like the authors cannot be displayed in this mode.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -183,15 +189,22 @@ authors  :
   ...
 </code></pre>
 
+<p>  Tabular summary</p>
+
+<pre><code>$ git summary --output-style tabular
+# Repo     | Age       | Last active | Active on | Commits | Uncommitted
+git-extras | 13 years  | 7 hours ago | 807 days  | 1703    | 3
+</code></pre>
+
 <p>  Oneline summary</p>
 
-<pre><code>$ git summary --oneline
-git-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
+<pre><code>$ git summary --output-style oneline
+git-extras / age: 13 years / last active: 7 hours ago / active on 807 days / commits: 1703 / uncommitted: 3
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#x3a;&#116;&#x6a;&#64;&#118;&#105;&#115;&#105;&#x6f;&#x6e;&#x2d;&#109;&#x65;&#100;&#x69;&#97;&#46;&#x63;&#97;" data-bare-link="true">&#x74;&#x6a;&#x40;&#118;&#105;&#x73;&#105;&#111;&#110;&#45;&#x6d;&#x65;&#x64;&#105;&#97;&#x2e;&#99;&#97;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="&#109;&#97;&#105;&#x6c;&#116;&#x6f;&#x3a;&#116;&#x6a;&#64;&#x76;&#x69;&#x73;&#105;&#111;&#110;&#x2d;&#109;&#x65;&#x64;&#105;&#x61;&#46;&#99;&#97;" data-bare-link="true">&#x74;&#106;&#64;&#x76;&#x69;&#115;&#x69;&#x6f;&#110;&#45;&#x6d;&#x65;&#x64;&#x69;&#97;&#x2e;&#99;&#x61;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -204,7 +217,7 @@ git-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commi
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>January 2023</li>
+    <li class='tc'>February 2023</li>
     <li class='tr'>git-summary(1)</li>
   </ol>
 

--- a/man/git-summary.md
+++ b/man/git-summary.md
@@ -45,9 +45,15 @@ Shows a summary of the repository or a path within it.
 
   This option can not be used together with `--dedup-by-email` or `--no-merges`.
 
-  --oneline
+  --output-style &lt;style&gt;
 
-  Summarizes the repository within one line. Some information like the authors cannot be displayed in this mode.
+  Summarizes the repository and print the output accoring to the specified style. 
+  Styles:
+  * `tabular`: Prints the summary in a tabular form having a header in the 
+               first line and the values in the second
+  * `oneline`: Prints the summary in a single line
+
+  Some information like the authors cannot be displayed in this mode.
 
 ## EXAMPLES
 
@@ -105,10 +111,16 @@ Shows a summary of the repository or a path within it.
     authors  :
       ...
 
+  Tabular summary
+
+    $ git summary --output-style tabular
+    # Repo     | Age       | Last active | Active on | Commits | Uncommitted
+    git-extras | 13 years  | 7 hours ago | 807 days  | 1703    | 3
+
   Oneline summary
 
-    $ git summary --oneline
-    git-extras / age: 5 days  / last active: 5 days ago / active on 799 days / commits: 1692 / uncommitted: 4
+    $ git summary --output-style oneline
+    git-extras / age: 13 years / last active: 7 hours ago / active on 807 days / commits: 1703 / uncommitted: 3
 
 ## AUTHOR
 


### PR DESCRIPTION
Hi,

I've change the `git summary --oneline` to `git summary  --output-style tabular` which gives an output like this:

```
# Repo                        | Age      | Last active  | Active on | Commits | Uncommitted
dev-infrastructure-automation | 8 weeks  | 18 hours ago | 22 days   | 46      | 0
```

When this is combined with the git bulk command, and some other bash magic, then this result can be achieved:

```
$ git bulk -q summary --output-style tabular | sed '1b;/^#/d' | column -t -s "|" -o "|" 
Core command "summary" accepted.
# Repo                            | Age                 | Last active          | Active on | Commits | Uncommitted
deno-data-handler-prototype       | 9 weeks             | 13 days ago          | 7 days    | 23      | 0
udp-handler                       | 9 weeks             | 2 weeks ago          | 2 days    | 5       | 0
azure-client                      | 9 weeks             | 2 weeks ago          | 2 days    | 4       | 0
dev-infrastructure-automation     | 8 weeks             | 18 hours ago         | 22 days   | 46      | 0
gitlab-project-settings-corrector | 4 months            | 2 weeks ago          | 2 days    | 3       | 0
free-for-all                      | 2 weeks             | 2 weeks ago          | 1 days    | 2       | 0
realm-initializer                 | 4 months            | 6 days ago           | 8 days    | 29      | 0
gitlab-k8s-cleaner                | 4 months            | 4 months ago         | 2 days    | 7       | 0
ci-docker-images                  | 4 months            | 7 days ago           | 4 days    | 9       | 0
...
```

The main advantage is, that the redundant header information stays just in the header and not pollutes the single lines any more.