### PR TITLE
fix: Unify handling of nprocs

### DIFF
--- a/bin/git-effort
+++ b/bin/git-effort
@@ -139,15 +139,6 @@ sort_effort() {
   < "$tmp" sort -rn -k 2
 }
 
-#
-# get processor count, default 8
-#
-procs() {
-  if ! (nproc --all || getconf NPROCESSORS_ONLN || getconf _NPROCESSORS_ONLN || grep -c processor /proc/cpuinfo) 2>/dev/null; then
-      echo 8
-  fi
-}
-
 declare -a paths=()
 while [ "${#}" -ge 1 ] ; do
 
@@ -216,7 +207,7 @@ heading
 
 # send paths to effort
 nPaths=${#paths[@]}
-nProcs=$(procs)
+nProcs=$(git_extra_get_nproc)
 nJobs="\j"
 for ((i=0; i<nPaths; ++i))
 do

--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -31,7 +31,8 @@ else
 
   # `-n` should be limited or parallelization will not give effect,
   # because all args will go into single worker.
-  NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
+  nproc=$(git_extra_get_nproc)
+
   # don't touch files that have been modified in the worktree or index
   #   bsd doesn't have `-z` option for `comm` and `cut`, so use `tr` as work around
   prefix="$(git rev-parse --show-prefix) "
@@ -39,5 +40,5 @@ else
            <(git status -z --porcelain | tr '\0' '\n' | cut -c 4- | sort) \
   | cut -c ${#prefix}- \
   | tr '\n' '\0' \
-  | xargs -0 -P${NPROC:-1} -n 24 $opt_r git utimes --touch "$1"
+  | xargs -0 -P"$nproc" -n 24 $opt_r git utimes --touch "$1"
 fi

--- a/helper/git-extra-utility
+++ b/helper/git-extra-utility
@@ -22,7 +22,9 @@ git_extra_default_branch() {
 # get processor count, default 2
 #
 git_extra_get_nproc() {
-    if ! (nproc || getconf NPROCESSORS_ONLN || getconf _NPROCESSORS_ONLN || grep -c ^processor /proc/cpuinfo) 2>/dev/null; then
-        printf '%s\n' 2
+    local default=${1:-2}
+
+    if ! { nproc || getconf NPROCESSORS_ONLN || getconf _NPROCESSORS_ONLN || grep -c ^processor /proc/cpuinfo; } 2>/dev/null; then
+        printf '%s\n' "$default"
     fi
 }

--- a/helper/git-extra-utility
+++ b/helper/git-extra-utility
@@ -17,3 +17,12 @@ git_extra_default_branch() {
         echo "main"
     fi
 }
+
+#
+# get processor count, default 2
+#
+git_extra_get_nproc() {
+    if ! (nproc || getconf NPROCESSORS_ONLN || getconf _NPROCESSORS_ONLN || grep -c ^processor /proc/cpuinfo) 2>/dev/null; then
+        printf '%s\n' 2
+    fi
+}


### PR DESCRIPTION
The default was also changed to 2, as it should be.

Been looking through some issues, and the following should be closed as they are already implemented:

- Closes #29 (-a [already used](https://github.com/tj/git-extras/blob/a008308267bb8e0042b1f8bf7606902eb4980b8a/bin/git-release#L131))
- Closes #943 (via https://github.com/tj/git-extras/pull/946)