### PR TITLE
Makefile: set bash COMPL_DIR to FreeBSD expected defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ else
 endif
 ifeq ($(OS), Darwin)
 	COMPL_DIR ?= "$(DESTDIR)$(SYSCONFDIR)/bash_completion.d"
+else ifeq ($(OS), FreeBSD)
+	COMPL_DIR ?= "$(DESTDIR)$(SYSCONFDIR)/bash_completion.d"
 else
 	COMPL_DIR ?= "$(DESTDIR)$(SYSCONFDIR)/bash-completion/completions"
 endif


### PR DESCRIPTION
See official conventions: https://docs.freebsd.org/en/books/porters-handbook/special/#shell-completion