### PR TITLE
Makefile: tune MANPREFIX configuration for FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SHELL := bash
 OS = $(shell uname)
 ifeq ($(OS), FreeBSD)
 	MANPREFIX ?= "$(PREFIX)/man/man1"
+	ifeq ($(MANPREFIX), /usr/local)
+		MANPREFIX = "/usr/local/man/man1"
+	endif
 else
 	MANPREFIX ?= "$(PREFIX)/share/man/man1"
 endif


### PR DESCRIPTION
We could think of the following use cases:

1. User installs git-extras from official port/pkg. man/man* structure is quite common among different systems, but location of man/ itself can be different. FreeBSD Ports framework setups MANPREFIX to PREFIX by default, i.e. it's /usr/local. The idea is that software may provide different man/man* sections, with final path being /usr/local/man/man*. In contrast, git-extras' Makefile process simplifies the things due to it works with section 1 only, and expects MANPREFIX to be set down to man/man1 path. For this reason, installation via FreeBSD Ports requires unconditional man path configuration like this:

    ifeq ($(OS), FreeBSD)
        MANPREFIX = "$(PREFIX)/man/man1"

Otherwise, the path will be incorrect. And this is how official FreeBSD port of git-extras has been fixing this difference for many years.

2. End user installs git-extras manually. There are two sub-cases:

  2.a. User explicitly defines custom MANPREFIX. Okay, it's user's
  decision -- nothing to do here, just follow as is.
  (But /usr/local will be corrected to /usr/local/man/man1)

  2.b. User does not define custom paths, i.e. it's expected to be
  installed according to FreeBSD defaults. And default values in
  git-extras' Makefile forms the expected correct path.

This change supports all the cases above, with the goal to avoid wrong man path for the most of the situations. As long as official git-extras make process tries to support FreeBSD, this change allows to omit extra patching for FreeBSD Ports framework.