### PR TITLE
tweak: Fix typos

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -883,7 +883,7 @@ $ (main) git ...
 
 ## git fresh-branch
 
-Create empty local branch `name`:
+Create empty local branch `docs`:
 
 ```bash
 $ git fresh-branch docs

--- a/check_integrity.sh
+++ b/check_integrity.sh
@@ -25,7 +25,7 @@ check_bash_script() {
 
 check_git_extras_cmd_list() {
     local whitelist=('extras')
-    for cmd in ${whitelist[*]}; do
+    for cmd in "${whitelist[@]}"; do
         test "$1" == "$cmd" && return
     done
 
@@ -54,7 +54,7 @@ check_documentation() {
 check_Commands_page() {
     # These are special cases. All listed together, so we ignore them
     local whitelist=('bug' 'chore' 'feature' 'refactor')
-    for cmd in ${whitelist[*]}; do
+    for cmd in "${whitelist[@]}"; do
         test "$1" == "$cmd" && return
     done
 

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # bash completion support for git-extras.
 
 _git_changelog(){


### PR DESCRIPTION
Improve loops and fix typos. Adds a declaration for Shellcheck at the top of the completion file to remove the spurious warning.