### PR TITLE
Improve `git-ignore` command

### DIFF
--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-: ${GIT_DIR:=$(git rev-parse --git-dir)}
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 
 function show_contents {
   local file="${2/#~/$HOME}"
@@ -11,10 +11,21 @@ function show_contents {
   fi
 }
 
+function maybe_cd_to_git_root {
+  local result=
+  if result=$(git rev-parse --show-toplevel 2>/dev/null); then
+    cd "$result" || exit
+  fi
+}
+
 function global_ignore() {
-    git config --global core.excludesFile || \
-        ([ -n "$XDG_CONFIG_HOME"  ] && echo "$XDG_CONFIG_HOME/git/ignore") || \
-        echo "$HOME/.config/git/ignore"
+  if ! git config --global core.excludesFile 2>/dev/null; then
+    if [ -f "$HOME/.gitignore" ]; then
+      echo "$HOME/.gitignore"
+    else
+      echo "${XDG_CONFIG_HOME:-$HOME/.config}/git/ignore"
+    fi
+  fi
 }
 
 function show_global {
@@ -22,7 +33,8 @@ function show_global {
 }
 
 function add_global {
-  local global_gitignore="$(global_ignore)"
+  local global_gitignore
+  global_gitignore="$(global_ignore)"
   if [ -z "$global_gitignore" ]; then
     echo "Can't find global .gitignore."
     echo ""
@@ -34,22 +46,22 @@ function add_global {
 }
 
 function show_local {
-  cd "$(git root)"
+  maybe_cd_to_git_root
   show_contents Local .gitignore
 }
 
 function add_local {
-  cd "$(git root)"
+  maybe_cd_to_git_root
   add_patterns .gitignore "$@"
 }
 
 function show_private {
-  cd "$(git root)"
+  maybe_cd_to_git_root
   show_contents Private "${GIT_DIR}/info/exclude"
 }
 
 function add_private {
-  cd "$(git root)"
+  maybe_cd_to_git_root
   test -d "${GIT_DIR}/info" || mkdir -p "${GIT_DIR}/info"
   add_patterns "${GIT_DIR}/info/exclude" "$@"
 }

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -11,7 +11,18 @@ function show_contents {
   fi
 }
 
-function maybe_cd_to_git_root {
+function cd_to_git_root {
+  local error_level="$1"
+
+  if ! git rev-parse --git-dir &>/dev/null; then
+    if [ "$error_level" = '--warn' ]; then
+      echo "Warning: Not currently in a Git repository" >&2
+    elif [ "$error_level" = '--error' ]; then
+      echo "Error: Not currently in a Git repository" >&2
+      exit 1
+    fi
+  fi
+
   local result=
   if result=$(git rev-parse --show-toplevel 2>/dev/null); then
     cd "$result" || exit
@@ -46,22 +57,22 @@ function add_global {
 }
 
 function show_local {
-  maybe_cd_to_git_root
+  cd_to_git_root --warn
   show_contents Local .gitignore
 }
 
 function add_local {
-  maybe_cd_to_git_root
+  cd_to_git_root --warn
   add_patterns .gitignore "$@"
 }
 
 function show_private {
-  maybe_cd_to_git_root
+  cd_to_git_root --error
   show_contents Private "${GIT_DIR}/info/exclude"
 }
 
 function add_private {
-  maybe_cd_to_git_root
+  cd_to_git_root --error
   test -d "${GIT_DIR}/info" || mkdir -p "${GIT_DIR}/info"
   add_patterns "${GIT_DIR}/info/exclude" "$@"
 }

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -265,7 +265,8 @@ _git-ignore() {
     _arguments -C \
         '(--local -l)'{--local,-l}'[show local gitignore]' \
         '(--global -g)'{--global,-g}'[show global gitignore]' \
-        '(--private -p)'{--private,-p}'[show repo gitignore]'
+        '(--private -p)'{--private,-p}'[show repo gitignore]' \
+        '*:filename:_files'
 }
 
 

--- a/not_need_git_repo
+++ b/not_need_git_repo
@@ -5,5 +5,6 @@ git-bulk
 git-extras
 git-force-clone
 git-fork
+git-ignore
 git-setup
 git-standup


### PR DESCRIPTION
Closes #38
  - `git ignore<TAB>` now shows file/directory names
  
Closes #347
  - No longer prints "fatal: not a git repository"-type errors to console. If no (local) Git repository is present, handle gracefully

Closes #427 (stale issue about file that does not exist)