### PR TITLE
feat(git-fork): add flags comprehension

### DIFF
--- a/bin/git-fork
+++ b/bin/git-fork
@@ -1,67 +1,120 @@
 #!/usr/bin/env bash
 
 abort() {
-  echo "$@"
-  exit 1
+        echo "$@"
+        exit 1
 }
 
-url="$1"
-test -z "$url" && url=$(git remote get-url origin 2> /dev/null) && origin=true
-# validate repo url
-test -z "$url" && abort "github repo needs to be specified as an argument"
+print_help() {
+        echo "Usage: git fork [options] [github-repo-url]"
+        echo "Options:"
+        echo "  -h, --help          Print this help message"
+        echo "  -c, --current       Use the URL of the current Git repository as the source"
+        echo "  -t, --token <token> GitHub personal access token"
+        echo "  -d, --target-dir <directory>  Target directory for cloning the forked repository"
+}
 
-# validate user
-echo "Enter your github username"
-read -r user
-[ -n "$user" ] || abort "git username required"
-# personal access token
-# config name is github-personal-access-token '_' is not allowed in git config
+parse_args() {
+        while getopts ":hct:d:" opt; do
+                case $opt in
+                h)
+                        print_help
+                        exit 0
+                        ;;
+                c)
+                        origin=true
+                        ;;
+                t)
+                        github_personal_access_token="$OPTARG"
+                        ;;
+                d)
+                        target_dir="$OPTARG"
+                        ;;
+                \?)
+                        abort "Invalid option: -$OPTARG"
+                        ;;
+                :)
+                        abort "Option -$OPTARG requires an argument"
+                        ;;
+                esac
+        done
+}
 
-github_personal_access_token=$(git config git-extras.github-personal-access-token)
+fork_repository() {
+        local repo_url=$1
+        local user=$2
+        local token=$3
+        local owner
+        local project
 
-test -z "$github_personal_access_token" && abort "git config git-extras.github-personal-access-token required"
+        # Extract owner and project from repo URL
+        project=${repo_url##*/}
+        owner=${repo_url%/"$project"}
+        project=${project%.git}
+        if [[ $owner == git@* ]]; then
+                owner=${owner##*:}
+        else
+                owner=${owner##*/}
+        fi
 
-# extract owner + project from repo url
-project=${url##*/}
-owner=${url%/"$project"}
-project=${project%.git}
-if [[ $owner == git@* ]]; then
-  owner=${owner##*:}
-else
-  owner=${owner##*/}
-fi
+        # Validate owner and project
+        [[ -z "$project" || -z "$owner" ]] && abort "GitHub repo URL is not valid"
 
-# validate
-[[ -z "$project" || -z "$owner" ]] && abort "github repo needs to be specified as an argument"
+        # Create fork
+        if ! curl -qsf \
+                -X POST \
+                -u "$user:$token" \
+                "https://api.github.com/repos/$owner/$project/forks"; then
+                abort "Fork failed"
+        fi
 
-# create fork
-if ! curl -qsf \
-  -X POST \
-  -u "$user:$github_personal_access_token" \
-  -H "X-GitHub-OTP: $MFA_CODE" \
-  "https://api.github.com/repos/$owner/$project/forks"
-then
-  abort "fork failed"
-fi
+        # Add GitHub remote branch via SSH or HTTPS
+        local remote_prefix
+        if [ -n "$use_ssh" ] && ssh -T git@github.com 2>&1 | grep -qi 'success'; then
+                remote_prefix="git@github.com:"
+        else
+                remote_prefix="https://github.com/"
+        fi
 
-echo "Add GitHub remote branch via SSH (you will be prompted to verify the server's credentials)? (y/n)"
-read -r use_ssh
-# Check if user has ssh configured with GitHub
-if [ -n "$use_ssh" ] && ssh -T git@github.com 2>&1 | grep -qi 'success'; then
-  remote_prefix="git@github.com:"
-else
-  remote_prefix="https://github.com/"
-fi
+        if [ "$origin" = true ]; then
+                # Rename and add remote for the existing repository
+                git remote rename origin upstream
+                git remote add origin "${remote_prefix}${user}/${project}.git"
+                git fetch origin
+        else
+                # Clone forked repo into the specified or default directory
+                local clone_dir="${target_dir:-$project}"
+                git clone "${remote_prefix}${user}/${project}.git" "$clone_dir"
+                # Add reference to the original fork for merging upstream changes
+                cd "$clone_dir" || exit
+                git remote add upstream "${remote_prefix}${owner}/${project}.git"
+                git fetch upstream
+        fi
+}
 
-if [ "$origin" = true ]; then
-    git remote rename origin upstream
-    git remote add origin "${remote_prefix}${user}/${project}.git"
-    git fetch origin
-else
-    # clone forked repo into current dir
-    git clone "${remote_prefix}${user}/${project}.git" "$project"
-    # add reference to origin fork so can merge in upstream changes
-    cd "$project"
-    git remote add upstream "${remote_prefix}${owner}/${project}.git"
-    git fetch upstream
-fi
+main() {
+        parse_args "$@"
+
+        # Prompt for GitHub username if not provided
+        echo "Enter your GitHub username:"
+        read -r user
+        [ -n "$user" ] || abort "GitHub username is required"
+
+        # Prompt for personal access token if not provided
+        if [ -z "$github_personal_access_token" ]; then
+                echo "Enter your GitHub personal access token:"
+                read -r -s github_personal_access_token
+                [ -n "$github_personal_access_token" ] || abort "GitHub personal access token is required"
+        fi
+
+        # Fetch the repository URL
+        local url=$1
+        [ -z "$url" ] && url=$(git remote get-url origin 2>/dev/null) && origin=true
+
+        # Validate repository URL
+        [ -n "$url" ] || abort "GitHub repo URL needs to be specified as an argument"
+
+        fork_repository "$url" "$user" "$github_personal_access_token"
+}
+
+main "$@"

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -1,161 +1,190 @@
 # shellcheck shell=bash
 # bash completion support for git-extras.
 
-_git_changelog(){
-  local s_opts=( '-a' '-l' '-t' '-f' '-s' '-n' '-p' '-x' '-h' '?' )
-  local l_opts=(
-    '--all'
-    '--list'
-    '--tag'
-    '--final-tag'
-    '--start-tag'
-    '--start-commit'
-    '--no-merges'
-    '--prune-old'
-    '--stdout'
-    '--help'
-  )
-  local merged_opts_str=""
-  merged_opts_str+="$(printf "%s " "${s_opts[@]}")"
-  merged_opts_str+="$(printf "%s " "${l_opts[@]}")"
+_git_changelog() {
+        local s_opts=('-a' '-l' '-t' '-f' '-s' '-n' '-p' '-x' '-h' '?')
+        local l_opts=(
+                '--all'
+                '--list'
+                '--tag'
+                '--final-tag'
+                '--start-tag'
+                '--start-commit'
+                '--no-merges'
+                '--prune-old'
+                '--stdout'
+                '--help'
+        )
+        local merged_opts_str=""
+        merged_opts_str+="$(printf "%s " "${s_opts[@]}")"
+        merged_opts_str+="$(printf "%s " "${l_opts[@]}")"
 
-  __gitcomp "$merged_opts_str"
+        __gitcomp "$merged_opts_str"
 }
 
-_git_authors(){
-  __gitcomp "-l --list --no-email"
+_git_authors() {
+        __gitcomp "-l --list --no-email"
 }
 
-_git_contrib(){
-# git completion function modified from
-# https://github.com/markgandolfo/git-bash-completion/blob/master/git-completion.bash
-  contributors="$(git shortlog -s | cut -f2)"
-  local all c s=$'\n' IFS=$'\n'
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  for c in $contributors; do
-    all="$all$c $s"
-  done
-  COMPREPLY=($(compgen -W "$all" -- "$cur"))
+_git_contrib() {
+        # git completion function modified from
+        # https://github.com/markgandolfo/git-bash-completion/blob/master/git-completion.bash
+        contributors="$(git shortlog -s | cut -f2)"
+        local all c s=$'\n' IFS=$'\n'
+        local cur="${COMP_WORDS[COMP_CWORD]}"
+        for c in $contributors; do
+                all="$all$c $s"
+        done
+        COMPREPLY=($(compgen -W "$all" -- "$cur"))
 }
 
-_git_count(){
-  __gitcomp "--all"
+_git_count() {
+        __gitcomp "--all"
 }
 
-__git_cp(){
-  __git_complete_file
+__git_cp() {
+        __git_complete_file
 }
 
-_git_delete_branch(){
-  __gitcomp "$(__git_heads)"
+_git_delete_branch() {
+        __gitcomp "$(__git_heads)"
 }
 
-_git_delete_squashed_branches(){
-  __gitcomp "$(__git_heads)"
+_git_delete_squashed_branches() {
+        __gitcomp "$(__git_heads)"
 }
 
-_git_delete_submodule(){
-  __gitcomp "$(git submodule status | awk '{print $2}')"
+_git_delete_submodule() {
+        __gitcomp "$(git submodule status | awk '{print $2}')"
 }
 
-_git_delete_tag(){
-  __gitcomp "$(__git_tags)"
+_git_delete_tag() {
+        __gitcomp "$(__git_tags)"
 }
 
-_git_effort(){
-  __git_has_doubledash && return
+_git_effort() {
+        __git_has_doubledash && return
 
-  case "$cur" in
-  --*)
-    __gitcomp "
+        case "$cur" in
+        --*)
+                __gitcomp "
       --above
       $__git_log_common_options
       $__git_log_shortlog_options
       "
-    return
-    ;;
-  esac
+                return
+                ;;
+        esac
 }
 
-_git_extras(){
-  __gitcomp "--version update"
+_git_extras() {
+        __gitcomp "--version update"
 }
 
-__git_extras_workflow(){
-  __gitcomp "$(__git_heads | grep -- ^$1/ | sed s/^$1\\///g) finish"
+__git_extras_workflow() {
+        __gitcomp "$(__git_heads | grep -- ^$1/ | sed s/^$1\\///g) finish"
 }
 
-_git_feature(){
-  __git_extras_workflow "feature"
+_git_feature() {
+        __git_extras_workflow "feature"
 }
 
-_git_graft(){
-  __gitcomp "$(__git_heads)"
+_git-fork() {
+        local cur prev opts
+        COMPREPLY=()
+        cur="${COMP_WORDS[COMP_CWORD]}"
+        prev="${COMP_WORDS[COMP_CWORD - 1]}"
+        opts="-h --help -c --current -t --token -d --target-dir"
+
+        case "${prev}" in
+        -t | --token)
+                return 0
+                ;;
+        -d | --target-dir)
+                # Complete directories
+                COMPREPLY=($(compgen -d -- "${cur}"))
+                return 0
+                ;;
+        *) ;;
+        esac
+
+        if [[ "${cur}" == -* ]]; then
+                COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+                return 0
+        else
+                # Complete GitHub repo URLs
+                COMPREPLY=($(compgen -W "$(git ls-remote --get-url --all)" -- ${cur}))
+                return 0
+        fi
 }
 
-_git_ignore(){
-  case "$cur" in
-  --*)
-    __gitcomp "--global --local --private"
-    return
-    ;;
-  -*)
-    __gitcomp "--global --local --private -g -l -p"
-    return
-    ;;
-  esac
+_git_graft() {
+        __gitcomp "$(__git_heads)"
 }
 
-_git_missing(){
-    # Suggest all known refs
-    __gitcomp "$(git for-each-ref --format='%(refname:short)')"
+_git_ignore() {
+        case "$cur" in
+        --*)
+                __gitcomp "--global --local --private"
+                return
+                ;;
+        -*)
+                __gitcomp "--global --local --private -g -l -p"
+                return
+                ;;
+        esac
 }
 
-_git_psykorebase(){
-  __gitcomp "$(__git_heads) --continue --no-ff"
+_git_missing() {
+        # Suggest all known refs
+        __gitcomp "$(git for-each-ref --format='%(refname:short)')"
 }
 
-_git_reauthor(){
-  local prev="${COMP_WORDS[COMP_CWORD-1]}"
-  local comp
-
-  if [[ "${prev}" == '--type' ]] || [[ "${prev}" == '-t' ]]; then
-    comp='author committer full'
-  else
-    comp='--all --correct-email --correct-name --old-email --type --use-config'
-  fi
-
-   __gitcomp "${comp}"
+_git_psykorebase() {
+        __gitcomp "$(__git_heads) --continue --no-ff"
 }
 
-_git_scp(){
-  __git_complete_remote_or_refspec
+_git_reauthor() {
+        local prev="${COMP_WORDS[COMP_CWORD - 1]}"
+        local comp
+
+        if [[ "${prev}" == '--type' ]] || [[ "${prev}" == '-t' ]]; then
+                comp='author committer full'
+        else
+                comp='--all --correct-email --correct-name --old-email --type --use-config'
+        fi
+
+        __gitcomp "${comp}"
 }
 
-_git_stamp(){
-  __gitcomp '--replace -r'
+_git_scp() {
+        __git_complete_remote_or_refspec
 }
 
-_git_rscp(){
-  __git_complete_remote_or_refspec
+_git_stamp() {
+        __gitcomp '--replace -r'
 }
 
-_git_squash(){
-  __gitcomp "$(__git_heads)"
+_git_rscp() {
+        __git_complete_remote_or_refspec
 }
 
-_git_undo(){
-   __gitcomp "--hard --soft -h -s"
+_git_squash() {
+        __gitcomp "$(__git_heads)"
 }
 
-_git_info(){
-  __gitcomp "--color -c --no-config"
+_git_undo() {
+        __gitcomp "--hard --soft -h -s"
 }
 
-_git_browse(){
-  __git_complete_remote_or_refspec
+_git_info() {
+        __gitcomp "--color -c --no-config"
 }
 
-_git_browse_ci(){
-  __git_complete_remote_or_refspec
+_git_browse() {
+        __git_complete_remote_or_refspec
+}
+
+_git_browse_ci() {
+        __git_complete_remote_or_refspec
 }

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -247,6 +247,25 @@ _git-feature() {
         '(--remote -r)'{--remote,-r}'[setup remote tracking branch]'
 }
 
+_git-fork() {
+  local curcontext="$curcontext" state line
+  typeset -A opt_args
+
+  _arguments \
+    '1: :->url' \
+    '-h[--help]'{-h,--help}'[Print help message]' \
+    '-c[--current]'{-c,--current}'[Use the URL of the current Git repository as the source]' \
+    '-t[--token]:GitHub personal access token:'{-t,--token}'[Specify the GitHub personal access token]' \
+    '-d[--target-dir]:Target directory:'{-d,--target-dir}'[Specify the target directory for cloning the forked repository]' \
+    && return 0
+
+  case "$state" in
+    url)
+      _urls
+      ;;
+  esac
+}
+
 _git-graft() {
     _arguments \
         ':src-branch-name:__gitex_branch_names' \

--- a/etc/git-extras.fish
+++ b/etc/git-extras.fish
@@ -70,20 +70,20 @@ set __fish_git_extras_commands \
     "unlock:Unlock a file excluded from version control"
 
 # completion for git-extras itself
-complete -c git -f -n '__fish_git_needs_command' -a 'extras' -d 'GIT utilities: repo summary, repl, changelog population, and more'
+complete -c git -f -n __fish_git_needs_command -a extras -d 'GIT utilities: repo summary, repl, changelog population, and more'
 complete -c git -f -n '__fish_git_using_command extras' -s h -l help -d 'Show the help message, can be used for any git-extras commands'
 complete -c git -f -n '__fish_git_using_command extras' -s v -l version -d 'Show git-extras version number'
-complete -c git -f -n '__fish_git_using_command extras; and not contains -- update (commandline -opc)' -a "update" -d 'Self update'
+complete -c git -f -n '__fish_git_using_command extras; and not contains -- update (commandline -opc)' -a update -d 'Self update'
 
 # completion for git-extras provided commands
 set __fish_git_extras_commands (printf -- '%s\n' $__fish_git_extras_commands | sed 's/:/\textras:/' | string collect | string escape)
-complete -c git -n '__fish_git_needs_command' -a "$__fish_git_extras_commands"
+complete -c git -n __fish_git_needs_command -a "$__fish_git_extras_commands"
 # authors
 complete -c git -f -n '__fish_git_using_command authors' -s l -l list -d 'show authors'
 complete -c git -f -n '__fish_git_using_command authors' -l no-email -d 'without email'
 # bulk
-complete -c git    -n '__fish_git_using_command bulk' -s a -d 'Run a git command on all workspaces and their repositories'
-complete -c git    -n '__fish_git_using_command bulk' -s g -d 'Ask the user for confirmation on every execution'
+complete -c git -n '__fish_git_using_command bulk' -s a -d 'Run a git command on all workspaces and their repositories'
+complete -c git -n '__fish_git_using_command bulk' -s g -d 'Ask the user for confirmation on every execution'
 complete -c git -x -n '__fish_git_using_command bulk' -s w -d 'Run on specified workspace'
 complete -c git -x -n '__fish_git_using_command bulk' -l addworkspace -d 'Register a workspace for builk operations'
 complete -c git -x -n '__fish_git_using_command bulk; and contains addworkspace (commandline -opc)' -l addworkspace -d 'the URL or file with URLs to be added'
@@ -118,18 +118,60 @@ complete -c git -x -n "__fish_git_using_command delete-tag" -a '(__fish_git for-
 complete -c git -f -n '__fish_git_using_command effort' -l above -d 'ignore file with less than x commits'
 # feature
 complete -c git -x -n '__fish_git_using_command feature' -s a -l alias -d 'use branch_prefix instead of feature'
-complete -c git -f -n '__fish_git_using_command feature; and not contains -- finish (commandline -opc)' -a "finish" -d 'merge and delete the feature branch'
+complete -c git -f -n '__fish_git_using_command feature; and not contains -- finish (commandline -opc)' -a finish -d 'merge and delete the feature branch'
 complete -c git -f -n '__fish_git_using_command feature; and contains -- finish (commandline -opc)' -l squash -d 'Run a squash merge'
 complete -c git -x -n '__fish_git_using_command feature; and contains -- finish (commandline -opc)' -a '(__fish_git for-each-ref --format="%(refname)" 2>/dev/null | grep "refs/heads/feature")' -d 'name of feature branch'
 complete -c git -x -n '__fish_git_using_command feature; and not contains -- finish (commandline -opc)' -s r -l remote -a '(__fish_git_unique_remote_branches)' -d 'Setup a remote tracking branch'
+# fork
+function __fish_git_fork_get_remotes
+    git remote -v | awk '{print $2}' | cut -d / -f 3
+end
+
+function __fish_git_fork
+    set -l cur (commandline -ct)
+    set -l prev (commandline -ct -1)
+    set -l opts '-h --help -c --current -t --token -d --target-dir'
+
+    switch "$prev"
+        case -t --token
+            return
+
+        case -d --target-dir
+            # Complete directories
+            set -l completions (commandline -e -o dirnames)
+            set -l dir (commandline -co)
+            for completion in $completions
+                echo $dir/$completion
+            end
+            return
+
+        case '*'
+
+            # Complete options
+            set -l completions (commandline -pco)
+            for completion in $completions
+                echo $completion
+            end
+            return
+    end
+
+    if string match -q -r -- '-.*' "$cur"
+        echo $opts
+    else
+        # Complete GitHub repo URLs
+        __fish_git_fork_get_remotes
+    end
+end
+
+complete -f -c git-fork -a "(__fish_git_fork)" -d 'Fork a repo on GitHub'
 # graft
-complete -c git -x -n '__fish_git_using_command graft' -s r -l remote -a '(__fish_git_branches)' -d 'src-branch-name'
-complete -c git -x -n '__fish_git_using_command graft' -s r -l remote -a '(__fish_git_branches)' -d 'dest-branch-name'
+complete -c git -x -n '__fish_git_using_command graft' -s r -l remote -a '(__fish_git_branches)' -d src-branch-name
+complete -c git -x -n '__fish_git_using_command graft' -s r -l remote -a '(__fish_git_branches)' -d dest-branch-name
 # guilt
 complete -c git -f -n '__fish_git_using_command guilt' -s w -l ignore-whitespace -d 'ignore whitespace only changes'
 complete -c git -f -n '__fish_git_using_command guilt' -s e -l email -d 'display author emails instead of names'
 complete -c git -f -n '__fish_git_using_command guilt' -s d -l debug -d 'output debug information'
-complete -c git -f -n '__fish_git_using_command guilt' -s h          -d 'output usage information'
+complete -c git -f -n '__fish_git_using_command guilt' -s h -d 'output usage information'
 # ignore
 complete -c git -f -n '__fish_git_using_command ignore' -s l -l local -d 'show local gitignore'
 complete -c git -f -n '__fish_git_using_command ignore' -s g -l global -d 'show global gitignore'
@@ -148,7 +190,7 @@ complete -c git -x -n '__fish_git_using_command ignore-io' -s s -l search -d 'se
 complete -c git -x -n '__fish_git_using_command ignore-io' -s t -l show-update-time -d 'Show the last modified time of ~/.gi_list'
 complete -c git -x -n '__fish_git_using_command ignore-io' -s u -l update -d 'Update ~/.gi_list'
 # merge-into
-complete -c git    -n '__fish_git_using_command merge-into' -l ff-only -d 'merge only fast-forward'
+complete -c git -n '__fish_git_using_command merge-into' -l ff-only -d 'merge only fast-forward'
 complete -c git -x -n '__fish_git_using_command merge-into' -a '(__fish_git_branches)'
 # missing
 complete -c git -x -n '__fish_git_using_command missing' -a '(__fish_git_branches)'
@@ -162,16 +204,16 @@ complete -c git -x -n '__fish_git_using_command standup' -s a -d 'Specify the au
 complete -c git -x -n '__fish_git_using_command standup' -s m -d 'The depth of recursive directory search'
 complete -c git -x -n '__fish_git_using_command standup' -s d -d 'Show history since N days ago'
 complete -c git -x -n '__fish_git_using_command standup' -s D -d 'Specify the date format displayed in commit history'
-complete -c git    -n '__fish_git_using_command standup' -s f -d 'Fetch commits before showing history'
-complete -c git    -n '__fish_git_using_command standup' -s g -d 'Display GPG signed info'
-complete -c git    -n '__fish_git_using_command standup' -s h -l help -d 'Display help message'
-complete -c git    -n '__fish_git_using_command standup' -s L -d 'Enable the inclusion of symbolic links'
-complete -c git    -n '__fish_git_using_command standup' -s B -d 'Display the commits in branch group'
+complete -c git -n '__fish_git_using_command standup' -s f -d 'Fetch commits before showing history'
+complete -c git -n '__fish_git_using_command standup' -s g -d 'Display GPG signed info'
+complete -c git -n '__fish_git_using_command standup' -s h -l help -d 'Display help message'
+complete -c git -n '__fish_git_using_command standup' -s L -d 'Enable the inclusion of symbolic links'
+complete -c git -n '__fish_git_using_command standup' -s B -d 'Display the commits in branch group'
 complete -c git -x -n '__fish_git_using_command standup' -s n -d 'Limit the number of commits displayed per group'
 # summary
-complete -c git    -n '__fish_git_using_command summary' -l line -d 'summarize with lines rather than commits'
-complete -c git    -n '__fish_git_using_command summary' -l dedup-by-email -d 'remove duplicate users by the email address'
-complete -c git    -n '__fish_git_using_command summary' -l no-merges -d 'exclude merge commits'
+complete -c git -n '__fish_git_using_command summary' -l line -d 'summarize with lines rather than commits'
+complete -c git -n '__fish_git_using_command summary' -l dedup-by-email -d 'remove duplicate users by the email address'
+complete -c git -n '__fish_git_using_command summary' -l no-merges -d 'exclude merge commits'
 # release
 complete -c git -x -n '__fish_git_using_command release' -s c -d 'Generates/populates the changelog with all commit message since the last tag'
 complete -c git -x -n '__fish_git_using_command release' -s r -d 'The "remote" repository that is destination of a push operation'
@@ -183,5 +225,3 @@ complete -c git -x -n '__fish_git_using_command release' -l no-empty-commit -d '
 # undo
 complete -c git -x -n '__fish_git_using_command undo' -s s -l soft -d 'only rolls back the commit but changes remain un-staged'
 complete -c git -x -n '__fish_git_using_command undo' -s h -l hard -d 'wipes your commit(s)'
-
-

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -1,123 +1,93 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-FORK" "1" "October 2017" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-FORK" "1" "June 2023" ""
 .SH "NAME"
 \fBgit\-fork\fR \- Fork a repo on github
-.
 .SH "SYNOPSIS"
 \fBgit\-fork\fR [<github\-repo\-url>]
-.
 .SH "DESCRIPTION"
-If a github repo url is given, fork the repo\. Like clone but forks first\.
-.
+If a GitHub repo URL is given, the command forks the specified repository\. It performs the following actions:
 .IP "1." 4
-forks the repo on github
-.
+Forks the repo on GitHub\.
 .IP "2." 4
-clones the repo into the current dir
-.
+Clones the repo into the current directory or the one specified with \fBd\fR or \fB\-\-target\-dir\fR\.
 .IP "3." 4
-adds the original repo as a remote called \fBupstream\fR
-.
+Adds the original repo as a remote called \fBupstream\fR\.
 .IP "" 0
-.
 .P
-If a url is not given and the current dir is a github repo, fork the repo\.
-.
+If a URL is not provided and the current directory is a GitHub repository, the command forks the current repo\. It performs the following actions:
 .IP "1." 4
-forks the current repo
-.
+Forks the current repo
 .IP "2." 4
-rename the \fBorigin\fR remote repo to \fBupstream\fR
-.
+Renames the \fBorigin\fR remote repo to \fBupstream\fR
 .IP "3." 4
-adds the forked repo as a remote called \fBorigin\fR
-.
+Adds the forked repo as a remote called \fBorigin\fR
 .IP "" 0
-.
 .P
-Remotes will use ssh if you have it configured with GitHub, if not, https will be used\.
-.
-Create a fork a project on GitHub via command line\.
-.
+Remotes will use SSH if you have it configured with GitHub\. Otherwise, HTTPS will be used\.
 .P
-A personal access token is required for making the API call to create a new fork in GitHub\. API Documentation here \fIhttps://docs\.github\.com/en/rest/reference/repos#forks\fR
-.
+To create a fork of a project on GitHub via the command line, a personal access token is required\.
 .P
-Make sure the personal access token has the right \fBOAuth\fR scopes for the repo(s)
-.
+The token is used for making the API call to create the fork on GitHub\.
 .P
-Use \fBgit config \-\-global \-\-add git\-extras\.github\-personal\-access\-token <your\-personal\-access\-token>\fR
-.
+Refer to the GitHub API Documentation \fIhttps://docs\.github\.com/en/rest/reference/repos#forks\fR for more information\.
 .P
-If using multiple accounts, override the global value in the specific repo using \fBgit config git\-extras\.github\-personal\-access\-token <other\-acc\-personal\-access\-token>\fR
-.
-.SH "EXAMPLE"
+Make sure that the personal access token has the necessary OAuth scopes for the repository\.
+.P
+You can configure the token by issuing the command:
+.P
+\fBgit config \-\-global \-\-add git\-extras\.github\-personal\-access\-token <your\-personal\-access\-token>\fR\.
+.P
+If you have multiple GitHub accounts and need to override the global token for a specific repository, use the command:
+.P
+\fBgit config git\-extras\.github\-personal\-access\-token <other\-acc\-personal\-access\-token>\fR\.
+.SH "OPTIONS"
+The following options are available:
+.IP "\[ci]" 4
+\fB\-h\fR, \fB\-\-help\fR: Print the help message and usage information\.
+.IP "\[ci]" 4
+\fB\-c\fR, \fB\-\-current\fR: Use the URL of the current Git repository as the source\.
+.IP "\[ci]" 4
+\fB\-t\fR, \fB\-\-token <token>\fR: Specify the GitHub personal access token\.
+.IP "\[ci]" 4
+\fB\-d\fR, \fB\-\-target\-dir <directory>\fR: Specify the target directory for cloning the forked repository\.
+.IP "" 0
+.SH "EXAMPLES"
 Fork expect\.js:
-.
 .IP "" 4
-.
 .nf
-
 $ git fork https://github\.com/LearnBoost/expect\.js
-.
 .fi
-.
 .IP "" 0
-.
 .P
 or just:
-.
 .IP "" 4
-.
 .nf
-
 $ git fork LearnBoost/expect\.js
-.
 .fi
-.
 .IP "" 0
-.
 .P
-Then:
-.
+Then, the forked repository will be cloned into the \fBexpect\.js\fR directory locally\. You can navigate to the directory and check the remotes:
 .IP "" 4
-.
 .nf
-
-$ \.\.<forks into your github profile and clones repo locally to expect\.js dir>\.\.\.
-
 $ cd expect\.js && git remote \-v
 
   origin          git@github\.com:<user>/expect\.js (fetch)
   origin          git@github\.com:<user>/expect\.js (push)
   upstream        git@github\.com:LearnBoost/expect\.js (fetch)
   upstream        git@github\.com:LearnBoost/expect\.js (push)
-.
 .fi
-.
 .IP "" 0
-.
 .P
 If the current dir is a clone of expect\.js, this has the same effect:
-.
 .IP "" 4
-.
 .nf
-
 $ git fork
-.
 .fi
-.
 .IP "" 0
-.
-.SH "AUTHOR"
-Written by Andrew Griffiths <\fImail@andrewgriffithsonline\.com\fR>
-.
+.SH "AUTHORS"
+Written by Andrew Griffiths <\fImail@andrewgriffithsonline\.com\fR> Co\-authored by Marcelina Hołub <\fImholub@tutanota\.com\fR>
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>
-.
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-fork.1.html
+++ b/man/git-fork.1.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
+  <title>git-fork(1) - Fork a repo on github</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHORS">AUTHORS</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-fork(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-fork(1)</li>
+  </ol>
+
+  
+
+<h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-fork</code> - <span class="man-whatis">Fork a repo on github</span>
+</p>
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-fork</code> [&lt;github-repo-url&gt;]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>If a GitHub repo URL is given, the command forks the specified repository. It performs the following actions:</p>
+
+<ol>
+  <li>Forks the repo on GitHub.</li>
+  <li>Clones the repo into the current directory or the one specified with <code>d</code> or <code>--target-dir</code>.</li>
+  <li>Adds the original repo as a remote called <code>upstream</code>.</li>
+</ol>
+
+<p>If a URL is not provided and the current directory is a GitHub repository, the command forks the current repo. 
+  It performs the following actions:</p>
+
+<ol>
+  <li>Forks the current repo</li>
+  <li>Renames the <code>origin</code> remote repo to <code>upstream</code>
+</li>
+  <li>Adds the forked repo as a remote called <code>origin</code>
+</li>
+</ol>
+
+<p>Remotes will use SSH if you have it configured with GitHub. Otherwise, HTTPS will be used.</p>
+
+<p>To create a fork of a project on GitHub via the command line, a personal access token is required.</p>
+
+<p>The token is used for making the API call to create the fork on GitHub.</p>
+
+<p>Refer to the <a href="https://docs.github.com/en/rest/reference/repos#forks">GitHub API Documentation</a> for more information.</p>
+
+<p>Make sure that the personal access token has the necessary OAuth scopes for the repository.</p>
+
+<p>You can configure the token by issuing the command:</p>
+
+<p><code>git config --global --add git-extras.github-personal-access-token &lt;your-personal-access-token&gt;</code>.</p>
+
+<p>If you have multiple GitHub accounts and need to override the global token for a specific repository, use the command:</p>
+
+<p><code>git config git-extras.github-personal-access-token &lt;other-acc-personal-access-token&gt;</code>.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>The following options are available:</p>
+
+<ul>
+  <li>
+<code>-h</code>, <code>--help</code>: Print the help message and usage information.</li>
+  <li>
+<code>-c</code>, <code>--current</code>: Use the URL of the current Git repository as the source.</li>
+  <li>
+<code>-t</code>, <code>--token &lt;token&gt;</code>: Specify the GitHub personal access token.</li>
+  <li>
+<code>-d</code>, <code>--target-dir &lt;directory&gt;</code>: Specify the target directory for cloning the forked repository.</li>
+</ul>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>Fork expect.js:</p>
+
+<pre><code>$ git fork https://github.com/LearnBoost/expect.js
+</code></pre>
+
+<p>or just:</p>
+
+<pre><code>$ git fork LearnBoost/expect.js
+</code></pre>
+
+<p>Then, the forked repository will be cloned into the <code>expect.js</code> directory locally. You can navigate to the directory and check the remotes:</p>
+
+<pre><code>$ cd expect.js &amp;&amp; git remote -v
+
+  origin          git@github.com:&lt;user&gt;/expect.js (fetch)
+  origin          git@github.com:&lt;user&gt;/expect.js (push)
+  upstream        git@github.com:LearnBoost/expect.js (fetch)
+  upstream        git@github.com:LearnBoost/expect.js (push)
+</code></pre>
+
+<p>If the current dir is a clone of expect.js, this has the same effect:</p>
+
+<pre><code>$ git fork
+</code></pre>
+
+<h2 id="AUTHORS">AUTHORS</h2>
+
+<p>Written by Andrew Griffiths &lt;<a href="mailto:mail@andrewgriffithsonline.com" data-bare-link="true">mail@andrewgriffithsonline.com</a>&gt;
+Co-authored by Marcelina Hołub &lt;<a href="mailto:mholub@tutanota.com" data-bare-link="true">mholub@tutanota.com</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>June 2023</li>
+    <li class='tr'>git-fork(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -7,31 +7,47 @@ git-fork(1) -- Fork a repo on github
 
 ## DESCRIPTION
 
-  If a github repo url is given, fork the repo. Like clone but forks first.
+  If a GitHub repo URL is given, the command forks the specified repository. It performs the following actions:
 
-  1. forks the repo on github
-  2. clones the repo into the current dir
-  3. adds the original repo as a remote called `upstream`
+  1. Forks the repo on GitHub.
+  2. Clones the repo into the current directory or the one specified with `d` or `--target-dir`.
+  3. Adds the original repo as a remote called `upstream`.
 
-  If a url is not given and the current dir is a github repo, fork the repo.
+  If a URL is not provided and the current directory is a GitHub repository, the command forks the current repo. 
+  It performs the following actions:
 
-  1. forks the current repo
-  2. rename the `origin` remote repo to `upstream`
-  3. adds the forked repo as a remote called `origin`
+  1. Forks the current repo
+  2. Renames the `origin` remote repo to `upstream`
+  3. Adds the forked repo as a remote called `origin`
 
-  Remotes will use ssh if you have it configured with GitHub, if not, https will be used.
+  Remotes will use SSH if you have it configured with GitHub. Otherwise, HTTPS will be used.
 
-  Create a fork of a project on GitHub via command line.
-  
-  A personal access token is required for making the API call to create a fork in GitHub. [API Documentation here](https://docs.github.com/en/rest/reference/repos#forks)
-  
-  Make sure the personal access token has the right `OAuth` scopes for the repo(s)
-  
-  Use `git config --global --add git-extras.github-personal-access-token <your-personal-access-token>`
-  
-  If using multiple accounts, override the global value in the specific repo using `git config git-extras.github-personal-access-token <other-acc-personal-access-token>`
+  To create a fork of a project on GitHub via the command line, a personal access token is required. 
 
-## EXAMPLE
+  The token is used for making the API call to create the fork on GitHub.
+
+  Refer to the [GitHub API Documentation](https://docs.github.com/en/rest/reference/repos#forks) for more information.
+
+  Make sure that the personal access token has the necessary OAuth scopes for the repository. 
+
+  You can configure the token by issuing the command:
+
+  `git config --global --add git-extras.github-personal-access-token <your-personal-access-token>`. 
+
+  If you have multiple GitHub accounts and need to override the global token for a specific repository, use the command:
+
+  `git config git-extras.github-personal-access-token <other-acc-personal-access-token>`.
+
+## OPTIONS
+
+The following options are available:
+
+- `-h`, `--help`: Print the help message and usage information.
+- `-c`, `--current`: Use the URL of the current Git repository as the source.
+- `-t`, `--token <token>`: Specify the GitHub personal access token.
+- `-d`, `--target-dir <directory>`: Specify the target directory for cloning the forked repository.
+
+## EXAMPLES
 
   Fork expect.js:
 
@@ -41,9 +57,7 @@ git-fork(1) -- Fork a repo on github
 
     $ git fork LearnBoost/expect.js
 
-  Then:
-
-    $ ..<forks into your github profile and clones repo locally to expect.js dir>...
+  Then, the forked repository will be cloned into the `expect.js` directory locally. You can navigate to the directory and check the remotes:
 
     $ cd expect.js && git remote -v
 
@@ -57,9 +71,10 @@ git-fork(1) -- Fork a repo on github
     $ git fork
 
 
-## AUTHOR
+## AUTHORS
 
 Written by Andrew Griffiths &lt;<mail@andrewgriffithsonline.com>&gt;
+Co-authored by Marcelina Hołub &lt;<mholub@tutanota.com>&gt;
 
 ## REPORTING BUGS
 


### PR DESCRIPTION
Initially I just wanted to add support for directly forking the current repo (say you clone something, notice something you want/need to change, and you don't want to use `git-fork $(git remote get-url origin)`, so I added the `-c` and `--current` flags for convenience, along with the help, token and target dir flags (because I'd rather keep my forks in *~/projects/forks*, than the subdirectory of the upstream repo, which I usually keep in *~/src*)