### PR TITLE
I have made two improvements to the git-bulk:

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -36,7 +36,7 @@ function addworkspace {
             source=$(realpath "$source" 2>/dev/null)
             if [ -f "$source" ]; then
                 pushd "$wsdir" > /dev/null
-                while IFS= read -r line || [[ -n $line ]]; do
+                while IFS= read -r line; do
                   if [ -n "$line" ]; then
                     git clone $line;
                   fi

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -36,8 +36,12 @@ function addworkspace {
             source=$(realpath "$source" 2>/dev/null)
             if [ -f "$source" ]; then
                 pushd "$wsdir" > /dev/null
-                while read -r line; do git clone "$line"; done < "$source";
-                popd > /dev/null
+                    while IFS= read -r line || [[ -n $line ]]; do
+                      if [ -n "$line" ]; then
+                        git clone $line;
+                      fi
+                    done < "$source"
+                    popd > /dev/null
             else
                 echo 1>&2 "format of URL or file unknown"
             fi

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -38,6 +38,7 @@ function addworkspace {
                 pushd "$wsdir" > /dev/null
                 while IFS= read -r line; do
                   if [ -n "$line" ]; then
+                    # the git clone command to take the complete line in the repository.txt as separate argument. This facilitated the cloning of the repository with a custom folder name.
                     git clone $line;
                   fi
                 done < "$source"

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -36,12 +36,12 @@ function addworkspace {
             source=$(realpath "$source" 2>/dev/null)
             if [ -f "$source" ]; then
                 pushd "$wsdir" > /dev/null
-                    while IFS= read -r line || [[ -n $line ]]; do
-                      if [ -n "$line" ]; then
-                        git clone $line;
-                      fi
-                    done < "$source"
-                    popd > /dev/null
+                while IFS= read -r line || [[ -n $line ]]; do
+                  if [ -n "$line" ]; then
+                    git clone $line;
+                  fi
+                done < "$source"
+                popd > /dev/null
             else
                 echo 1>&2 "format of URL or file unknown"
             fi


### PR DESCRIPTION
1. Previously, if the "repository.txt" file did not end with a blank line, the last entry in the list of repositories was omitted during the cloning process. This limitation has been addressed, and now all repositories listed in the file, including the last one, will be successfully cloned regardless of whether the file ends with a blank line or not.

2. There is support for cloning repositories into custom folder names when using the "repository.txt" file.

repositories\.txt
\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
https://host-of-git/repo-1.git Repo-1-Code
https://host-of-git/repo-2.git Repo-2-Code
https://host-of-git/repo-3.git Repo-3-Code