### PR TITLE
Filter authors by commit count

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -3,11 +3,7 @@
 
 cd "$(git root)" || { echo "Can't cd to top level directory";exit 1; }
 
-authors_file=
-_exit() {
-  rm -f "${authors_file}"
-}
-trap '_exit' EXIT
+AUTHOR_LISTING=
 
 SUMMARY_BY_LINE=
 DEDUP_BY_EMAIL=
@@ -147,7 +143,7 @@ format_authors() {
   # a rare unicode character is used as separator to avoid conflicting with
   # author name. However, Linux column utility will escape tab if separator
   # specified, so we do unesaping after it.
-  LC_ALL=C awk '
+  echo "${AUTHOR_LISTING:?}" | LC_ALL=C awk '
   BEGIN {
      commitLimit = strtonum('"${AUTHOR_COMMIT_LIMIT}"');
   }
@@ -211,7 +207,7 @@ uncommitted_changes_count() {
 }
 
 number_of_authors() {
-  wc -l ${authors_file:?}|cut -d$' ' -f1
+  echo "${AUTHOR_LISTING:?}" | wc -l
 }
 
 
@@ -228,10 +224,9 @@ print_summary_by_line() {
     echo
     echo " project     : $project"
     echo " lines       : $(line_count "${paths[@]}")"
-    authors_file=$(git_extra_mktemp)
-    lines "${paths[@]}" | sort | uniq -c | sort -rn >${authors_file}
+    AUTHOR_LISTING=$(lines "${paths[@]}" | sort | uniq -c | sort -rn)
     echo " authors     : $(number_of_authors)"
-    format_authors <${authors_file}
+    format_authors
   fi
 }
 
@@ -257,17 +252,16 @@ print_summary() {
       echo " files       : $(file_count)"
     fi
     echo " uncommitted : $(uncommitted_changes_count)"
-    authors_file=$(git_extra_mktemp)
     if [ -n "$DEDUP_BY_EMAIL" ]; then
       # the $commit can be empty
       # shellcheck disable=SC2086
-      git shortlog $MERGES_ARG -n -s -e $commit | dedup_by_email >${authors_file}
+      AUTHOR_LISTING=$(git shortlog $MERGES_ARG -n -s -e $commit | dedup_by_email)
     else
       # shellcheck disable=SC2086
-      git shortlog $MERGES_ARG -n -s $commit >${authors_file}
+      AUTHOR_LISTING=$(git shortlog $MERGES_ARG -n -s $commit)
     fi
     echo " authors     : $(number_of_authors)"
-    format_authors <${authors_file}
+    format_authors
   fi
 }
 

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -143,7 +143,7 @@ format_authors() {
   # a rare unicode character is used as separator to avoid conflicting with
   # author name. However, Linux column utility will escape tab if separator
   # specified, so we do unesaping after it.
-  echo "${AUTHOR_LISTING:?}" | LC_ALL=C awk '
+  echo "${1:?}" | LC_ALL=C awk '
   BEGIN {
      commitLimit = strtonum('"${AUTHOR_COMMIT_LIMIT}"');
   }
@@ -207,7 +207,7 @@ uncommitted_changes_count() {
 }
 
 number_of_authors() {
-  echo "${AUTHOR_LISTING:?}" | wc -l
+  echo "${1:?}" | wc -l
 }
 
 
@@ -224,9 +224,9 @@ print_summary_by_line() {
     echo
     echo " project     : $project"
     echo " lines       : $(line_count "${paths[@]}")"
-    AUTHOR_LISTING=$(lines "${paths[@]}" | sort | uniq -c | sort -rn)
-    echo " authors     : $(number_of_authors)"
-    format_authors
+    local AUTHOR_LISTING=$(lines "${paths[@]}" | sort | uniq -c | sort -rn)
+    echo " authors     : $(number_of_authors "${AUTHOR_LISTING}")"
+    format_authors "${AUTHOR_LISTING}"
   fi
 }
 
@@ -252,6 +252,7 @@ print_summary() {
       echo " files       : $(file_count)"
     fi
     echo " uncommitted : $(uncommitted_changes_count)"
+    local AUTHOR_LISTING
     if [ -n "$DEDUP_BY_EMAIL" ]; then
       # the $commit can be empty
       # shellcheck disable=SC2086
@@ -260,8 +261,8 @@ print_summary() {
       # shellcheck disable=SC2086
       AUTHOR_LISTING=$(git shortlog $MERGES_ARG -n -s $commit)
     fi
-    echo " authors     : $(number_of_authors)"
-    format_authors
+    echo " authors     : $(number_of_authors "${AUTHOR_LISTING}")"
+    format_authors "${AUTHOR_LISTING}"
   fi
 }
 

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -3,6 +3,12 @@
 
 cd "$(git root)" || { echo "Can't cd to top level directory";exit 1; }
 
+authors_file=
+_exit() {
+  rm -f "${authors_file}"
+}
+trap '_exit' EXIT
+
 SUMMARY_BY_LINE=
 DEDUP_BY_EMAIL=
 MERGES_ARG=
@@ -194,6 +200,10 @@ uncommitted_changes_count() {
   git status --porcelain | wc -l
 }
 
+number_of_authors() {
+  wc -l ${authors_file:?}|cut -d$' ' -f1
+}
+
 
 COLUMN_CMD_DELIMTER="¬" # Hopefully, this symbol is not used in branch names... I use it as a separator for columns
 SP="$COLUMN_CMD_DELIMTER|"
@@ -208,8 +218,10 @@ print_summary_by_line() {
     echo
     echo " project     : $project"
     echo " lines       : $(line_count "${paths[@]}")"
-    echo " authors     :"
-    lines "${paths[@]}" | sort | uniq -c | sort -rn | format_authors
+    authors_file=$(git_extra_mktemp)
+    lines "${paths[@]}" | sort | uniq -c | sort -rn >${authors_file}
+    echo " authors     : $(number_of_authors)"
+    format_authors <${authors_file}
   fi
 }
 
@@ -235,15 +247,17 @@ print_summary() {
       echo " files       : $(file_count)"
     fi
     echo " uncommitted : $(uncommitted_changes_count)"
-    echo " authors     : "
+    authors_file=$(git_extra_mktemp)
     if [ -n "$DEDUP_BY_EMAIL" ]; then
       # the $commit can be empty
       # shellcheck disable=SC2086
-      git shortlog $MERGES_ARG -n -s -e $commit | dedup_by_email | format_authors
+      git shortlog $MERGES_ARG -n -s -e $commit | dedup_by_email >${authors_file}
     else
       # shellcheck disable=SC2086
-      git shortlog $MERGES_ARG -n -s $commit | format_authors
+      git shortlog $MERGES_ARG -n -s $commit >${authors_file}
     fi
+    echo " authors     : $(number_of_authors)"
+    format_authors <${authors_file}
   fi
 }
 

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -13,6 +13,7 @@ SUMMARY_BY_LINE=
 DEDUP_BY_EMAIL=
 MERGES_ARG=
 OUTPUT_STYLE=
+AUTHOR_COMMIT_LIMIT=0
 for arg in "$@"; do
     case "$arg" in
         --line)
@@ -26,6 +27,10 @@ for arg in "$@"; do
             ;;
         --output-style)
             OUTPUT_STYLE="$2"
+            shift
+            ;;
+        --author-commit-limit)
+            AUTHOR_COMMIT_LIMIT="$2"
             shift
             ;;
         -*)
@@ -143,9 +148,14 @@ format_authors() {
   # author name. However, Linux column utility will escape tab if separator
   # specified, so we do unesaping after it.
   LC_ALL=C awk '
+  BEGIN {
+     commitLimit = strtonum('"${AUTHOR_COMMIT_LIMIT}"');
+  }
   { args[NR] = $0; sum += $0 }
   END {
     for (i = 1; i <= NR; ++i) {
+      if (strtonum(args[i]) < commitLimit)
+         break;
       printf "%s♪%2.1f%%\n", args[i], 100 * args[i] / sum
     }
   }

--- a/man/git-summary.1
+++ b/man/git-summary.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "GIT\-SUMMARY" "1" "June 2023" "" "Git Extras"
+.TH "GIT\-SUMMARY" "1" "July 2023" "" "Git Extras"
 .SH "NAME"
 \fBgit\-summary\fR \- Show repository summary
 .SH "SYNOPSIS"
@@ -63,7 +63,7 @@ active on   : 93 days
 commits     : 1893
 files       : 111
 uncommitted : 3
-authors     :
+authors     : 18
  1285 visionmedia
   478 Tj Holowaychuk
    48 Aaron Heckmann
@@ -99,7 +99,7 @@ $ git summary \-\-line
 
 project  : git\-extras
 lines    : 26820
-authors  :
+authors  : 206
   \|\.\|\.\|\.
 .fi
 .IP "" 0
@@ -111,7 +111,7 @@ $ git summary \-\-line bin/
 
 project  : git\-extras
 lines    : 4420
-authors  :
+authors  : 141
   \|\.\|\.\|\.
 .fi
 .IP "" 0

--- a/man/git-summary.1
+++ b/man/git-summary.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBgit\-summary\fR \- Show repository summary
 .SH "SYNOPSIS"
-\fBgit\-summary\fR [\-\-dedup\-by\-email] [\-\-no\-merges] [<committish>]
+\fBgit\-summary\fR [\-\-dedup\-by\-email] [\-\-no\-merges] [\-\-author\-commit\-limit <count>] [<committish>]
 .P
 \fBgit\-summary\fR \-\-line [<path>]
 .SH "DESCRIPTION"
@@ -37,6 +37,10 @@ $ git summary \-\-dedup\-by\-email
 \-\-no\-merges
 .P
 Exclude merge commits\.
+.P
+\-\-author\-commit\-limit <count>
+.P
+Omit authors with less than <count> authored commits from author listing\. Defaults to zero\.
 .P
 \-\-line
 .P

--- a/man/git-summary.html
+++ b/man/git-summary.html
@@ -147,7 +147,7 @@ active on   : 93 days
 commits     : 1893
 files       : 111
 uncommitted : 3
-authors     :
+authors     : 18
  1285 visionmedia
   478 Tj Holowaychuk
    48 Aaron Heckmann
@@ -180,7 +180,7 @@ authors     :
 
 project  : git-extras
 lines    : 26820
-authors  :
+authors  : 206
   ...
 </code></pre>
 
@@ -190,7 +190,7 @@ authors  :
 
 project  : git-extras
 lines    : 4420
-authors  :
+authors  : 141
   ...
 </code></pre>
 
@@ -221,7 +221,7 @@ git-extras / age: 13 years / last active: 7 hours ago / active on 807 days / com
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>June 2023</li>
+    <li class='tc'>July 2023</li>
     <li class='tr'>git-summary(1)</li>
   </ol>
 

--- a/man/git-summary.html
+++ b/man/git-summary.html
@@ -77,7 +77,7 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-summary</code> [--dedup-by-email] [--no-merges] [&lt;committish&gt;]</p>
+<p><code>git-summary</code> [--dedup-by-email] [--no-merges] [--author-commit-limit &lt;count&gt;] [&lt;committish&gt;]</p>
 
 <p><code>git-summary</code> --line [&lt;path&gt;]</p>
 
@@ -113,6 +113,10 @@ $ git summary --dedup-by-email
 <p>--no-merges</p>
 
 <p>Exclude merge commits.</p>
+
+<p>--author-commit-limit &lt;count&gt;</p>
+
+<p>Omit authors with less than &lt;count&gt; authored commits from author listing. Defaults to zero.</p>
 
 <p>--line</p>
 

--- a/man/git-summary.md
+++ b/man/git-summary.md
@@ -3,7 +3,7 @@ git-summary(1) -- Show repository summary
 
 ## SYNOPSIS
 
-`git-summary` [--dedup-by-email] [--no-merges] [&lt;committish&gt;]
+`git-summary` [--dedup-by-email] [--no-merges] [--author-commit-limit &lt;count&gt;] [&lt;committish&gt;]
 
 `git-summary` --line [&lt;path&gt;]
 
@@ -38,6 +38,10 @@ Shows a summary of the repository or a path within it.
   --no-merges
 
   Exclude merge commits.
+
+  --author-commit-limit &lt;count&gt;
+
+  Omit authors with less than &lt;count&gt; authored commits from author listing. Defaults to zero.
 
   --line
 

--- a/man/git-summary.md
+++ b/man/git-summary.md
@@ -72,7 +72,7 @@ Shows a summary of the repository or a path within it.
     commits     : 1893
     files       : 111
     uncommitted : 3
-    authors     :
+    authors     : 18
      1285 visionmedia
       478 Tj Holowaychuk
        48 Aaron Heckmann
@@ -103,7 +103,7 @@ Shows a summary of the repository or a path within it.
 
     project  : git-extras
     lines    : 26820
-    authors  :
+    authors  : 206
       ...
 
   Filter with the path:
@@ -112,7 +112,7 @@ Shows a summary of the repository or a path within it.
 
     project  : git-extras
     lines    : 4420
-    authors  :
+    authors  : 141
       ...
 
   Tabular summary


### PR DESCRIPTION
In git summary

- Show the number of authors before listing them
- Added option --author-commit-limit to filter the list of authors

This gives better UX when running it on very large repos.