### PR TITLE
fix: add missing quote in git-extras-completion.zsh

### DIFF
--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -102,7 +102,7 @@ __gitex_author_names() {
 }
 
 __gitex_author_emails2() {
-    echo "$g s
+    echo "$g s"
     # read -Ac words
     # read -cn cword
 


### PR DESCRIPTION
Broken in #1074