### PR TITLE
ci: Use Go v1.20 for running `editorconfig-checker`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,12 @@ jobs:
         # reviewing!
       - name: Check out code.
         uses: actions/checkout@v3
+      - uses: 'actions/setup-go@v4'
+        with:
+          go-version: '1.20'
       - name: 'Check EditorConfig Lint'
         run: |
-          sudo apt install -y jq golang
+          sudo apt install -y jq
           go install 'github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest'
 
           readarray -t changed_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.added_modified }}')"


### PR DESCRIPTION
The tool requires a more recent version of Go, as per [this commit](https://github.com/editorconfig/editorconfig-core-go/commit/73c37c49c298ff5a605f2a07228f3f99acf3d2d8)

Closes #1085