### PR TITLE
Fix: harden utimes, use single quotes

### DIFF
--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -34,10 +34,6 @@ fi
 if bash --help 2>&1 | grep -q -- '--norc'; then
   bash_opts="${bash_opts} --norc"
 fi
-# sanity check, not required:
-if bash --help 2>&1 | grep -q -- '--posix'; then
-  bash_opts="${bash_opts} --posix"
-fi
 
 status_opts=
 whatchanged_opts=

--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2312,SC2248,SC2250,SC2064,SC2086
+# shellcheck disable=SC2312
 #
 # Change files modification time to their last commit date
 #
@@ -39,9 +39,6 @@ if bash --help 2>&1 | grep -q -- '--posix'; then
   bash_opts="${bash_opts} --posix"
 fi
 
-prefix="$(git rev-parse --show-prefix) "
-strip="${#prefix}"
-
 status_opts=
 whatchanged_opts=
 if git status --help 2>&1 | grep -q -- "--no-renames"; then
@@ -55,23 +52,30 @@ if git status --help 2>&1 | grep -q -- "--ignored"; then
   status_opts="${status_opts} --ignored=no"
 fi
 
+prefix="$(git rev-parse --show-prefix) "
+strip="${#prefix}"
+
 tmpfile=$(mktemp)
+# shellcheck disable=SC2064
 trap "rm -f '${tmpfile}'" 0
 
 # prefix is stripped:
+# shellcheck disable=SC2086
 git --no-pager status --porcelain --short ${status_opts} . |
   cut -c 4- >"${tmpfile}"
 
 # prefix is not stripped:
+# shellcheck disable=SC1003,SC2086,SC2248
 git --no-pager whatchanged ${whatchanged_opts} --format='%ct' . |
-  awk $awk_flags \
+  awk ${awk_flags} \
     -F'\t' \
     -v date_flags="${date_flags}" \
     -v op="${op}" \
     -v stat_flags="${stat_flags}" \
     -v strip="${strip}" \
     -v tmpfile="${tmpfile}" \
-    'BEGIN {
+    '\
+BEGIN {
   seen[""]=1
   print "t() {"
   print " test -e \"$2\" || return 0"
@@ -108,7 +112,7 @@ FILENAME==tmpfile {
   }
   seen[$2]=1
   # escape quotes:
-  gsub(/"/, "\\\"", $2)
-  printf("t %s \"%s\"\n", ct, $2)
+  gsub(/'\''/, "'\''\\'\'''\''", $2)
+  printf("t %s '\''%s'\''\n", ct, $2)
 }
 ' "${tmpfile}" - | BASH_ENV='' bash ${bash_opts} /dev/stdin

--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -70,8 +70,7 @@ git --no-pager whatchanged ${whatchanged_opts} --format='%ct' . |
     -v stat_flags="${stat_flags}" \
     -v strip="${strip}" \
     -v tmpfile="${tmpfile}" \
-    '\
-BEGIN {
+    'BEGIN {
   seen[""]=1
   print "t() {"
   print " test -e \"$2\" || return 0"

--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -107,7 +107,12 @@ FILENAME==tmpfile {
     next
   }
   seen[$2]=1
-  # escape quotes:
+  # remove double quotes and backslashes that git adds:
+  if (substr($2, 1, 1) == "\"" && substr($2, length($2), 1) == "\"") {
+    $2 = substr($2, 2, length($2) - 2)
+    gsub(/\\/, "", $2)
+  }
+  # escape single quotes:
   gsub(/'\''/, "'\''\\'\'''\''", $2)
   printf("t %s '\''%s'\''\n", ct, $2)
 }

--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -80,7 +80,7 @@ BEGIN {
     print " echo \"+ touch -h -d@$1 $2\""
     print " touch -h -d@$1 \"$2\""
   } else {
-    printf(" t=$(date %s$1 \"+%Y%m%d%H%M.%S\")\n", date_flags)
+    print " t=$(date -r$1 \"+%Y%m%d%H%M.%S\")"
     print " echo \"+ touch -h -t $t $2\""
     print " touch -h -t $t \"$2\""
   }


### PR DESCRIPTION
**EDIT**: I replaced the double quotes with single quotes to stop bash from processing shell meta-characters, such as `$` and \` in filenames.

**EDIT**: I also removed passing `--posix` to bash, as bash may whine about non-posix code in the user's existing environment. For example, if a user has a function name with a colon in it, bash will complain:
`bash: line 4: BASH_FUNC_lib:funcname%%': not a valid identifier`
when `--posix` is passed.

Now works on repos with tricky filenames:
```
$ git-utimes 
+ touch -h -d@1699829680 "`whoami`"
+ touch -h -d@1699829626 "$USER"
+ touch -h -d@1699829626 $USER
+ touch -h -d@1699829337 "'quotes-and-single-quotes'"
+ touch -h -d@1699829337 '"single-quotes-and-quotes"'
+ touch -h -d@1699829337 a-quote-and-single-quote"'
+ touch -h -d@1699829337 a-single-quote-and-quote'"
+ touch -h -d@1699828363 `whoami`
+ touch -h -d@1699828215 file-in-root-dir.symlink
+ touch -h -d@1699828203 root-dir.symlink
+ touch -h -d@1699828037 file-in-dir.symlink
+ touch -h -d@1699827933  a-space-at-the-beginning
+ touch -h -d@1699720671 "2-quotes"
+ touch -h -d@1699720671 '2-single-quotes'
+ touch -h -d@1699720671 2-quotes-together""
+ touch -h -d@1699720671 2-single-quotes-together''
+ touch -h -d@1699720671 a-single-quote'
+ touch -h -d@1675048802 a-colon:
+ touch -h -d@1627401449 a-backslash\
+ touch -h -d@1627399934 CON.txt
+ touch -h -d@1627399912 CON
+ touch -h -d@1626789305 a-space
+ touch -h -d@1626789277 a-dot.
+ touch -h -d@1626789249 a-less-than<
+ touch -h -d@1626789223 a-greater-than>
+ touch -h -d@1626789196 a-pipe|
+ touch -h -d@1626789165 a-question-mark?
+ touch -h -d@1626789137 a-asterisk*
+ touch -h -d@1626789107 a-quote"
+ touch -h -d@1619369190 executable.sh
+ touch -h -d@1608172298 executable.cmd
+ touch -h -d@1607657114 CASESENSITIVE.TXT
+ touch -h -d@1607656480 CaseSensitive.txt
+ touch -h -d@1607656480 casesensitive.txt
+ touch -h -d@1607651028 file☠☡☢☣.txt
+ touch -h -d@1607650377 dir.symlink
+ touch -h -d@1607650377 dir/file
+ touch -h -d@1607650181 file
+ touch -h -d@1607650181 file.symlink
+ touch -h -d@1607649124 .gitignore
+ touch -h -d@1607649124 LICENSE
+ touch -h -d@1607649124 README.md
$ ls -al
total 108
drwxr-xr-x  4 ross ross 4096 Nov 12 15:06  .
drwxr-xr-x 30 ross ross 4096 Nov 12 15:06  ..
drwxr-xr-x  2 ross ross 4096 Nov 12 15:06  dir
lrwxrwxrwx  1 ross ross    3 Dec 10  2020  dir.symlink -> dir
lrwxrwxrwx  1 ross ross    6 Nov 12 14:30  root-dir.symlink -> dir/..
-rw-r--r--  1 ross ross    0 Nov 12 14:53 '"$USER"'
-rw-r--r--  1 ross ross    0 Nov 12 14:53 '$USER'
-rw-r--r--  1 ross ross    0 Nov 11 08:37 '"2-quotes"'
-rw-r--r--  1 ross ross    0 Nov 11 08:37 '2-quotes-together""'
-rw-r--r--  1 ross ross    0 Nov 11 08:37 "'2-single-quotes'"
-rw-r--r--  1 ross ross    0 Nov 11 08:37 "2-single-quotes-together''"
-rw-r--r--  1 ross ross   12 Jul 20  2021 'a-asterisk*'
-rw-r--r--  1 ross ross   13 Nov 12 15:06 'a-backslash\'
-rw-r--r--  1 ross ross    9 Jan 29  2023  a-colon:
-rw-r--r--  1 ross ross    1 Jul 20  2021  a-dot.
-rw-r--r--  1 ross ross   16 Jul 20  2021 'a-greater-than>'
-rw-r--r--  1 ross ross   13 Jul 20  2021 'a-less-than<'
-rw-r--r--  1 ross ross    8 Jul 20  2021 'a-pipe|'
-rw-r--r--  1 ross ross   17 Jul 20  2021 'a-question-mark?'
-rw-r--r--  1 ross ross    9 Jul 20  2021 'a-quote"'
-rw-r--r--  1 ross ross    0 Nov 12 14:48 'a-quote-and-single-quote"'\'''
-rw-r--r--  1 ross ross    0 Nov 11 08:37 "a-single-quote'"
-rw-r--r--  1 ross ross    0 Nov 12 14:48 'a-single-quote-and-quote'\''"'
-rw-r--r--  1 ross ross    9 Jul 20  2021  a-space
-rw-r--r--  1 ross ross    0 Nov 12 14:25 ' a-space-at-the-beginning'
-rw-r--r--  1 ross ross   18 Dec 10  2020  casesensitive.txt
-rw-r--r--  1 ross ross   18 Dec 10  2020  CaseSensitive.txt
-rw-r--r--  1 ross ross   19 Dec 10  2020  CASESENSITIVE.TXT
-rw-r--r--  1 ross ross    4 Jul 27  2021  CON
-rw-r--r--  1 ross ross    8 Jul 27  2021  CON.txt
-rwxr-xr-x  1 ross ross   20 Dec 16  2020  executable.cmd
-rwxr-xr-x  1 ross ross   42 Apr 25  2021  executable.sh
-rw-r--r--  1 ross ross    5 Dec 10  2020  file
lrwxrwxrwx  1 ross ross    8 Nov 12 14:27  file-in-dir.symlink -> dir/file
lrwxrwxrwx  1 ross ross   11 Nov 12 14:30  file-in-root-dir.symlink -> dir/../file
lrwxrwxrwx  1 ross ross    4 Dec 10  2020  file.symlink -> file
-rw-r--r--  1 ross ross   21 Dec 10  2020  file☠☡☢☣.txt
-rw-r--r--  1 ross ross 1799 Dec 10  2020  .gitignore
-rw-r--r--  1 ross ross 1070 Dec 10  2020  LICENSE
-rw-r--r--  1 ross ross    0 Nov 12 14:48 '"'\''quotes-and-single-quotes'\''"'
-rw-r--r--  1 ross ross   54 Dec 10  2020  README.md
-rw-r--r--  1 ross ross    0 Nov 12 14:48 ''\''"single-quotes-and-quotes"'\'''
-rw-r--r--  1 ross ross    0 Nov 12 14:54 '"`whoami`"'
-rw-r--r--  1 ross ross    9 Nov 12 14:32 '`whoami`'
```