### PR TITLE
maintenance: Add my name to maintainers category in AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,13 +11,13 @@ Maintainers
 - Nimit Kalra <me@nimit.io>
 - Nicolai Skogheim <nicolai.skogheim@gmail.com>
 - spacewander <spacewanderlzx@gmail.com>
+- Edwin Kofler <edwin@kofler.dev>
 
 Patches and Suggestions
 ```````````````````````
 - Jonhnny Weslley
 - Tobias Fendin
 - LeeW
-- Edwin Kofler
 - timfeirg
 - Niklas Schlimm
 - nickl-


### PR DESCRIPTION
As requested, I am adding my name to the maintainers category in the AUTHORS file. :)
I wasn't sure if it was alphabetical or chronological order, but it seemed chronological.