### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         # a force push will cause the action above to fail. Don't do force push when people are
         # reviewing!
       - name: Check out code.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: 'actions/setup-go@v4'
         with:
           go-version: '1.20'
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: spell check
         run: |
           pip install codespell==2.2
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out code.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Linux Install
         if: matrix.platform == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
Resolve deprecation warnings, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

For an example of the warnings see any recent ci run, for example https://github.com/tj/git-extras/actions/runs/8826310597