### PR TITLE
fix: git-summary commit count

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -77,7 +77,7 @@ active_days() {
 #
 commit_count() {
   # shellcheck disable=SC2086
-  git rev-list --count "$commit"
+  git rev-list $MERGES_ARG --count "$commit"
 }
 
 #

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -77,7 +77,7 @@ active_days() {
 #
 commit_count() {
   # shellcheck disable=SC2086
-  git log $MERGES_ARG --oneline "$commit" | wc -l | tr -d ' '
+  git rev-list --count "$commit"
 }
 
 #


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
If the user has set log.showSignature = ture in gitconfig file, then the `commits` field in the git-summary result is wrong. Replace `git log` with `git rev-list` to avoid the problem, `git rev-list` isn't affected by log.* config parameters, which is also the same as `git-count` command.

---
The result of `git log --oneline HEAD` is as follows, then `| wc -l | tr -d ' '` get wrong count.
```
e34dea9 (origin/main, origin/HEAD) gpg: Signature made Fri May  3 15:52:28 2024 JST
gpg:                using RSA key B5690EEEBB952194
gpg: Can't check signature: No public key
tests: update dependencies (#1142)
3bac05e gpg: Signature made Mon Apr 29 10:59:50 2024 JST
gpg:                using RSA key B5690EEEBB952194
gpg: Can't check signature: No public key
chore(deps): bump masesgroup/retrieve-changed-files from 2 to 3 (#1144)
...
```