### PR TITLE
Add pathspec support in `git-missing`

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -1296,12 +1296,18 @@ Creates a zip archive of the current git repository. The name of the archive wil
 
 ## git missing
 
-Print out which commits are on one branch or the other but not both.
+Print out which commits are on one branch or the other but not both. Optionally, you can specify a path to limit the comparison to a specific directory or file.
 
 ```bash
 $ git missing master
 < d14b8f0 only on current checked out branch
 > 97ef387 only on master
+```
+
+```bash
+$ git missing master -- src/
+< ed52989 only on current branch, in src/ directory
+> 7988c4b only on master, in src/ directory
 ```
 
 ## git lock

--- a/bin/git-missing
+++ b/bin/git-missing
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 usage() {
-    echo 1>&2 "usage: git missing [<first branch>] <second branch> [<git log options>]"
+    echo 1>&2 "usage: git missing [<first branch>] <second branch> [<git log options>] [[--] <path>...]"
 }
 
 if [ "${#}" -lt 1 ]
@@ -12,9 +12,20 @@ fi
 
 declare -a git_log_args=()
 declare -a branches=()
+declare pathspec=""
+declare parse_path=false
+
 for arg in "$@" ; do
 
+    if [[ $parse_path == true ]]; then
+        pathspec="$*"
+        break
+    fi
+
     case "$arg" in
+        --)
+            parse_path=true
+            ;;
         --*)
             git_log_args+=( "$arg" )
             ;;
@@ -22,6 +33,7 @@ for arg in "$@" ; do
             branches+=( "$arg" )
             ;;
     esac
+    shift
 done
 
 firstbranch=
@@ -38,4 +50,8 @@ else
     exit 1
 fi
 
-git log "${git_log_args[@]}" "$firstbranch"..."$secondbranch" --format="%m %h %s" --left-right
+if [[ -n "$pathspec" ]]; then
+    git log "${git_log_args[@]}" "$firstbranch"..."$secondbranch" --format="%m %h %s" --left-right -- "$pathspec"
+else
+    git log "${git_log_args[@]}" "$firstbranch"..."$secondbranch" --format="%m %h %s" --left-right
+fi

--- a/bin/git-missing
+++ b/bin/git-missing
@@ -12,13 +12,13 @@ fi
 
 declare -a git_log_args=()
 declare -a branches=()
-declare pathspec=""
+declare -a pathspec=()
 declare parse_path=false
 
 for arg in "$@" ; do
 
     if [[ $parse_path == true ]]; then
-        pathspec="$*"
+        pathspec+=("$@")
         break
     fi
 
@@ -33,7 +33,6 @@ for arg in "$@" ; do
             branches+=( "$arg" )
             ;;
     esac
-    shift
 done
 
 firstbranch=
@@ -50,8 +49,4 @@ else
     exit 1
 fi
 
-if [[ -n "$pathspec" ]]; then
-    git log "${git_log_args[@]}" "$firstbranch"..."$secondbranch" --format="%m %h %s" --left-right -- "$pathspec"
-else
-    git log "${git_log_args[@]}" "$firstbranch"..."$secondbranch" --format="%m %h %s" --left-right
-fi
+git log "${git_log_args[@]}" "$firstbranch"..."$secondbranch" --format="%m %h %s" --left-right -- "${pathspec[@]}"

--- a/man/git-missing.1
+++ b/man/git-missing.1
@@ -10,7 +10,7 @@
 \fBgit\-missing\fR [<first branch>] <second branch> [<git log options>] [[\-\-] <path>\.\.\.]
 .
 .SH "DESCRIPTION"
-Shows commits that are in either of two branches but not both\. Useful for seeing what would come across in a merge or push\.O ptionally, the comparison can be limited to specific paths\.
+Shows commits that are in either of two branches but not both\. Useful for seeing what would come across in a merge or push\. Optionally, the comparison can be limited to specific paths\.
 .
 .SH "OPTIONS"
 [<first branch>]

--- a/man/git-missing.1
+++ b/man/git-missing.1
@@ -1,16 +1,16 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-MISSING" "1" "April 2018" "" "Git Extras"
+.TH "GIT\-MISSING" "1" "August 2024" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-missing\fR \- Show commits missing from another branch
 .
 .SH "SYNOPSIS"
-\fBgit\-missing\fR [<first branch>] <second branch> [<git log options>]
+\fBgit\-missing\fR [<first branch>] <second branch> [<git log options>] [[\-\-] <path>\.\.\.]
 .
 .SH "DESCRIPTION"
-Shows commits that are in either of two branches but not both\. Useful for seeing what would come across in a merge or push\.
+Shows commits that are in either of two branches but not both\. Useful for seeing what would come across in a merge or push\.O ptionally, the comparison can be limited to specific paths\.
 .
 .SH "OPTIONS"
 [<first branch>]
@@ -29,6 +29,12 @@ Second branch to compare\.
 .
 .P
 Any flags that should be passed to \'git log\', such as \-\-no\-merges\.
+.
+.P
+[[\-\-] <path>\.\.\.]
+.
+.P
+Optional path specifications (pathspec) to limit the comparison to specific files or directories\. For more details about the pathspec syntax, see the pathspec entry in gitglossary[7] \fIhttps://git\-scm\.com/docs/gitglossary#Documentation/gitglossary\.txt\-aiddefpathspecapathspec\fR\.
 .
 .SH "EXAMPLES"
 Show commits on either my current branch or master but not both:
@@ -60,11 +66,26 @@ $ git missing foo bar
 .
 .IP "" 0
 .
+.P
+Show commits on either my current branch or master but not both, limited to the src/ directory:
+.
+.IP "" 4
+.
+.nf
+
+$ git missing master \-\- src/
+< ed52989 only on current checked out branch, in src/ directory
+> 7988c4b only on master, in src/ directory
+.
+.fi
+.
+.IP "" 0
+.
 .SH "AUTHOR"
 Written by Nate Jones <\fInate@endot\.org\fR>
 .
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/tj/git\-extras/issues\fR>
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
 .
 .SH "SEE ALSO"
-<\fIhttp://github\.com/tj/git\-extras\fR>
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-missing.html
+++ b/man/git-missing.html
@@ -76,12 +76,13 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-missing</code> [&lt;first branch&gt;] &lt;second branch&gt; [&lt;git log options&gt;]</p>
+<p><code>git-missing</code> [&lt;first branch&gt;] &lt;second branch&gt; [&lt;git log options&gt;] [[--] &lt;path&gt;...]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Shows commits that are in either of two branches but not both.  Useful for
-  seeing what would come across in a merge or push.</p>
+<p>  Shows commits that are in either of two branches but not both. Useful for
+  seeing what would come across in a merge or push.O ptionally, the comparison
+  can be limited to specific paths.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
@@ -96,6 +97,12 @@
 <p>  [&lt;git log options&gt;]</p>
 
 <p>  Any flags that should be passed to 'git log', such as --no-merges.</p>
+
+<p>  [[--] &lt;path&gt;...]</p>
+
+<p>  Optional path specifications (pathspec) to limit the comparison to specific
+  files or directories. For more details about the pathspec syntax, see the
+  pathspec entry in <a href="https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec">gitglossary[7]</a>.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -113,22 +120,30 @@
 > f38797e only on bar
 </code></pre>
 
+<p>  Show commits on either my current branch or master but not both, limited to the
+  src/ directory:</p>
+
+<pre><code>$ git missing master -- src/
+&lt; ed52989 only on current checked out branch, in src/ directory
+&gt; 7988c4b only on master, in src/ directory
+</code></pre>
+
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Nate Jones &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#116;&#111;&#58;&#x6e;&#x61;&#116;&#101;&#x40;&#101;&#110;&#x64;&#111;&#x74;&#46;&#111;&#x72;&#x67;" data-bare-link="true">&#x6e;&#97;&#116;&#x65;&#64;&#101;&#x6e;&#100;&#111;&#116;&#x2e;&#x6f;&#x72;&#x67;</a>&gt;</p>
+<p>Written by Nate Jones &lt;<a href="&#109;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#x6e;&#97;&#116;&#101;&#x40;&#x65;&#110;&#100;&#x6f;&#116;&#46;&#x6f;&#x72;&#x67;" data-bare-link="true">&#x6e;&#97;&#x74;&#x65;&#x40;&#101;&#110;&#100;&#111;&#x74;&#46;&#x6f;&#x72;&#x67;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
-<p>&lt;<a href="http://github.com/tj/git-extras/issues" data-bare-link="true">http://github.com/tj/git-extras/issues</a>&gt;</p>
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p>&lt;<a href="http://github.com/tj/git-extras" data-bare-link="true">http://github.com/tj/git-extras</a>&gt;</p>
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2018</li>
+    <li class='tc'>August 2024</li>
     <li class='tr'>git-missing(1)</li>
   </ol>
 

--- a/man/git-missing.html
+++ b/man/git-missing.html
@@ -81,7 +81,7 @@
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
 <p>  Shows commits that are in either of two branches but not both. Useful for
-  seeing what would come across in a merge or push.O ptionally, the comparison
+  seeing what would come across in a merge or push. Optionally, the comparison
   can be limited to specific paths.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
@@ -130,7 +130,7 @@
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Nate Jones &lt;<a href="&#109;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#x6e;&#97;&#116;&#101;&#x40;&#x65;&#110;&#100;&#x6f;&#116;&#46;&#x6f;&#x72;&#x67;" data-bare-link="true">&#x6e;&#97;&#x74;&#x65;&#x40;&#101;&#110;&#100;&#111;&#x74;&#46;&#x6f;&#x72;&#x67;</a>&gt;</p>
+<p>Written by Nate Jones &lt;<a href="&#x6d;&#x61;&#105;&#x6c;&#116;&#111;&#x3a;&#110;&#x61;&#x74;&#101;&#64;&#x65;&#110;&#x64;&#x6f;&#116;&#46;&#x6f;&#x72;&#103;" data-bare-link="true">&#x6e;&#97;&#116;&#101;&#x40;&#101;&#110;&#100;&#111;&#116;&#46;&#x6f;&#114;&#x67;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 

--- a/man/git-missing.md
+++ b/man/git-missing.md
@@ -3,12 +3,13 @@ git-missing(1) -- Show commits missing from another branch
 
 ## SYNOPSIS
 
-`git-missing` [&lt;first branch&gt;] &lt;second branch&gt; [&lt;git log options&gt;]
+`git-missing` [&lt;first branch&gt;] &lt;second branch&gt; [&lt;git log options&gt;] [[--] &lt;path&gt;...]
 
 ## DESCRIPTION
 
-  Shows commits that are in either of two branches but not both.  Useful for
-  seeing what would come across in a merge or push.
+  Shows commits that are in either of two branches but not both. Useful for
+  seeing what would come across in a merge or push.O ptionally, the comparison
+  can be limited to specific paths.
 
 ## OPTIONS
 
@@ -24,6 +25,12 @@ git-missing(1) -- Show commits missing from another branch
 
   Any flags that should be passed to 'git log', such as --no-merges.
 
+  [[--] &lt;path&gt;...]
+
+  Optional path specifications (pathspec) to limit the comparison to specific
+  files or directories. For more details about the pathspec syntax, see the
+  pathspec entry in [gitglossary[7]](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec).
+
 ## EXAMPLES
 
   Show commits on either my current branch or master but not both:
@@ -37,6 +44,13 @@ git-missing(1) -- Show commits missing from another branch
     $ git missing foo bar
     < b8f0d14 only on foo
     > f38797e only on bar
+
+  Show commits on either my current branch or master but not both, limited to the
+  src/ directory:
+
+    $ git missing master -- src/
+    < ed52989 only on current checked out branch, in src/ directory
+    > 7988c4b only on master, in src/ directory
 
 ## AUTHOR
 

--- a/man/git-missing.md
+++ b/man/git-missing.md
@@ -8,7 +8,7 @@ git-missing(1) -- Show commits missing from another branch
 ## DESCRIPTION
 
   Shows commits that are in either of two branches but not both. Useful for
-  seeing what would come across in a merge or push.O ptionally, the comparison
+  seeing what would come across in a merge or push. Optionally, the comparison
   can be limited to specific paths.
 
 ## OPTIONS


### PR DESCRIPTION
This PR add pathspec support for the `git-missing` command. Users can now limit the commit difference to specific directories or files. Addition is particularly useful for big repositories where users are not concerned with other directories outside their usual workspace.

Pathspec is optional, command will work as usual for users not using it.

## New Usage

```bash
git missing [<first branch>] <second branch> [<git log options>] [[--] <path>...]
```

## Example

Compare differences between the current branch and master, limited to the `src/` directory:

```bash
$ git missing master -- src/
< a1b2c3d feat: Add new component in src/
> d4e5f6g fix: Update existing module in src/
```