### PR TITLE
Update git-repl.md: typo: "let's" for "lets"

### DIFF
--- a/man/git-repl.1
+++ b/man/git-repl.1
@@ -10,7 +10,7 @@
 \fBgit\-repl\fR
 .
 .SH "DESCRIPTION"
-Git read\-eval\-print\-loop\. Let\'s you run \fBgit\fR commands without typing \'git\'\.
+Git read\-eval\-print\-loop\. Lets you run \fBgit\fR commands without typing \'git\'\.
 .
 .P
 Commands can be prefixed with an exclamation mark (!) to be interpreted as a regular command\.

--- a/man/git-repl.html
+++ b/man/git-repl.html
@@ -80,7 +80,7 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Git read-eval-print-loop. Let's you run <code>git</code> commands without typing 'git'.</p>
+<p>  Git read-eval-print-loop. Lets you run <code>git</code> commands without typing 'git'.</p>
 
 <p>  Commands can be prefixed with an exclamation mark (!) to be interpreted as
   a regular command.</p>

--- a/man/git-repl.md
+++ b/man/git-repl.md
@@ -7,7 +7,7 @@ git-repl(1) -- git read-eval-print-loop
 
 ## DESCRIPTION
 
-  Git read-eval-print-loop. Let's you run `git` commands without typing 'git'.
+  Git read-eval-print-loop. Lets you run `git` commands without typing 'git'.
 
   Commands can be prefixed with an exclamation mark (!) to be interpreted as
   a regular command.


### PR DESCRIPTION
"Lets" is a verb in the present tense third person, while "let's" is short for "let us"

<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
