### PR TITLE
Enhance `git-repl`

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -375,7 +375,7 @@ Git read-eval-print-loop. Lets you run `git` commands without typing 'git'.
 Commands can be prefixed with an exclamation mark (!) to be interpreted as
 a regular command.
 
-Type `exit` or `quit` to end the repl session.
+Type `exit`, `quit`, or `q` to end the repl session.
 
 Any arguments to git repl will be taken as the first command to execute in
 the repl.

--- a/Commands.md
+++ b/Commands.md
@@ -382,10 +382,9 @@ the repl.
 
 ```bash
 $ git repl
-git version 2.9.2
-git-extras version 3.0.0
-type 'ls' to ls files below current directory,
-'!command' to execute any command or just 'subcommand' to execute any git subcommand
+git version 2.34.1
+git-extras version 7.3.0
+Type 'ls' to ls files below current directory; '!command' to execute any command or just 'subcommand' to execute any git subcommand; 'quit', 'exit', 'q', ^D, or ^C to exit the git repl.
 
 git (master)> ls-files
 History.md

--- a/Commands.md
+++ b/Commands.md
@@ -377,6 +377,9 @@ a regular command.
 
 Type `exit` or `quit` to end the repl session.
 
+Any arguments to git repl will be taken as the first command to execute in
+the repl.
+
 ```bash
 $ git repl
 git version 2.9.2

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -10,9 +10,9 @@ while true; do
 
   # Prompt
   if test -n "$cur"; then
-    prompt="git ($cur)> "
+    prompt="$exit_status|git ($cur)> "
   else
-    prompt="git> "
+    prompt="$exit_status|git> "
   fi
 
   # Readline
@@ -32,11 +32,14 @@ while true; do
   esac
 
   if [[ $cmd == !*  ]]; then
-    eval ${cmd:1} 
+    eval ${cmd:1}
+    exit_status=$?
   elif [[ $cmd == git* ]]; then
     eval $cmd
+    exit_status=$?
   else
     eval git "$cmd"
+    exit_status=$?
   fi
 done
 

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -45,14 +45,12 @@ while true; do
 
   if [[ $cmd == !*  ]]; then
     eval ${cmd:1}
-    exit_status=$?
   elif [[ $cmd == git* ]]; then
     eval $cmd
-    exit_status=$?
   else
     eval git "$cmd"
-    exit_status=$?
   fi
+  exit_status=$?
 done
 
 echo

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -17,7 +17,7 @@ while true; do
 
   # Use arguments as a command if any are provided
   if [ $# -ne 0 ]; then
-    cmd="$@"
+    cmd=$*
     set --
   else
     # Readline

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -25,7 +25,7 @@ while true; do
   if [ $# -ne 0 ]; then
     cmd=$*
     set --
-    echo "$prompt" "$cmd" # iI is as though you had entered a command.
+    echo "$prompt" "$cmd" # It is as though you had entered a command.
   else
     # Readline
     read -e -r -p "$prompt" cmd

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -10,10 +10,16 @@ while true; do
 
   # Prompt
   if test -n "$cur"; then
-    prompt="$exit_status|git ($cur)> "
+    cur_string=" ($cur)"
   else
-    prompt="$exit_status|git> "
+    cur_string=""
   fi
+  if test -n "$exit_status" && test "$exit_status" -ne 0; then
+    es_string=$' \e[31m['"$exit_status"$']\e[0m'
+  else
+    es_string=""
+  fi
+  prompt="git$cur_string$es_string> "
 
   # Use arguments as a command if any are provided
   if [ $# -ne 0 ]; then

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -2,7 +2,7 @@
 
 git version
 echo "git-extras version ""$(git-extras -v)"
-echo "type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', 'x', ^D, or ^C to exit the git repl."
+echo "type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', ^D, or ^C to exit the git repl."
 
 while true; do
   # Current branch
@@ -33,7 +33,7 @@ while true; do
   case $cmd in
     ls) cmd=ls-files;;
     "") continue;;
-    quit|exit|q|x) break;;
+    quit|exit|q) break;;
   esac
 
   if [[ $cmd == !*  ]]; then

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -15,11 +15,16 @@ while true; do
     prompt="$exit_status|git> "
   fi
 
-  # Readline
-  read -e -r -p "$prompt" cmd
-
-  # EOF
-  test $? -ne 0 && break
+  # Use arguments as a command if any are provided
+  if [ $# -eq 0 ]; then
+    cmd="$@"
+    set --
+  else
+    # Readline
+    read -e -r -p "$prompt" cmd
+    # check for EOF, and end the program if so (handles ^D)
+    test $? -ne 0 && break
+  fi
 
   # History
   history -s "$cmd"

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -2,7 +2,7 @@
 
 git version
 echo "git-extras version ""$(git-extras -v)"
-echo "type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand"
+echo "type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', 'x', ^D, or ^C to exit the git repl."
 
 while true; do
   # Current branch
@@ -28,7 +28,7 @@ while true; do
   case $cmd in
     ls) cmd=ls-files;;
     "") continue;;
-    quit|exit) break;;
+    quit|exit|q|x) break;;
   esac
 
   if [[ $cmd == !*  ]]; then

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -2,7 +2,7 @@
 
 git version
 echo "git-extras version ""$(git-extras -v)"
-echo "type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', ^D, or ^C to exit the git repl."
+echo "Type 'ls' to ls files below current directory; '!command' to execute any command or just 'subcommand' to execute any git subcommand; 'quit', 'exit', 'q', ^D, or ^C to exit the git repl."
 
 while true; do
   # Current branch

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -16,7 +16,7 @@ while true; do
   fi
 
   # Use arguments as a command if any are provided
-  if [ $# -eq 0 ]; then
+  if [ $# -ne 0 ]; then
     cmd="$@"
     set --
   else

--- a/bin/git-repl
+++ b/bin/git-repl
@@ -21,14 +21,15 @@ while true; do
   fi
   prompt="git$cur_string$es_string> "
 
-  # Use arguments as a command if any are provided
+  # Use arguments as a command if any are provided.
   if [ $# -ne 0 ]; then
     cmd=$*
     set --
+    echo "$prompt" "$cmd" # iI is as though you had entered a command.
   else
     # Readline
     read -e -r -p "$prompt" cmd
-    # check for EOF, and end the program if so (handles ^D)
+    # Check for EOF, and end the program if so (handles ^D).
     test $? -ne 0 && break
   fi
 

--- a/man/git-repl.1
+++ b/man/git-repl.1
@@ -14,7 +14,7 @@ Commands can be prefixed with an exclamation mark (!) to be interpreted as a reg
 .P
 Any arguments to git repl will be taken collectively as the first command to execute in the repl\.
 .P
-Type \fBexit\fR, \fBquit\fR, or \fBq\fR to end the repl session\. Ctrl\-D an Ctrl\-C will also work\.
+Type \fBexit\fR, \fBquit\fR, or \fBq\fR to end the repl session\. Ctrl\-D and Ctrl\-C will also work\.
 .SH "COMMANDS"
 <command>
 .P

--- a/man/git-repl.1
+++ b/man/git-repl.1
@@ -1,56 +1,42 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-REPL" "1" "October 2017" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-REPL" "1" "September 2024" "" "Git Extras"
 .SH "NAME"
 \fBgit\-repl\fR \- git read\-eval\-print\-loop
-.
 .SH "SYNOPSIS"
 \fBgit\-repl\fR
-.
+.P
+\fBgit\-repl\fR [command\|\.\|\.\|\.]
 .SH "DESCRIPTION"
-Git read\-eval\-print\-loop\. Lets you run \fBgit\fR commands without typing \'git\'\.
-.
+Git read\-eval\-print\-loop\. Lets you run \fBgit\fR commands without typing 'git'\.
 .P
-Commands can be prefixed with an exclamation mark (!) to be interpreted as a regular command\.
-.
+Commands can be prefixed with an exclamation mark (!) to be interpreted as a regular shell command\.
 .P
-Type \fBexit\fR or \fBquit\fR to end the repl session\.
-.
+Any arguments to git repl will be taken collectively as the first command to execute in the repl\.
+.P
+Type \fBexit\fR, \fBquit\fR, or \fBq\fR to end the repl session\. Ctrl\-D an Ctrl\-C will also work\.
 .SH "COMMANDS"
 <command>
-.
 .P
 Interpreted as \fBgit <command>\fR\.
-.
 .P
 !<command>
-.
 .P
 Interpreted as \fB<command>\fR (not through \fBgit\fR)\.
-.
 .P
 ls
-.
 .P
-Equivalent of \'git ls\-files\'\.
-.
+Equivalent of 'git ls\-files'\.
 .P
-exit|quit
-.
+exit|quit|q
 .P
 Ends the repl session\.
-.
 .SH "EXAMPLES"
-.
 .nf
-
 $ git repl
-git version 2\.9\.2
-git\-extras version 3\.0\.0
-type \'ls\' to ls files below current directory,
-\'!command\' to execute any command or just \'subcommand\' to execute any git subcommand
+git version 2\.34\.1
+git\-extras version 7\.3\.0
+Type 'ls' to ls files below current directory; '!command' to execute any command or just 'subcommand' to execute any git subcommand; 'quit', 'exit', 'q', ^D, or ^C to exit the git repl\.
 
 git (master)> ls\-files
 History\.md
@@ -67,14 +53,10 @@ git (master)> !echo Straight from the shell!
 Straight from the shell!
 
 git (master)> quit
-.
 .fi
-.
 .SH "AUTHOR"
-Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>
-.
+Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>\. Updated by Wyatt S Carpenter to add display of the previous command's exit status, 'q', and the ability to pass in the initial command as arguments\.
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>
-.
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-repl.html
+++ b/man/git-repl.html
@@ -91,7 +91,7 @@
 <p>Any arguments to git repl will be taken collectively as the first command
   to execute in the repl.</p>
 
-<p>Type <code>exit</code>, <code>quit</code>, or <code>q</code> to end the repl session. Ctrl-D an Ctrl-C
+<p>Type <code>exit</code>, <code>quit</code>, or <code>q</code> to end the repl session. Ctrl-D and Ctrl-C
   will also work.</p>
 
 <h2 id="COMMANDS">COMMANDS</h2>

--- a/man/git-repl.html
+++ b/man/git-repl.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-repl(1) - git read-eval-print-loop</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,49 +69,55 @@
     <li class='tr'>git-repl(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-repl</code> - <span class="man-whatis">git read-eval-print-loop</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p><code>git-repl</code></p>
 
+<p><code>git-repl</code> [command...]</p>
+
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>  Git read-eval-print-loop. Lets you run <code>git</code> commands without typing 'git'.</p>
+<p>Git read-eval-print-loop. Lets you run <code>git</code> commands without typing 'git'.</p>
 
-<p>  Commands can be prefixed with an exclamation mark (!) to be interpreted as
-  a regular command.</p>
+<p>Commands can be prefixed with an exclamation mark (!) to be interpreted as
+  a regular shell command.</p>
 
-<p>  Type <code>exit</code> or <code>quit</code> to end the repl session.</p>
+<p>Any arguments to git repl will be taken collectively as the first command
+  to execute in the repl.</p>
+
+<p>Type <code>exit</code>, <code>quit</code>, or <code>q</code> to end the repl session. Ctrl-D an Ctrl-C
+  will also work.</p>
 
 <h2 id="COMMANDS">COMMANDS</h2>
 
-<p>  &lt;command&gt;</p>
+<p>&lt;command&gt;</p>
 
-<p>  Interpreted as <code>git &lt;command></code>.</p>
+<p>Interpreted as <code>git &lt;command&gt;</code>.</p>
 
-<p>  !&lt;command&gt;</p>
+<p>!&lt;command&gt;</p>
 
-<p>  Interpreted as <code>&lt;command></code> (not through <code>git</code>).</p>
+<p>Interpreted as <code>&lt;command&gt;</code> (not through <code>git</code>).</p>
 
-<p>  ls</p>
+<p>ls</p>
 
-<p>  Equivalent of 'git ls-files'.</p>
+<p>Equivalent of 'git ls-files'.</p>
 
-<p>  exit|quit</p>
+<p>exit|quit|q</p>
 
-<p>  Ends the repl session.</p>
+<p>Ends the repl session.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <pre><code>$ git repl
-git version 2.9.2
-git-extras version 3.0.0
-type 'ls' to ls files below current directory,
-'!command' to execute any command or just 'subcommand' to execute any git subcommand
+git version 2.34.1
+git-extras version 7.3.0
+Type 'ls' to ls files below current directory; '!command' to execute any command or just 'subcommand' to execute any git subcommand; 'quit', 'exit', 'q', ^D, or ^C to exit the git repl.
 
 git (master)&gt; ls-files
 History.md
@@ -132,7 +138,7 @@ git (master)&gt; quit
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#x61;&#105;&#108;&#x74;&#111;&#58;&#x74;&#106;&#64;&#118;&#105;&#x73;&#105;&#111;&#x6e;&#45;&#x6d;&#x65;&#x64;&#105;&#x61;&#x2e;&#x63;&#97;" data-bare-link="true">&#x74;&#x6a;&#x40;&#118;&#x69;&#115;&#x69;&#111;&#110;&#45;&#x6d;&#101;&#100;&#x69;&#97;&#46;&#x63;&#x61;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="mailto:tj@vision-media.ca" data-bare-link="true">tj@vision-media.ca</a>&gt;. Updated by Wyatt S Carpenter to add display of the previous command's exit status, 'q', and the ability to pass in the initial command as arguments.</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -142,10 +148,9 @@ git (master)&gt; quit
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>September 2024</li>
     <li class='tr'>git-repl(1)</li>
   </ol>
 

--- a/man/git-repl.md
+++ b/man/git-repl.md
@@ -5,12 +5,17 @@ git-repl(1) -- git read-eval-print-loop
 
 `git-repl`
 
+`git-repl` [command...]
+
 ## DESCRIPTION
 
   Git read-eval-print-loop. Lets you run `git` commands without typing 'git'.
 
   Commands can be prefixed with an exclamation mark (!) to be interpreted as
-  a regular command.
+  a regular shell command.
+
+  Any arguments to git repl will be taken collectively as the first command
+  to execute in the repl.
 
   Type `exit`, `quit`, or `q` to end the repl session. Ctrl-D an Ctrl-C
   will also work.
@@ -29,7 +34,7 @@ git-repl(1) -- git read-eval-print-loop
 
   Equivalent of 'git ls-files'.
 
-  exit|quit|q
+  exit\|quit\|q
 
   Ends the repl session.
 
@@ -39,7 +44,7 @@ git-repl(1) -- git read-eval-print-loop
     $ git repl
     git version 2.34.1
     git-extras version 7.3.0
-    type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', ^D, or ^C to exit the git repl.
+    Type 'ls' to ls files below current directory; '!command' to execute any command or just 'subcommand' to execute any git subcommand; 'quit', 'exit', 'q', ^D, or ^C to exit the git repl.
 
     git (master)> ls-files
     History.md
@@ -59,7 +64,7 @@ git-repl(1) -- git read-eval-print-loop
 
 ## AUTHOR
 
-Written by Tj Holowaychuk &lt;<tj@vision-media.ca>&gt;
+Written by Tj Holowaychuk &lt;<tj@vision-media.ca>&gt;. Updated by Wyatt S Carpenter to add display of the previous command's exit status, 'q', and the ability to pass in the initial command as arguments.
 
 ## REPORTING BUGS
 

--- a/man/git-repl.md
+++ b/man/git-repl.md
@@ -17,7 +17,7 @@ git-repl(1) -- git read-eval-print-loop
   Any arguments to git repl will be taken collectively as the first command
   to execute in the repl.
 
-  Type `exit`, `quit`, or `q` to end the repl session. Ctrl-D an Ctrl-C
+  Type `exit`, `quit`, or `q` to end the repl session. Ctrl-D and Ctrl-C
   will also work.
 
 ## COMMANDS

--- a/man/git-repl.md
+++ b/man/git-repl.md
@@ -12,7 +12,8 @@ git-repl(1) -- git read-eval-print-loop
   Commands can be prefixed with an exclamation mark (!) to be interpreted as
   a regular command.
 
-  Type `exit` or `quit` to end the repl session.
+  Type `exit`, `quit`, `x`, or `q` to end the repl session. Ctrl-D an Ctrl-C
+  will also work.
 
 ## COMMANDS
 
@@ -28,7 +29,7 @@ git-repl(1) -- git read-eval-print-loop
 
   Equivalent of 'git ls-files'.
 
-  exit|quit
+  exit|quit|x|q
 
   Ends the repl session.
 
@@ -36,10 +37,9 @@ git-repl(1) -- git read-eval-print-loop
 ## EXAMPLES
 
     $ git repl
-    git version 2.9.2
-    git-extras version 3.0.0
-    type 'ls' to ls files below current directory,
-    '!command' to execute any command or just 'subcommand' to execute any git subcommand
+    git version 2.34.1
+    git-extras version 7.3.0
+    type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', 'x', ^D, or ^C to exit the git repl.
 
     git (master)> ls-files
     History.md

--- a/man/git-repl.md
+++ b/man/git-repl.md
@@ -12,7 +12,7 @@ git-repl(1) -- git read-eval-print-loop
   Commands can be prefixed with an exclamation mark (!) to be interpreted as
   a regular command.
 
-  Type `exit`, `quit`, `x`, or `q` to end the repl session. Ctrl-D an Ctrl-C
+  Type `exit`, `quit`, or `q` to end the repl session. Ctrl-D an Ctrl-C
   will also work.
 
 ## COMMANDS
@@ -29,7 +29,7 @@ git-repl(1) -- git read-eval-print-loop
 
   Equivalent of 'git ls-files'.
 
-  exit|quit|x|q
+  exit|quit|q
 
   Ends the repl session.
 
@@ -39,7 +39,7 @@ git-repl(1) -- git read-eval-print-loop
     $ git repl
     git version 2.34.1
     git-extras version 7.3.0
-    type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', 'x', ^D, or ^C to exit the git repl.
+    type 'ls' to ls files below current directory, '!command' to execute any command or just 'subcommand' to execute any git subcommand. 'quit', 'exit', 'q', ^D, or ^C to exit the git repl.
 
     git (master)> ls-files
     History.md


### PR DESCRIPTION
This makes 3 improvements to git-repl:

- It displays  the exit code of the previous command

- The message at the beginning now tells you how to quit. q ~and x~ have been added as commands that quit

- If git-repl is given arguments, it will be evaluate them as the first command.

Closes #1159