### PR TITLE
Update git-alias.md: add brs to prevent incorrect line behavior

### DIFF
--- a/man/git-alias.1
+++ b/man/git-alias.1
@@ -1,10 +1,27 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "GIT\-ALIAS" "1" "September 2023" "" "Git Extras"
+.TH "GIT\-ALIAS" "1" "September 2024" "" "Git Extras"
 .SH "NAME"
 \fBgit\-alias\fR \- Define, search and show aliases
 .SH "SYNOPSIS"
-\fBgit\-alias\fR \fBgit\-alias\fR <search\-pattern> \fBgit\-alias\fR <alias\-name> <command> \fBgit\-alias\fR [\-\-global] \fBgit\-alias\fR [\-\-local] \fBgit\-alias\fR [\-\-global] <search\-pattern> \fBgit\-alias\fR [\-\-local] <search\-pattern> \fBgit\-alias\fR [\-\-global] <alias\-name> <command> \fBgit\-alias\fR [\-\-local] <alias\-name> <command>
+\fBgit\-alias\fR
+.br
+\fBgit\-alias\fR <search\-pattern>
+.br
+\fBgit\-alias\fR <alias\-name> <command>
+.br
+\fBgit\-alias\fR [\-\-global]
+.br
+\fBgit\-alias\fR [\-\-local]
+.br
+\fBgit\-alias\fR [\-\-global] <search\-pattern>
+.br
+\fBgit\-alias\fR [\-\-local] <search\-pattern>
+.br
+\fBgit\-alias\fR [\-\-global] <alias\-name> <command>
+.br
+\fBgit\-alias\fR [\-\-local] <alias\-name> <command>
+.br
 .SH "DESCRIPTION"
 List all aliases, show one alias, or set one (global or local) alias\.
 .SH "OPTIONS"
@@ -50,8 +67,8 @@ $ git alias
 s = status
 amend = commit \-\-amend
 rank = shortlog \-sn \-\-no\-merges
-whatis = show \-s \-\-pretty=\'tformat:%h (%s, %ad)\' \-\-date=short
-whois = !sh \-c \'git log \-i \-1 \-\-pretty="format:%an <%ae>
+whatis = show \-s \-\-pretty='tformat:%h (%s, %ad)' \-\-date=short
+whois = !sh \-c 'git log \-i \-1 \-\-pretty="format:%an <%ae>
 .fi
 .IP "" 0
 .SH "AUTHOR"

--- a/man/git-alias.html
+++ b/man/git-alias.html
@@ -77,15 +77,15 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-alias</code>
-<code>git-alias</code> &lt;search-pattern&gt;
-<code>git-alias</code> &lt;alias-name&gt; &lt;command&gt;
-<code>git-alias</code> [--global]
-<code>git-alias</code> [--local]
-<code>git-alias</code> [--global] &lt;search-pattern&gt;
-<code>git-alias</code> [--local] &lt;search-pattern&gt;
-<code>git-alias</code> [--global] &lt;alias-name&gt; &lt;command&gt;
-<code>git-alias</code> [--local] &lt;alias-name&gt; &lt;command&gt;</p>
+<p><code>git-alias</code> <br>
+<code>git-alias</code> &lt;search-pattern&gt; <br>
+<code>git-alias</code> &lt;alias-name&gt; &lt;command&gt; <br>
+<code>git-alias</code> [--global] <br>
+<code>git-alias</code> [--local] <br>
+<code>git-alias</code> [--global] &lt;search-pattern&gt; <br>
+<code>git-alias</code> [--local] &lt;search-pattern&gt; <br>
+<code>git-alias</code> [--global] &lt;alias-name&gt; &lt;command&gt; <br>
+<code>git-alias</code> [--local] &lt;alias-name&gt; &lt;command&gt; <br></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -150,7 +150,7 @@ whois = !sh -c 'git log -i -1 --pretty="format:%an &lt;%ae&gt;
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>September 2023</li>
+    <li class='tc'>September 2024</li>
     <li class='tr'>git-alias(1)</li>
   </ol>
 

--- a/man/git-alias.md
+++ b/man/git-alias.md
@@ -3,15 +3,15 @@ git-alias(1) -- Define, search and show aliases
 
 ## SYNOPSIS
 
-`git-alias`
-`git-alias` &lt;search-pattern&gt;
-`git-alias` &lt;alias-name&gt; &lt;command&gt;
-`git-alias` [--global]
-`git-alias` [--local]
-`git-alias` [--global] &lt;search-pattern&gt;
-`git-alias` [--local] &lt;search-pattern&gt;
-`git-alias` [--global] &lt;alias-name&gt; &lt;command&gt;
-`git-alias` [--local] &lt;alias-name&gt; &lt;command&gt;
+`git-alias` <br>
+`git-alias` &lt;search-pattern&gt; <br>
+`git-alias` &lt;alias-name&gt; &lt;command&gt; <br>
+`git-alias` [--global] <br>
+`git-alias` [--local] <br>
+`git-alias` [--global] &lt;search-pattern&gt; <br>
+`git-alias` [--local] &lt;search-pattern&gt; <br>
+`git-alias` [--global] &lt;alias-name&gt; &lt;command&gt; <br>
+`git-alias` [--local] &lt;alias-name&gt; &lt;command&gt; <br>
 
 ## DESCRIPTION
 

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -79,7 +79,7 @@ git-extras(1) -- Awesome GIT utilities
    - **git-rebase-patch(1)** Rebases a patch
    - **git-release(1)** Commit, tag and push changes to the repository
    - **git-rename-branch(1)** rename local branch and push to remote
-   - **git-rename-file(1)** CRename a file or directory and ensure Git recognizes the change, regardless of filesystem case-sensitivity.
+   - **git-rename-file(1)** Rename a file or directory and ensure Git recognizes the change, regardless of filesystem case-sensitivity.
    - **git-rename-remote(1)** Rename a remote
    - **git-rename-tag(1)** Rename a tag
    - **git-repl(1)** git read-eval-print-loop


### PR DESCRIPTION
Currently these all appear on one line, in the rendered markdown viewer and also in the man page. That isn't what's wanted. What's wanted is for each to be on its own line, which this change implements, using the strategy I found in git-bulk.

Running `make` to generate the new documentation files apparently fixed a typo in another file, as well.
