### PR TITLE
Use filetimes in check_integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get install -y bsdmainutils
       - name: Script
         run: |
-          ./check_integrity.sh $(find bin | cut -b 5- | xargs)
+          ./check_integrity.sh
       - name: Brew release
         if: matrix.platform == 'macos-latest'
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Let's say you wish to add a new command. Assuming your new command is named `foo
 5. (Optional) Update `./etc/bash_completion.sh`.
 6. (Optional) Update `./etc/git-extras.fish`.
 7. (Optional) Add a test under `./tests`.
-8. Run `./check_integrity.sh foo` to check if all done.
+8. Run `./check_integrity.sh foo` to check if all done. (You may also run `./check_integrity.sh` to check all commands.)
 
 You are welcome to open up an issue to discuss new commands or features before opening a pull request.
 

--- a/check_integrity.sh
+++ b/check_integrity.sh
@@ -82,12 +82,9 @@ check() {
     check_completion "$1"
 }
 
-usage() {
-    echo >&2 "Usage: ./check_integrity.sh <command-name> [<command-name2> ...]"
-    exit 0
-}
+test $# == 0 && set -- $(find bin | cut -b 5- | xargs)
 
-test $# == 0 && usage
+./bin/git-utimes --newer
 
 for name in "$@"; do
     name=${name#git-}

--- a/check_integrity.sh
+++ b/check_integrity.sh
@@ -47,6 +47,11 @@ check_documentation() {
         err "Create man/$cmd.1 and man/$cmd.html via $(make_doc "$1")"
     fi
 
+    if [ "man/$cmd.md" -nt "man/$cmd.1" ] || [ "man/$cmd.md" -nt "man/$cmd.html" ]
+    then
+      err "man/$cmd.md, man/$cmd.1, and man/$cmd.html all exist, but man/$cmd.md is newer. You should rm man/$cmd.1 man/$cmd.html and then create man/$cmd.1 and man/$cmd.html via $(make_doc "$1")"
+    fi
+
     check_git_extras_cmd_list "$@"
     check_man_page_index "$@"
 }

--- a/man/git-extras.1
+++ b/man/git-extras.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "GIT\-EXTRAS" "1" "May 2023" "" "Git Extras"
+.TH "GIT\-EXTRAS" "1" "September 2024" "" "Git Extras"
 .SH "NAME"
 \fBgit\-extras\fR \- Awesome GIT utilities
 .SH "SYNOPSIS"
@@ -126,6 +126,8 @@ Change the default branch to \fB$BRANCH\fR\. If \fBgit\-extras\.default\-branch\
 \fBgit\-release(1)\fR Commit, tag and push changes to the repository
 .IP "\[ci]" 4
 \fBgit\-rename\-branch(1)\fR rename local branch and push to remote
+.IP "\[ci]" 4
+\fBgit\-rename\-file(1)\fR Rename a file or directory and ensure Git recognizes the change, regardless of filesystem case\-sensitivity\.
 .IP "\[ci]" 4
 \fBgit\-rename\-remote(1)\fR Rename a remote
 .IP "\[ci]" 4

--- a/man/git-extras.html
+++ b/man/git-extras.html
@@ -209,6 +209,8 @@
   <li>
 <strong><a class="man-ref" href="git-rename-branch.html">git-rename-branch<span class="s">(1)</span></a></strong> rename local branch and push to remote</li>
   <li>
+<strong><a class="man-ref" href="git-rename-file.html">git-rename-file<span class="s">(1)</span></a></strong> Rename a file or directory and ensure Git recognizes the change, regardless of filesystem case-sensitivity.</li>
+  <li>
 <strong><a class="man-ref" href="git-rename-remote.html">git-rename-remote<span class="s">(1)</span></a></strong> Rename a remote</li>
   <li>
 <strong><a class="man-ref" href="git-rename-tag.html">git-rename-tag<span class="s">(1)</span></a></strong> Rename a tag</li>
@@ -265,7 +267,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>May 2023</li>
+    <li class='tc'>September 2024</li>
     <li class='tr'>git-extras(1)</li>
   </ol>
 

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -79,7 +79,7 @@ git-extras(1) -- Awesome GIT utilities
    - **git-rebase-patch(1)** Rebases a patch
    - **git-release(1)** Commit, tag and push changes to the repository
    - **git-rename-branch(1)** rename local branch and push to remote
-   - **git-rename-file(1)** CRename a file or directory and ensure Git recognizes the change, regardless of filesystem case-sensitivity.
+   - **git-rename-file(1)** Rename a file or directory and ensure Git recognizes the change, regardless of filesystem case-sensitivity.
    - **git-rename-remote(1)** Rename a remote
    - **git-rename-tag(1)** Rename a tag
    - **git-repl(1)** git read-eval-print-loop


### PR DESCRIPTION
Before this change, if you changed the documentation in foo.md, check_integrity.sh would not warn you that you had to update foo.html and foo.1. This is bad, because then the derived files could get out of sync. (It also was not checked by the CI, which also just uses check_integrity.sh)

This PR makes 4 changes:

1. check_integrity.sh now tells if you've updated the md since you updated the html and man page, using the file modified times. I got this idea from the tool we use to generate the files, which also checks that, which is why you have to touch the md if you want it to generate fresh derived files.
2. To facilitate the first point, check_integrity.sh now calls our very own `git-utimes --newer` in order to give the files the correct file modified times. This always runs, which has the downside of taking a couple more seconds. It has the upside of being simple, and always correct. (Well, I guess it could technically become incorrect if you deliberately touched the md to before the previous git commit date for it. But you can only cheat yourself that way.)
3. If check_integrity.sh is given no arguments, it checks the integrity of all the commands. This uses the `$(find bin | cut -b 5- | xargs)` method of getting all the command names, that was previously in the CI.
4. Update git-extras, which was out of sync.