### PR TITLE
Update some documentation that was out of sync

### DIFF
--- a/check_integrity.sh
+++ b/check_integrity.sh
@@ -6,7 +6,7 @@ err() {
 }
 
 make_doc() {
-    echo "'touch man/git-$1.md && make man/git-$1.{1,html}'"
+    echo "touch man/git-$1.md && make man/git-$1.{1,html}"
 }
 
 check_bash_script() {
@@ -49,7 +49,7 @@ check_documentation() {
 
     if [ "man/$cmd.md" -nt "man/$cmd.1" ] || [ "man/$cmd.md" -nt "man/$cmd.html" ]
     then
-      err "man/$cmd.md, man/$cmd.1, and man/$cmd.html all exist, but man/$cmd.md is newer. You should rm man/$cmd.1 man/$cmd.html and then create man/$cmd.1 and man/$cmd.html via $(make_doc "$1")"
+      err "man/$cmd.md, man/$cmd.1, and man/$cmd.html all exist, but man/$cmd.md is newer. You should rm man/$cmd.{1,html} && $(make_doc "$1")"
     fi
 
     check_git_extras_cmd_list "$@"

--- a/man/git-reauthor.1
+++ b/man/git-reauthor.1
@@ -1,198 +1,121 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-REAUTHOR" "1" "October 2017" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-REAUTHOR" "1" "September 2019" "" "Git Extras"
 .SH "NAME"
-\fBgit\-reauthor\fR \- Rewrite history to change author\'s identity
-.
+\fBgit\-reauthor\fR \- Rewrite history to change author's identity
 .SH "SYNOPSIS"
 \fBgit reauthor [<options>]\fR
-.
 .SH "DESCRIPTION"
 Lets you replace the author and/or committer identities in commits and tags\.
-.
 .P
 The command goes through all existing commits and tags in all local branches to selectively modify the identities present in those objects\. All the other information such as dates, messages,\.\. are preserved\.
-.
 .P
 You can rewrite all the identities in the commits and tags objects by using the \-\-all flag, or only replace the identities whose email matches the value of the \-\-old\-email option\. It is also possible to limit the rewrite to a certain type of identity: the author or the committer identity\. By default, both of them are affected\.
-.
 .br
 For each of those identities to update, the command will replace the name and/or email with the new correct values as defined via the options\. If the new identity name to set is not defined, the current one will be kept (and vice\-versa with the email)\.
-.
 .P
 \fBWARNING!\fR This command rewrites history and as a result you will not able to push your branch to the remote without using the \-\-force option\.
-.
 .br
 See more information with \fBgit help filter\-branch\fR\.
-.
 .SH "OPTIONS"
 \-a, \-\-all
-.
 .IP "" 4
-.
 .nf
-
 Rewrite ALL identities in commits and tags\.
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \-c, \-\-use\-config
-.
 .IP "" 4
-.
 .nf
-
 Define correct values from user Git config
 Values of \-\-correct\-email and \-\-correct\-name options take precedence over the ones from the config if specified as well
-.
 .fi
-.
 .IP "" 0
-.
 .P
 \-e, \-\-correct\-email <\fIemail\fR>
-.
 .IP "" 4
-.
 .nf
-
 Define the correct email to set
-Empty email \'\' is allowed
-.
+Empty email '' is allowed
 .fi
-.
 .IP "" 0
-.
 .P
 \-n, \-\-correct\-name <\fIname\fR>
-.
 .IP "" 4
-.
 .nf
-
 Define the correct name to set
-Empty name \'\' is not allowed
-.
+Empty name '' is not allowed
 .fi
-.
 .IP "" 0
-.
 .P
 \-o, \-\-old\-email <\fIemail\fR>
-.
 .IP "" 4
-.
 .nf
-
 Rewrite identities matching old email in commits and tags
-Empty email \'\' is allowed
-.
+Empty email '' is allowed
 .fi
-.
 .IP "" 0
-.
 .P
 \-t, \-\-type <\fIid\fR>
-.
 .IP "" 4
-.
 .nf
-
 Define the type of identities affected by the rewrite
 Possible type identifiers are: author, committer, both (default)
-.
 .fi
-.
 .IP "" 0
-.
 .SH "EXAMPLES"
 Replace the personal email and name of Jack to his work ones
-.
 .IP "" 4
-.
 .nf
-
-$ git reauthor \-\-old\-email jack@perso\.me \-\-correct\-email jack@work\.com \-\-correct\-name \'Jack Foobar\'
-.
+$ git reauthor \-\-old\-email jack@perso\.me \-\-correct\-email jack@work\.com \-\-correct\-name 'Jack Foobar'
 .fi
-.
 .IP "" 0
-.
 .P
 Replace the email and name of Jack to the ones defined in the Git config
-.
 .IP "" 4
-.
 .nf
-
 $ git reauthor \-\-old\-email jack@perso\.me \-\-use\-config
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Replace only the email of Jack (keep the name already used)
-.
 .IP "" 4
-.
 .nf
-
 $ git reauthor \-\-old\-email jack@perso \-\-correct\-email jack@perso\.me
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Change only the committer email of Jack (keep the author email already used)
-.
 .IP "" 4
-.
 .nf
-
 $ git reauthor \-\-old\-email jack@perso\.me \-\-correct\-email jack@work\.com \-\-type committer
-.
 .fi
-.
 .IP "" 0
-.
 .P
-Set Jack\'s identity as the only one of the whole repository
-.
+Change only the name and keep email to merge one user with multiple pseudonyms\.
 .IP "" 4
-.
 .nf
-
-$ git reauthor \-\-all \-\-correct\-email jack@perso\.me \-\-correct\-name Jack
-.
+$ git reauthor \-\-old\-email jack@perso\.me \-\-correct\-name Jack
 .fi
-.
 .IP "" 0
-.
+.P
+Set Jack's identity as the only one of the whole repository
+.IP "" 4
+.nf
+$ git reauthor \-\-all \-\-correct\-email jack@perso\.me \-\-correct\-name Jack
+.fi
+.IP "" 0
 .P
 Set Jack as the only committer of the whole repository (keeps authors)
-.
 .IP "" 4
-.
 .nf
-
 $ git reauthor \-\-all \-\-correct\-email jack@perso\.me \-\-correct\-name Jack \-\-type committer
-.
 .fi
-.
 .IP "" 0
-.
 .SH "AUTHOR"
 Written by Damien Tardy\-Panis <\fIdamien@tardypad\.me\fR>
-.
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/tj/git\-extras/issues\fR>
-.
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-reauthor.html
+++ b/man/git-reauthor.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-reauthor(1) - Rewrite history to change author&#39;s identity</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,14 +69,15 @@
     <li class='tr'>git-reauthor(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-reauthor</code> - <span class="man-whatis">Rewrite history to change author's identity</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git reauthor [&lt;options>]</code></p>
+<p><code>git reauthor [&lt;options&gt;]</code></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -84,44 +85,44 @@
 
 <p>The command goes through all existing commits and tags in all local branches to selectively modify the identities present in those objects. All the other information such as dates, messages,.. are preserved.</p>
 
-<p>You can rewrite all the identities in the commits and tags objects by using the --all flag, or only replace the identities whose email matches the value of the --old-email option. It is also possible to limit the rewrite to a certain type of identity: the author or the committer identity. By default, both of them are affected.<br />
+<p>You can rewrite all the identities in the commits and tags objects by using the --all flag, or only replace the identities whose email matches the value of the --old-email option. It is also possible to limit the rewrite to a certain type of identity: the author or the committer identity. By default, both of them are affected.<br>
 For each of those identities to update, the command will replace the name and/or email with the new correct values as defined via the options. If the new identity name to set is not defined, the current one will be kept (and vice-versa with the email).</p>
 
-<p><code>WARNING!</code> This command rewrites history and as a result you will not able to push your branch to the remote without using the --force option.<br />
+<p><code>WARNING!</code> This command rewrites history and as a result you will not able to push your branch to the remote without using the --force option.<br>
 See more information with <code>git help filter-branch</code>.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  -a, --all</p>
+<p>-a, --all</p>
 
 <pre><code>Rewrite ALL identities in commits and tags.
 </code></pre>
 
-<p>  -c, --use-config</p>
+<p>-c, --use-config</p>
 
 <pre><code>Define correct values from user Git config
 Values of --correct-email and --correct-name options take precedence over the ones from the config if specified as well
 </code></pre>
 
-<p>  -e, --correct-email &lt;<var>email</var>&gt;</p>
+<p>-e, --correct-email &lt;<var>email</var>&gt;</p>
 
 <pre><code>Define the correct email to set
 Empty email '' is allowed
 </code></pre>
 
-<p>  -n, --correct-name &lt;<var>name</var>&gt;</p>
+<p>-n, --correct-name &lt;<var>name</var>&gt;</p>
 
 <pre><code>Define the correct name to set
 Empty name '' is not allowed
 </code></pre>
 
-<p>  -o, --old-email &lt;<var>email</var>&gt;</p>
+<p>-o, --old-email &lt;<var>email</var>&gt;</p>
 
 <pre><code>Rewrite identities matching old email in commits and tags
 Empty email '' is allowed
 </code></pre>
 
-<p>  -t, --type &lt;<var>id</var>&gt;</p>
+<p>-t, --type &lt;<var>id</var>&gt;</p>
 
 <pre><code>Define the type of identities affected by the rewrite
 Possible type identifiers are: author, committer, both (default)
@@ -149,6 +150,11 @@ Possible type identifiers are: author, committer, both (default)
 <pre><code>$ git reauthor --old-email jack@perso.me --correct-email jack@work.com --type committer
 </code></pre>
 
+<p>Change only the name and keep email to merge one user with multiple pseudonyms.</p>
+
+<pre><code>$ git reauthor --old-email jack@perso.me --correct-name Jack
+</code></pre>
+
 <p>Set Jack's identity as the only one of the whole repository</p>
 
 <pre><code>$ git reauthor --all --correct-email jack@perso.me --correct-name Jack
@@ -161,20 +167,19 @@ Possible type identifiers are: author, committer, both (default)
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Damien Tardy-Panis &lt;<a href="&#x6d;&#97;&#x69;&#108;&#x74;&#111;&#58;&#100;&#x61;&#109;&#x69;&#x65;&#x6e;&#x40;&#116;&#x61;&#114;&#100;&#x79;&#x70;&#97;&#x64;&#x2e;&#x6d;&#x65;" data-bare-link="true">&#100;&#x61;&#109;&#105;&#x65;&#x6e;&#x40;&#x74;&#97;&#x72;&#100;&#121;&#x70;&#97;&#x64;&#46;&#109;&#101;</a>&gt;</p>
+<p>Written by Damien Tardy-Panis &lt;<a href="mailto:damien@tardypad.me" data-bare-link="true">damien@tardypad.me</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
-<p>&lt;<a href="http://github.com/tj/git-extras/issues" data-bare-link="true">http://github.com/tj/git-extras/issues</a>&gt;</p>
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>September 2019</li>
     <li class='tr'>git-reauthor(1)</li>
   </ol>
 

--- a/man/git-rebase-patch.1
+++ b/man/git-rebase-patch.1
@@ -1,63 +1,41 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-REBASE\-PATCH" "1" "October 2017" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-REBASE\-PATCH" "1" "September 2019" "" "Git Extras"
 .SH "NAME"
 \fBgit\-rebase\-patch\fR \- Rebases a patch
-.
 .SH "SYNOPSIS"
 \fBgit\-rebase\-patch\fR <patch\-file>
-.
 .SH "DESCRIPTION"
-Given you have a patch that doesn\'t apply to the current HEAD, but you know it applied to some commit in the past, \fBgit\-rebase\-patch\fR will help you find that commit and do a rebase\.
-.
+Given you have a patch that doesn't apply to the current HEAD, but you know it applied to some commit in the past, \fBgit\-rebase\-patch\fR will help you find that commit and do a rebase\.
 .SH "OPTIONS"
-.
 .TP
 <patch\-file>
 The patch to be applied\.
-.
 .SH "EXAMPLES"
 Executing
-.
 .IP "" 4
-.
 .nf
-
 $ git rebase\-patch test\.patch
-.
 .fi
-.
 .IP "" 0
-.
 .P
 could give you something like that:
-.
 .IP "" 4
-.
 .nf
-
-Trying to find a commit the patch applies to\.\.\.
+Trying to find a commit the patch applies to\|\.\|\.\|\.
 Patch applied to dbcf408dd26 as 7dc8b23ae1a
-First, rewinding head to replay your work on top of it\.\.\.
+First, rewinding head to replay your work on top of it\|\.\|\.\|\.
 Applying: test\.patch
-Using index info to reconstruct a base tree\.\.\.
-Falling back to patching base and 3\-way merge\.\.\.
+Using index info to reconstruct a base tree\|\.\|\.\|\.
+Falling back to patching base and 3\-way merge\|\.\|\.\|\.
 Auto\-merging README\.txt
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Then your last commit has the changes of the patch and is named \fItest\.patch\fR\.
-.
 .SH "AUTHOR"
 Written by Niklas Fiekas <\fIniklas\.fiekas@tu\-clausthal\.de\fR>
-.
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/tj/git\-extras/issues\fR>
-.
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
 .SH "SEE ALSO"
-<\fIhttp://github\.com/tj/git\-extras\fR>
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-rebase-patch.html
+++ b/man/git-rebase-patch.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-rebase-patch(1) - Rebases a patch</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,11 +69,12 @@
     <li class='tr'>git-rebase-patch(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-rebase-patch</code> - <span class="man-whatis">Rebases a patch</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p><code>git-rebase-patch</code> &lt;patch-file&gt;</p>
@@ -87,18 +88,18 @@ commit and do a rebase.</p>
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <dl>
-<dt>&lt;patch-file&gt;</dt><dd> The patch to be applied.</dd>
+<dt>&lt;patch-file&gt;</dt>
+<dd> The patch to be applied.</dd>
 </dl>
-
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p>  Executing</p>
+<p>Executing</p>
 
 <pre><code>$ git rebase-patch test.patch
 </code></pre>
 
-<p>  could give you something like that:</p>
+<p>could give you something like that:</p>
 
 <pre><code>Trying to find a commit the patch applies to...
 Patch applied to dbcf408dd26 as 7dc8b23ae1a
@@ -109,24 +110,23 @@ Falling back to patching base and 3-way merge...
 Auto-merging README.txt
 </code></pre>
 
-<p>  Then your last commit has the changes of the patch and is named <em>test.patch</em>.</p>
+<p>Then your last commit has the changes of the patch and is named <em>test.patch</em>.</p>
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Niklas Fiekas &lt;<a href="&#x6d;&#x61;&#x69;&#108;&#116;&#111;&#58;&#x6e;&#x69;&#107;&#108;&#x61;&#115;&#46;&#x66;&#105;&#x65;&#107;&#97;&#x73;&#x40;&#x74;&#117;&#45;&#x63;&#108;&#97;&#x75;&#115;&#116;&#104;&#x61;&#x6c;&#x2e;&#x64;&#x65;" data-bare-link="true">&#x6e;&#x69;&#107;&#108;&#x61;&#115;&#46;&#x66;&#x69;&#x65;&#107;&#97;&#x73;&#64;&#x74;&#117;&#x2d;&#x63;&#x6c;&#97;&#117;&#x73;&#116;&#104;&#x61;&#108;&#46;&#100;&#x65;</a>&gt;</p>
+<p>Written by Niklas Fiekas &lt;<a href="mailto:niklas.fiekas@tu-clausthal.de" data-bare-link="true">niklas.fiekas@tu-clausthal.de</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
-<p>&lt;<a href="http://github.com/tj/git-extras/issues" data-bare-link="true">http://github.com/tj/git-extras/issues</a>&gt;</p>
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p>&lt;<a href="http://github.com/tj/git-extras" data-bare-link="true">http://github.com/tj/git-extras</a>&gt;</p>
-
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>October 2017</li>
+    <li class='tc'>September 2019</li>
     <li class='tr'>git-rebase-patch(1)</li>
   </ol>
 

--- a/man/git-stamp.1
+++ b/man/git-stamp.1
@@ -1,66 +1,41 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-STAMP" "1" "April 2018" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-STAMP" "1" "September 2024" "" "Git Extras"
 .SH "NAME"
 \fBgit\-stamp\fR \- Stamp the last commit message
-.
 .SH "SYNOPSIS"
 \fBgit stamp [<options>] <id> [<messages>]\fR
-.
 .SH "DESCRIPTION"
 Lets you amend the last commit with a stamp message\.
-.
 .P
 The command appends a message with its identifier to the last commit message\.
-.
 .br
 By default all stamps are appended as a new paragraph to the commit message\.
-.
 .br
 You can change this behavior by using the \-\-replace flag\.
-.
 .br
 With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended\.
-.
 .P
 \fBWARNING!\fR If a commit message without stamp have a line starting with the same identifier, it will be interpreted as a stamp
-.
 .SH "OPTIONS"
 \-r, \-\-replace
-.
 .IP "" 4
-.
 .nf
-
 Replace all previous stamps in the last commit message that have the same identifier
 The identifier is case insensitive for this replacement
-.
 .fi
-.
 .IP "" 0
-.
 .SH "EXAMPLES"
 Commit message is
-.
 .IP "" 4
-.
 .nf
-
 | Fix timezone bug
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Reference the issues numbers from your bug tracker
-.
 .IP "" 4
-.
 .nf
-
 $ git stamp Issue FOO\-123
 $ git stamp Issue FOO\-456 \e#close
 
@@ -69,18 +44,12 @@ $ git stamp Issue FOO\-456 \e#close
 | Issue FOO\-123
 |
 | Issue FOO\-456 #close
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Link to its review page
-.
 .IP "" 4
-.
 .nf
-
 $ git stamp Review https://reviews\.foo\.org/r/4567/
 
 | Fix timezone bug
@@ -90,21 +59,14 @@ $ git stamp Review https://reviews\.foo\.org/r/4567/
 | Issue FOO\-456 #close
 |
 | Review https://reviews\.foo\.org/r/4567/
-.
 .fi
-.
 .IP "" 0
-.
 .P
 Replace previous issues with a new one
-.
 .br
 (Note that the identifier is case insensitive)
-.
 .IP "" 4
-.
 .nf
-
 $ git stamp \-\-replace issue BAR\-123
 
 | Fix timezone bug
@@ -112,16 +74,11 @@ $ git stamp \-\-replace issue BAR\-123
 | Review https://reviews\.foo\.org/r/4567/
 |
 | issue BAR\-123
-.
 .fi
-.
 .IP "" 0
-.
 .SH "AUTHOR"
 Written by Damien Tardy\-Panis <\fIdamien@tardypad\.me\fR>
-.
 .SH "REPORTING BUGS"
-<\fIhttp://github\.com/tj/git\-extras/issues\fR>
-.
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-stamp.html
+++ b/man/git-stamp.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-stamp(1) - Stamp the last commit message</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -69,29 +69,30 @@
     <li class='tr'>git-stamp(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>git-stamp</code> - <span class="man-whatis">Stamp the last commit message</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git stamp [&lt;options>] &lt;id> [&lt;messages>]</code></p>
+<p><code>git stamp [&lt;options&gt;] &lt;id&gt; [&lt;messages&gt;]</code></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
 <p>Lets you amend the last commit with a stamp message.</p>
 
-<p>The command appends a message with its identifier to the last commit message.<br />
-By default all stamps are appended as a new paragraph to the commit message.<br />
-You can change this behavior by using the --replace flag.<br />
+<p>The command appends a message with its identifier to the last commit message.<br>
+By default all stamps are appended as a new paragraph to the commit message.<br>
+You can change this behavior by using the --replace flag.<br>
 With this flag, all the related stamps with the same identifier will be removed first before the new one gets appended.</p>
 
 <p><code>WARNING!</code> If a commit message without stamp have a line starting with the same identifier, it will be interpreted as a stamp</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  -r, --replace</p>
+<p>-r, --replace</p>
 
 <pre><code>Replace all previous stamps in the last commit message that have the same identifier  
 The identifier is case insensitive for this replacement
@@ -129,7 +130,7 @@ $ git stamp Issue FOO-456 \#close
 | Review https://reviews.foo.org/r/4567/
 </code></pre>
 
-<p>Replace previous issues with a new one<br />
+<p>Replace previous issues with a new one<br>
 (Note that the identifier is case insensitive)</p>
 
 <pre><code>$ git stamp --replace issue BAR-123
@@ -143,20 +144,19 @@ $ git stamp Issue FOO-456 \#close
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Damien Tardy-Panis &lt;<a href="&#x6d;&#97;&#x69;&#x6c;&#116;&#111;&#58;&#x64;&#97;&#x6d;&#105;&#x65;&#x6e;&#64;&#x74;&#97;&#x72;&#100;&#x79;&#112;&#97;&#x64;&#46;&#x6d;&#x65;" data-bare-link="true">&#100;&#x61;&#109;&#x69;&#101;&#x6e;&#64;&#x74;&#97;&#x72;&#x64;&#121;&#112;&#97;&#x64;&#x2e;&#x6d;&#101;</a>&gt;</p>
+<p>Written by Damien Tardy-Panis &lt;<a href="mailto:damien@tardypad.me" data-bare-link="true">damien@tardypad.me</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
-<p>&lt;<a href="http://github.com/tj/git-extras/issues" data-bare-link="true">http://github.com/tj/git-extras/issues</a>&gt;</p>
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2018</li>
+    <li class='tc'>September 2024</li>
     <li class='tr'>git-stamp(1)</li>
   </ol>
 


### PR DESCRIPTION
As I was updating some other code, the check_integrity script informed me that these three files were out of sync... and indeed they were! In the first one, there's a whole new usage pattern documented, and in the others an http has been changed to an https.

It's nice that the script worked now, but why hasn't it worked to prevent this in the CI, such as the recent runs of https://github.com/tj/git-extras/pull/1160 (after the new CI should be in place)? For that matter, why didn't it show up to me locally earlier? Did something else change? Perhaps the --newer flag should be removed from our invocation of git-utimes in check_integrity?

(Perhaps this PR shouldn't be accepted until there is at least one other commit past the CI-altering commit https://github.com/tj/git-extras/commit/4d2d393142918594da02e498169dd692fe21e17c in the git history (or at least has been attempted to be put in the git history), because maybe that would trigger the new CI and quell my doubts.)

Since I had to run the instructions to update each file, I noticed they were hard to copy-paste, and changed them to be easier.
