### PR TITLE
Improve warning for `git clear`

### DIFF
--- a/bin/git-clear
+++ b/bin/git-clear
@@ -32,7 +32,7 @@ done
 
 # Only wait for answer if not forced by user
 if [[ $FORCE == 0 ]]; then
-    echo -n "Sure? - This command may delete files that cannot be recovered, including those in .gitignore [y/N]: "
+    echo -n "Sure? - THIS COMMAND MAY DELETE FILES THAT CANNOT BE RECOVERED, including those in .gitignore [y/N]: "
     read -r clean
 else
     clean=y


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->

This partially addresses #1167 by making the "deleting files warning" in uppercase characters.
