### PR TITLE
Initial Bats scaffold (DO NOT MERGE)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/bats-all"]
+	path = vendor/bats-all
+	url = https://github.com/hyperupcall/bats-all

--- a/tests/git-abort.bats
+++ b/tests/git-abort.bats
@@ -1,0 +1,63 @@
+# shellcheck shell=bash
+
+source "$BATS_TEST_DIRNAME/test_util.sh"
+
+setup_file() {
+    test_util.setup_file
+}
+
+# This is ran before each "@test".
+setup() {
+    # cd's to a temporary directory that is unique for each "@test".
+    test_util.cd_test
+
+    # Do initialization (this code is copied from test_git_alias.py)
+    git init
+    git config --global alias.globalalias status
+    git config --global alias.x status
+    git config --local alias.localalias status
+    git config --local alias.y status
+}
+
+@test "list all works" {
+    run git alias
+
+    # This is one way to do it, most similar to the "test_list_all" test in
+    # test_git_alias.py. It's slightly more accurate because each substring
+    # must match a particular line of output (rather than matching any part of the output)
+    assert_line 'globalalias = status'
+    assert_line 'x = status'
+    assert_line 'localalias = status'
+    assert_line 'y = status'
+
+    # To test the full output, this is one way:
+    assert_output 'globalalias = status
+localalias = status
+x = status
+y = status'
+
+    # One can use heredocs to also achieve this, which makes the test look a little nicer. Note that the indentation MUST BE DONE WITH TABS.
+    assert_output - <<-"EOF"
+		globalalias = status
+		localalias = status
+		x = status
+		y = status
+EOF
+
+    # I tend to put 'assert_success' at the bottom. This usually makes debugging easier because an "assert_output" written above will usuall fail first. This will cause the the output of the run command to be printed (instead of just the exit code).
+    # The downside to this is that sometimes there is a bug: An error "lines: parameter not set" will be shown instead (which is a Bats issue).
+    assert_success
+}
+
+@test "list all global works" {
+    run git alias --global
+
+    # One debugging technique for bats test I've found useful is to redirect to
+    # fd3. The variable "$output" is set by Bats, and it is the output of the previous "run" command (in this case, `git alias --global`). Here, we are printing it to fd3 for debugging. Naturally, be sure to run `exec 3>&1` (assuming you are running Bash or Zsh shell) in the terminal before running Bats.
+#     echo "$output" >&3
+
+
+    assert_output 'globalalias = status
+x = status'
+    assert_success
+}

--- a/tests/git-alias.bats
+++ b/tests/git-alias.bats
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+
+source "$BATS_TEST_DIRNAME/test_util.sh"
+
+setup_file() {
+    test_util.setup_file
+}
+
+setup() {
+    test_util.cd_test
+
+    # Any extra setup goes here.
+}
+
+@test "blah 1" {
+    :
+}
+
+@test "blah 2" {
+    :
+}

--- a/tests/test_util.sh
+++ b/tests/test_util.sh
@@ -1,0 +1,33 @@
+# shellcheck shell=bash
+
+# Bats has some very (official) nifty utility libraries to make testing easier.
+# For example, `bats-support` adds `fail()`
+# For example, `bats-assert` adds `assert()`, `assert_success`, `assert_output`.
+# These helper functions:
+# - _Significantly_ improve error messages (this is the main reason why I like to use these)
+# - Make the test more semantic and readable (ex. assert_success reads better than [ $? == 0 ])
+# I created a repository that combines each of the three Bats utility libraries. This makes testing easier, but separate submodules for each Bats utility library can be crated (ex. vendor/bats-all, vendor/bats-support, vendor/bats-assert)
+# This `load.bash` sources all Bats utility libraries
+source "$BATS_TEST_DIRNAME/../vendor/bats-all/load.bash"
+
+# Various helper functions. I always prefix them with "test_util" so their intent and
+# location of definition (this file) is obvious wherever they are used.
+
+test_util.setup_file() {
+    # Bats automatically sets 'set -e', so we don't have to do any "|| exit 1" stuff
+    cd "$BATS_FILE_TMPDIR"
+
+    # Export some variables so Git neither reads nor mutates the users' Git config.
+    export GIT_CONFIG_NOSYSTEM=1
+    export GIT_CONFIG_GLOBAL="$PWD/git_config"
+    # This removes default warning about default "master" branch on some Git versions.
+    git config --global init.defaultBranch main
+
+    # Append to path so that we can access all commands included from git-extras
+    # TODO: This currently breaks with commands that are included in "not_needed_git_repo" etc.
+    PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
+}
+
+test_util.cd_test() {
+    cd "$BATS_TEST_TMPDIR"
+}


### PR DESCRIPTION
The purpose of this PR is to better show the additions that might be made to incorporate [Bats](https://github.com/bats-core/bats-core), a testing framework for Bash. More information about this PR can be found in [this comment](https://github.com/tj/git-extras/issues/1131#issuecomment-2390817797).

To run this code, be sure to:
1. Install Bats (see instructions on Bats website)
2. Switch to this branch (this branch adds a git submodule, [hyperupcall/bats-all](https://github.com/bash-bastion/bats-all), be sure to update submodules (i think that `git submodule update --init` should do the trick))
3. Now you can run `bats ./tests`

When executing Bats, Bats will look for files inside of `./tests` that end with `.bats`. If it sees any, it "executes" it. In this PR, there are two `.bats` files used to demonstrate a few features of Bats.