### PR TITLE
Fix stripping trailing forward slash for git-get

### DIFF
--- a/bin/git-get
+++ b/bin/git-get
@@ -33,7 +33,7 @@ if [ -z "$clone_path" ]; then
 fi
 
 dirname=${url%/}
-dirname=${url%.git}
+dirname=${dirname%.git}
 dirname=${dirname##*/}
 
 mkdir -p "$clone_path"


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->

This allows for the removal of any potential trailing forward slash to be propagated into the final dirname.