### PR TITLE
Support `GITHUB_TOKEN` var for `git-fork` and `git-pull-request`

### DIFF
--- a/bin/git-fork
+++ b/bin/git-fork
@@ -17,11 +17,7 @@ read -r user
 # personal access token
 # config name is github-personal-access-token '_' is not allowed in git config
 
-if test -z "${GITHUB_TOKEN}"; then
-  github_personal_access_token=$(git config git-extras.github-personal-access-token)
-else
-  github_personal_access_token=$GITHUB_TOKEN
-fi
+github_personal_access_token=$(git config --default "$GITHUB_TOKEN" git-extras.github-personal-access-token)
 
 test -z "$github_personal_access_token" && abort "GITHUB_TOKEN, or git config git-extras.github-personal-access-token required"
 

--- a/bin/git-fork
+++ b/bin/git-fork
@@ -17,9 +17,13 @@ read -r user
 # personal access token
 # config name is github-personal-access-token '_' is not allowed in git config
 
-github_personal_access_token=$(git config git-extras.github-personal-access-token)
+if test -z "${GITHUB_TOKEN}"; then
+  github_personal_access_token=$(git config git-extras.github-personal-access-token)
+else
+  github_personal_access_token=$GITHUB_TOKEN
+fi
 
-test -z "$github_personal_access_token" && abort "git config git-extras.github-personal-access-token required"
+test -z "$github_personal_access_token" && abort "GITHUB_TOKEN, or git config git-extras.github-personal-access-token required"
 
 # extract owner + project from repo url
 project=${url##*/}

--- a/bin/git-pull-request
+++ b/bin/git-pull-request
@@ -31,9 +31,13 @@ EOF
 # personal access token
 # config name is github-personal-access-token '_' is not allowed in git config
 
-github_personal_access_token=$(git config git-extras.github-personal-access-token)
+if test -z "${GITHUB_TOKEN}"; then
+  github_personal_access_token=$(git config git-extras.github-personal-access-token)
+else
+  github_personal_access_token=$GITHUB_TOKEN
+fi
 
-test -z "$github_personal_access_token" && abort "git config git-extras.github-personal-access-token required"
+test -z "$github_personal_access_token" && abort "GITHUB_TOKEN or git config git-extras.github-personal-access-token required"
 
 # branch
 

--- a/bin/git-pull-request
+++ b/bin/git-pull-request
@@ -31,11 +31,7 @@ EOF
 # personal access token
 # config name is github-personal-access-token '_' is not allowed in git config
 
-if test -z "${GITHUB_TOKEN}"; then
-  github_personal_access_token=$(git config git-extras.github-personal-access-token)
-else
-  github_personal_access_token=$GITHUB_TOKEN
-fi
+github_personal_access_token=$(git config --default "$GITHUB_TOKEN" git-extras.github-personal-access-token)
 
 test -z "$github_personal_access_token" && abort "GITHUB_TOKEN or git config git-extras.github-personal-access-token required"
 

--- a/man/git-fork.1
+++ b/man/git-fork.1
@@ -49,7 +49,7 @@ A personal access token is required for making the API call to create a new fork
 Make sure the personal access token has the right \fBOAuth\fR scopes for the repo(s)
 .
 .P
-Use \fBgit config \-\-global \-\-add git\-extras\.github\-personal\-access\-token <your\-personal\-access\-token>\fR
+Use \fBGITHUB_TOKEN\fR environment variable, or \fBgit config \-\-global \-\-add git\-extras\.github\-personal\-access\-token <your\-personal\-access\-token>\fR
 .
 .P
 If using multiple accounts, override the global value in the specific repo using \fBgit config git\-extras\.github\-personal\-access\-token <other\-acc\-personal\-access\-token>\fR

--- a/man/git-fork.html
+++ b/man/git-fork.html
@@ -105,7 +105,7 @@
 
 <p>Make sure the personal access token has the right <code>OAuth</code> scopes for the repo(s)</p>
 
-<p>Use <code>git config --global --add git-extras.github-personal-access-token &lt;your-personal-access-token></code></p>
+<p>Use <code>GITHUB_TOKEN</code> environment variable, or <code>git config --global --add git-extras.github-personal-access-token &lt;your-personal-access-token></code></p>
 
 <p>If using multiple accounts, override the global value in the specific repo using <code>git config git-extras.github-personal-access-token &lt;other-acc-personal-access-token></code></p>
 

--- a/man/git-fork.md
+++ b/man/git-fork.md
@@ -27,7 +27,7 @@ git-fork(1) -- Fork a repo on github
   
   Make sure the personal access token has the right `OAuth` scopes for the repo(s)
   
-  Use `git config --global --add git-extras.github-personal-access-token <your-personal-access-token>`
+  Use `GITHUB_TOKEN` environment variable, or `git config --global --add git-extras.github-personal-access-token <your-personal-access-token>`
   
   If using multiple accounts, override the global value in the specific repo using `git config git-extras.github-personal-access-token <other-acc-personal-access-token>`
 

--- a/man/git-pull-request.1
+++ b/man/git-pull-request.1
@@ -19,7 +19,7 @@ A personal access token is required for making the API call to open the pull req
 Make sure the personal access token has the right \fBOAuth\fR scopes for the repo(s)
 .
 .P
-Use \fBgit config \-\-global \-\-add git\-extras\.github\-personal\-access\-token <your\-personal\-access\-token>\fR
+Use \fBGITHUB_TOKEN\fR environment variable, or \fBgit config \-\-global \-\-add git\-extras\.github\-personal\-access\-token <your\-personal\-access\-token>\fR
 .
 .P
 If using multiple accounts, override the global value in the specific repo using \fBgit config git\-extras\.github\-personal\-access\-token <other\-acc\-personal\-access\-token>\fR

--- a/man/git-pull-request.html
+++ b/man/git-pull-request.html
@@ -86,7 +86,7 @@
 
 <p>Make sure the personal access token has the right <code>OAuth</code> scopes for the repo(s)</p>
 
-<p>Use <code>git config --global --add git-extras.github-personal-access-token &lt;your-personal-access-token></code></p>
+<p>Use <code>GITHUB_TOKEN</code> environment variable, or <code>git config --global --add git-extras.github-personal-access-token &lt;your-personal-access-token></code></p>
 
 <p>If using multiple accounts, override the global value in the specific repo using <code>git config git-extras.github-personal-access-token &lt;other-acc-personal-access-token></code></p>
 
@@ -104,9 +104,9 @@ Everything up-to-date
   create pull-request for spacewander/spacewander-toolbox 'master'
 
   title: test
-  body:  
-  base [master]: 
-  GitHub two-factor authentication code (leave blank if not set up): 
+  body:
+  base [master]:
+  GitHub two-factor authentication code (leave blank if not set up):
 
 ...
 </code></pre>

--- a/man/git-pull-request.md
+++ b/man/git-pull-request.md
@@ -13,7 +13,7 @@ A personal access token is required for making the API call to open the pull req
 
 Make sure the personal access token has the right `OAuth` scopes for the repo(s)
 
-Use `git config --global --add git-extras.github-personal-access-token <your-personal-access-token>`
+Use `GITHUB_TOKEN` environment variable, or `git config --global --add git-extras.github-personal-access-token <your-personal-access-token>`
 
 If using multiple accounts, override the global value in the specific repo using `git config git-extras.github-personal-access-token <other-acc-personal-access-token>`
 


### PR DESCRIPTION
Hi,

`git-fork` & `git-pull-request` currently require to set github token in git config global file.
I would like to keep this file versionned and public on github, so I would prefer not having to put secrets inside.

A common solution to this issue is to pass that token through the `GITHUB_TOKEN` environment variable instead.

Here is a simple commit implementing and documenting that.

ref. #839

<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
