### PR TITLE
feat: add ruff linter with ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
           readarray -t changed_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.added_modified }}')"
           ~/go/bin/editorconfig-checker ${changed_files[@]}
+      - name: Lint and format Python with Ruff
+        uses: astral-sh/ruff-action@v1
 
   typo:
     runs-on: ubuntu-latest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,14 @@
 import pytest
 from helper import TempRepository
 
-def create_repo(dirname = None):
+
+def create_repo(dirname=None):
     repo = TempRepository(dirname)
     tmp_file_a = repo.create_tmp_file()
     tmp_file_b = repo.create_tmp_file()
     repo.switch_cwd_under_repo()
     return repo
+
 
 def init_repo_git_status(repo):
     git = repo.get_repo_git()
@@ -18,11 +20,13 @@ def init_repo_git_status(repo):
     git.config("--local", "user.email", "test@git-extras.com")
     git.commit("-m", "chore: initial commit")
 
+
 @pytest.fixture(scope="module")
 def temp_repo():
     repo = create_repo()
     init_repo_git_status(repo)
     return repo
+
 
 @pytest.fixture(scope="module")
 def named_temp_repo(request):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -10,15 +10,16 @@ GITHUB_ORIGIN = "https://github.com/tj/git-extras.git"
 GITLAB_ORIGIN = "https://gitlab.com/tj/git-extras.git"
 BITBUCKET_ORIGIN = "https://bitbucket.org/tj/git-extras.git"
 
+
 class TempRepository:
-    def __init__(self, repo_work_dir = None):
+    def __init__(self, repo_work_dir=None):
         self._system_tmpdir = tempfile.gettempdir()
         if repo_work_dir == None:
             repo_work_dir = tempfile.mkdtemp()
         else:
             repo_work_dir = os.path.join(self._system_tmpdir, repo_work_dir)
         self._cwd = repo_work_dir
-        self._tempdirname = self._cwd[len(self._system_tmpdir) + 1:]
+        self._tempdirname = self._cwd[len(self._system_tmpdir) + 1 :]
         self._git_repo = Repo.init(repo_work_dir, b="default")
         self._files = []
         self.change_origin_to_github()
@@ -50,7 +51,7 @@ class TempRepository:
         tmp_dir = tempfile.mkdtemp()
         return tmp_dir
 
-    def create_tmp_file(self, temp_dir = None):
+    def create_tmp_file(self, temp_dir=None):
         if temp_dir == None:
             temp_dir = self._cwd
 
@@ -86,8 +87,9 @@ class TempRepository:
         origin_extras_command = os.path.join(GIT_EXTRAS_BIN, command_name)
         temp_extras_command = os.path.join(self._cwd, command_name)
         helpers = [
-                os.path.join(GIT_EXTRAS_HELPER, "git-extra-utility"),
-                os.path.join(GIT_EXTRAS_HELPER, "is-git-repo")]
+            os.path.join(GIT_EXTRAS_HELPER, "git-extra-utility"),
+            os.path.join(GIT_EXTRAS_HELPER, "is-git-repo"),
+        ]
 
         if not os.path.exists(temp_extras_command):
             whole = []
@@ -106,7 +108,7 @@ class TempRepository:
             os.chmod(temp_extras_command, 0o775)
 
         script = [temp_extras_command, *params]
-        print(f"Run the script \"{script}\"")
+        print(f'Run the script "{script}"')
         return subprocess.run(script, capture_output=True)
 
     def change_origin(self, origin_url):

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -21,3 +21,66 @@ testpaths = ["."]
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.9
+target-version = "py39"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/tests/test_git_abort.py
+++ b/tests/test_git_abort.py
@@ -1,5 +1,6 @@
 from git import GitCommandError
 
+
 class TestGitAbort:
     def test_init(self, temp_repo):
         git = temp_repo.get_repo_git()

--- a/tests/test_git_archive_file.py
+++ b/tests/test_git_archive_file.py
@@ -1,5 +1,6 @@
 import os, pytest
 
+
 class TestGitArchiveFile:
     def test_init(self, temp_repo):
         git = temp_repo.get_repo_git()
@@ -16,14 +17,17 @@ class TestGitArchiveFile:
         filename = "{0}.{1}.zip".format(temp_repo.get_repo_dirname(), git.describe())
         assert filename in os.listdir()
 
-    def test_archive_file_on_any_not_tags_branch_without_default_branch(self, temp_repo):
+    def test_archive_file_on_any_not_tags_branch_without_default_branch(
+        self, temp_repo
+    ):
         git = temp_repo.get_repo_git()
         git.checkout("-b", "not-tags-branch")
         temp_repo.invoke_installed_extras_command("archive-file")
         filename = "{0}.{1}.{2}.zip".format(
-                temp_repo.get_repo_dirname(),
-                git.describe("--always", "--long"),
-                "not-tags-branch")
+            temp_repo.get_repo_dirname(),
+            git.describe("--always", "--long"),
+            "not-tags-branch",
+        )
         assert filename in os.listdir()
 
     def test_archive_file_on_any_not_tags_branch_with_default_branch(self, temp_repo):
@@ -32,8 +36,8 @@ class TestGitArchiveFile:
         git.config("git-extras.default-branch", "default")
         temp_repo.invoke_installed_extras_command("archive-file")
         filename = "{0}.{1}.zip".format(
-                temp_repo.get_repo_dirname(),
-                git.describe("--always", "--long"))
+            temp_repo.get_repo_dirname(), git.describe("--always", "--long")
+        )
         assert filename in os.listdir()
 
     def test_archive_file_on_branch_name_has_slash(self, temp_repo):
@@ -41,9 +45,10 @@ class TestGitArchiveFile:
         git.checkout("-b", "feature/slash")
         temp_repo.invoke_installed_extras_command("archive-file")
         filename = "{0}.{1}.{2}.zip".format(
-                temp_repo.get_repo_dirname(),
-                git.describe("--always", "--long"),
-                "feature-slash")
+            temp_repo.get_repo_dirname(),
+            git.describe("--always", "--long"),
+            "feature-slash",
+        )
         assert filename in os.listdir()
 
     @pytest.mark.parametrize("named_temp_repo", ["backslash\\dir"], indirect=True)
@@ -51,9 +56,8 @@ class TestGitArchiveFile:
         named_temp_repo.invoke_installed_extras_command("archive-file")
         git = named_temp_repo.get_repo_git()
         filename = "{0}.{1}.{2}.zip".format(
-                "backslash-dir",
-                git.describe("--always", "--long"),
-                "default")
+            "backslash-dir", git.describe("--always", "--long"), "default"
+        )
         assert filename in os.listdir()
 
     def test_archive_file_on_tag_name_has_slash(self, temp_repo):
@@ -65,6 +69,6 @@ class TestGitArchiveFile:
         temp_repo.invoke_installed_extras_command("archive-file")
         description_include_version = git.describe("--always", "--long")
         filename = "{0}.{1}.zip".format(
-                temp_repo.get_repo_dirname(),
-                description_include_version.replace("/", "-"))
+            temp_repo.get_repo_dirname(), description_include_version.replace("/", "-")
+        )
         assert filename in os.listdir()

--- a/tests/test_git_authors.py
+++ b/tests/test_git_authors.py
@@ -1,8 +1,11 @@
 import os, subprocess
 
-expected_authors_list = "test <test@git-extras.com>\ntestagain <testagain@git-extras.com>\n"
+expected_authors_list = (
+    "test <test@git-extras.com>\ntestagain <testagain@git-extras.com>\n"
+)
 expected_authors_list_without_email = "test\ntestagain\n"
 authors_file = "AUTHORS"
+
 
 class TestGitAuthors:
     def test_init(self, temp_repo):

--- a/tests/test_git_browse.py
+++ b/tests/test_git_browse.py
@@ -3,20 +3,22 @@ from testpath import MockCommand, modified_env
 
 UNKNOWN_SITE_ORIGIN = "https://unknown-site.com/tj/git-extras.git"
 
+
 def get_file_uri(mode, filename, git):
     commit_hash = git.rev_parse("HEAD")
     if mode == "github":
-        return "https://github.com/tj/git-extras/blob/" + commit_hash + '/' + filename
+        return "https://github.com/tj/git-extras/blob/" + commit_hash + "/" + filename
     if mode == "gitlab":
-        return "https://gitlab.com/tj/git-extras/-/blob/" + commit_hash + '/' + filename
+        return "https://gitlab.com/tj/git-extras/-/blob/" + commit_hash + "/" + filename
     if mode == "bitbucket":
-        return "https://bitbucket.org/tj/git-extras/src/" + commit_hash + '/' + filename
+        return "https://bitbucket.org/tj/git-extras/src/" + commit_hash + "/" + filename
+
 
 class TestGitBrowse:
     def test_browse_github_file_on_mac(self, temp_repo):
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "darwin" }), MockCommand("open") as openCommand:
+        with modified_env({"OSTYPE": "darwin"}), MockCommand("open") as openCommand:
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("github", filename, git)
             openCommand.assert_called([expected_url])
@@ -25,7 +27,7 @@ class TestGitBrowse:
         temp_repo.change_origin_to_gitlab()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "darwin" }), MockCommand("open") as openCommand:
+        with modified_env({"OSTYPE": "darwin"}), MockCommand("open") as openCommand:
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("gitlab", filename, git)
             openCommand.assert_called([expected_url])
@@ -34,7 +36,7 @@ class TestGitBrowse:
         temp_repo.change_origin_to_bitbucket()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "darwin" }), MockCommand("open") as openCommand:
+        with modified_env({"OSTYPE": "darwin"}), MockCommand("open") as openCommand:
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("bitbucket", filename, git)
             openCommand.assert_called([expected_url])
@@ -43,7 +45,7 @@ class TestGitBrowse:
         temp_repo.change_origin_to_github()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "msys" }), MockCommand("start") as openCommand:
+        with modified_env({"OSTYPE": "msys"}), MockCommand("start") as openCommand:
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("github", filename, git)
             openCommand.assert_called([expected_url])
@@ -52,7 +54,7 @@ class TestGitBrowse:
         temp_repo.change_origin_to_gitlab()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "msys" }), MockCommand("start") as openCommand:
+        with modified_env({"OSTYPE": "msys"}), MockCommand("start") as openCommand:
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("gitlab", filename, git)
             openCommand.assert_called([expected_url])
@@ -61,7 +63,7 @@ class TestGitBrowse:
         temp_repo.change_origin_to_bitbucket()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "msys" }), MockCommand("start") as openCommand:
+        with modified_env({"OSTYPE": "msys"}), MockCommand("start") as openCommand:
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("bitbucket", filename, git)
             openCommand.assert_called([expected_url])
@@ -70,8 +72,12 @@ class TestGitBrowse:
         temp_repo.change_origin_to_github()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "microsoft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("powershell.exe") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "microsoft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("powershell.exe") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("github", filename, git)
             openCommand.assert_called(["-NoProfile", "start", expected_url])
@@ -80,8 +86,12 @@ class TestGitBrowse:
         temp_repo.change_origin_to_gitlab()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "microsoft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("powershell.exe") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "microsoft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("powershell.exe") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("gitlab", filename, git)
             openCommand.assert_called(["-NoProfile", "start", expected_url])
@@ -90,8 +100,12 @@ class TestGitBrowse:
         temp_repo.change_origin_to_bitbucket()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "microsoft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("powershell.exe") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "microsoft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("powershell.exe") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("bitbucket", filename, git)
             openCommand.assert_called(["-NoProfile", "start", expected_url])
@@ -100,8 +114,12 @@ class TestGitBrowse:
         temp_repo.change_origin_to_github()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "no-micro-soft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "no-micro-soft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("github", filename, git)
             openCommand.assert_called([expected_url])
@@ -110,8 +128,12 @@ class TestGitBrowse:
         temp_repo.change_origin_to_gitlab()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "no-micro-soft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "no-micro-soft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("gitlab", filename, git)
             openCommand.assert_called([expected_url])
@@ -120,8 +142,12 @@ class TestGitBrowse:
         temp_repo.change_origin_to_bitbucket()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "no-micro-soft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "no-micro-soft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("bitbucket", filename, git)
             openCommand.assert_called([expected_url])
@@ -130,7 +156,10 @@ class TestGitBrowse:
         temp_repo.change_origin_to_github()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("github", filename, git)
             openCommand.assert_called([expected_url])
@@ -139,7 +168,10 @@ class TestGitBrowse:
         temp_repo.change_origin_to_gitlab()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("gitlab", filename, git)
             openCommand.assert_called([expected_url])
@@ -148,7 +180,10 @@ class TestGitBrowse:
         temp_repo.change_origin_to_bitbucket()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename)
             expected_url = get_file_uri("bitbucket", filename, git)
             openCommand.assert_called([expected_url])
@@ -157,7 +192,10 @@ class TestGitBrowse:
         temp_repo.change_origin_to_github()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename, "10", "20")
             expected_url = get_file_uri("github", filename, git)
             openCommand.assert_called([expected_url + "#L10-L20"])
@@ -166,7 +204,10 @@ class TestGitBrowse:
         temp_repo.change_origin_to_gitlab()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename, "10", "20")
             expected_url = get_file_uri("gitlab", filename, git)
             openCommand.assert_called([expected_url + "#L10-20"])
@@ -175,7 +216,10 @@ class TestGitBrowse:
         temp_repo.change_origin_to_bitbucket()
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename, "10", "20")
             expected_url = get_file_uri("bitbucket", filename, git)
             openCommand.assert_called([expected_url + "#lines-10:20"])
@@ -183,13 +227,19 @@ class TestGitBrowse:
     def test_browse_unknown_site_file(self, temp_repo):
         temp_repo.change_origin(UNKNOWN_SITE_ORIGIN)
         git = temp_repo.get_repo_git()
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin")
             openCommand.assert_called([UNKNOWN_SITE_ORIGIN[0:-4]])
 
     def test_browse_unknown_site_file_with_line_number(self, temp_repo):
         git = temp_repo.get_repo_git()
         filename = temp_repo.get_filename(0)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse", "origin", filename, "10", "20")
             openCommand.assert_called([UNKNOWN_SITE_ORIGIN[0:-4]])

--- a/tests/test_git_browse_ci.py
+++ b/tests/test_git_browse_ci.py
@@ -3,6 +3,7 @@ from testpath import MockCommand, modified_env
 
 UNKNOWN_SITE_ORIGIN = "https://unknown-site.com/tj/git-extras.git"
 
+
 def get_ci_uri_by_domain(mode):
     if mode == "github":
         return "https://github.com/tj/git-extras/actions"
@@ -11,119 +12,156 @@ def get_ci_uri_by_domain(mode):
     if mode == "bitbucket":
         return "https://bitbucket.org/tj/git-extras/addon/pipelines/home"
 
+
 class TestGitBrowse:
     def test_browse_github_ci_on_mac(self, temp_repo):
-        with modified_env({ "OSTYPE": "darwin" }), MockCommand("open") as openCommand:
+        with modified_env({"OSTYPE": "darwin"}), MockCommand("open") as openCommand:
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("github")
             openCommand.assert_called([expected_url])
 
     def test_browse_gitlab_ci_on_mac(self, temp_repo):
         temp_repo.change_origin_to_gitlab()
-        with modified_env({ "OSTYPE": "darwin" }), MockCommand("open") as openCommand:
+        with modified_env({"OSTYPE": "darwin"}), MockCommand("open") as openCommand:
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("gitlab")
             openCommand.assert_called([expected_url])
 
     def test_browse_bitbucket_ci_on_mac(self, temp_repo):
         temp_repo.change_origin_to_bitbucket()
-        with modified_env({ "OSTYPE": "darwin" }), MockCommand("open") as openCommand:
+        with modified_env({"OSTYPE": "darwin"}), MockCommand("open") as openCommand:
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("bitbucket")
             openCommand.assert_called([expected_url])
 
     def test_browse_github_ci_on_git_bash_on_window(self, temp_repo):
         temp_repo.change_origin_to_github()
-        with modified_env({ "OSTYPE": "msys" }), MockCommand("start") as openCommand:
+        with modified_env({"OSTYPE": "msys"}), MockCommand("start") as openCommand:
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("github")
             openCommand.assert_called([expected_url])
 
     def test_browse_gitlab_ci_on_git_bash_on_window(self, temp_repo):
         temp_repo.change_origin_to_gitlab()
-        with modified_env({ "OSTYPE": "msys" }), MockCommand("start") as openCommand:
+        with modified_env({"OSTYPE": "msys"}), MockCommand("start") as openCommand:
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("gitlab")
             openCommand.assert_called([expected_url])
 
     def test_browse_bitbucket_ci_on_git_bash_on_window(self, temp_repo):
         temp_repo.change_origin_to_bitbucket()
-        with modified_env({ "OSTYPE": "msys" }), MockCommand("start") as openCommand:
+        with modified_env({"OSTYPE": "msys"}), MockCommand("start") as openCommand:
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("bitbucket")
             openCommand.assert_called([expected_url])
 
     def test_browse_github_ci_on_WSL_with_microsoft_key(self, temp_repo):
         temp_repo.change_origin_to_github()
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "microsoft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("powershell.exe") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "microsoft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("powershell.exe") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("github")
             openCommand.assert_called(["-NoProfile", "start", expected_url])
 
     def test_browse_gitlab_ci_on_WSL_with_microsoft_key(self, temp_repo):
         temp_repo.change_origin_to_gitlab()
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "microsoft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("powershell.exe") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "microsoft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("powershell.exe") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("gitlab")
             openCommand.assert_called(["-NoProfile", "start", expected_url])
 
     def test_browse_bitbucket_ci_on_WSL_with_microsoft_key(self, temp_repo):
         temp_repo.change_origin_to_bitbucket()
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "microsoft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("powershell.exe") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "microsoft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("powershell.exe") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("bitbucket")
             openCommand.assert_called(["-NoProfile", "start", expected_url])
 
     def test_browse_github_ci_on_WSL_without_microsoft_key(self, temp_repo):
         temp_repo.change_origin_to_github()
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "no-micro-soft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "no-micro-soft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("github")
             openCommand.assert_called([expected_url])
 
     def test_browse_gitlab_ci_on_WSL_without_microsoft_key(self, temp_repo):
         temp_repo.change_origin_to_gitlab()
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "no-micro-soft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "no-micro-soft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("gitlab")
             openCommand.assert_called([expected_url])
 
     def test_browse_bitbucket_ci_on_WSL_without_microsoft_key(self, temp_repo):
         temp_repo.change_origin_to_bitbucket()
-        with modified_env({ "OSTYPE": "linux" }), MockCommand.fixed_output("uname", "no-micro-soft"), \
-            MockCommand.fixed_output("command", "/powershell.exe"), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "linux"}),
+            MockCommand.fixed_output("uname", "no-micro-soft"),
+            MockCommand.fixed_output("command", "/powershell.exe"),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("bitbucket")
             openCommand.assert_called([expected_url])
 
     def test_browse_github_ci_not_mac_or_msys_or_linux(self, temp_repo):
         temp_repo.change_origin_to_github()
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("github")
             openCommand.assert_called([expected_url])
 
     def test_browse_gitlab_ci_not_mac_or_msys_or_linux(self, temp_repo):
         temp_repo.change_origin_to_gitlab()
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("gitlab")
             openCommand.assert_called([expected_url])
 
     def test_browse_bitbucket_ci_not_mac_or_msys_or_linux(self, temp_repo):
         temp_repo.change_origin_to_bitbucket()
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
             expected_url = get_ci_uri_by_domain("bitbucket")
             openCommand.assert_called([expected_url])
 
     def test_browse_unknown_site_file(self, temp_repo):
         temp_repo.change_origin(UNKNOWN_SITE_ORIGIN)
-        with modified_env({ "OSTYPE": "unique-system" }), MockCommand("xdg-open") as openCommand:
+        with (
+            modified_env({"OSTYPE": "unique-system"}),
+            MockCommand("xdg-open") as openCommand,
+        ):
             temp_repo.invoke_extras_command("browse-ci", "origin")
-            openCommand.assert_called([''])
+            openCommand.assert_called([""])


### PR DESCRIPTION
Linting the python files in tests directory would reduce whitespace etc change and enforce basic coding standard for those. Kind of opportunistic PR as there might be other opinions about how to deal with this.