### PR TITLE
fix(github-actions): changed files output for editorcondig-checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,32 @@ jobs:
   lint:
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'Get Changed Files'
-        id: 'files'
-        uses: 'masesgroup/retrieve-changed-files@v3'
-        with:
-          format: 'json'
-        # a force push will cause the action above to fail. Don't do force push when people are
-        # reviewing!
       - name: Check out code.
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: 'Get Changed Files'
+        id: 'files'
+        run: |
+          {
+            echo "added_modified<<EOF"
+            git diff --name-only "${BASE_SHA:-$BEFORE_SHA}...${HEAD_SHA:-GITHUB_REF}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: "${{ github.event.before }}"
       - uses: 'actions/setup-go@v5'
         with:
           go-version: '1.20'
+      - name: 'Install EditorConfig Lint'
+        run: go install 'github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest'
       - name: 'Check EditorConfig Lint'
-        run: |
-          sudo apt install -y jq
-          go install 'github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest'
-
-          readarray -t changed_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.added_modified }}')"
-          ~/go/bin/editorconfig-checker ${changed_files[@]}
+        run: echo "$FILES" | xargs ~/go/bin/editorconfig-checker
+        env:
+          # NOTE: use env to pass the output in order to avoid possible injection attacks
+          FILES: "${{ steps.files.outputs.added_modified }}"
 
   typo:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,11 @@ jobs:
       - name: 'Get Changed Files'
         id: 'files'
         run: |
+          CHANGED_FILES=$(git diff --name-only "${BASE_SHA:-$BEFORE_SHA}...${HEAD_SHA:-GITHUB_REF}")
+          echo "::notice::Changed files: $CHANGED_FILES"
           {
             echo "added_modified<<EOF"
-            git diff --name-only "${BASE_SHA:-$BEFORE_SHA}...${HEAD_SHA:-GITHUB_REF}"
+            echo "$CHANGED_FILES"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
Seems that ci.yml includes a dead dependency action just to get list of changed files for the PR / push. This seems weird as the repo is all about git. Propose removing this extra dep with straightforward implementation that supports force push for the PR branches.
Also:
- github runners do have `jq` preinstalled, so that was redundant and now no longer needed. 
- separate the install step of the go dependency

<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
