### PR TITLE
feat(git-bulk): Add compatibility to match workspaces using environnement variable

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -120,9 +120,9 @@ function wsnameToCurrent () {
   while read -r workspace; do
     if [ -z "$workspace" ]; then continue; fi
     parseWsName "$workspace"
-    # compatibility with environnement variable inside .gitconfig:
+    # compatibility with environment variable inside .gitconfig:
     # use combination of `eval` and `realpath` to:
-    # 1. dereference possible environnement variable contained in $rwsdir
+    # 1. dereference possible environment variable contained in $rwsdir
     # 2. match workspaces even across different symlinks
     rwsdir_rp=$(eval realpath $rwsdir 2>/dev/null)
     pwd_rp=$(eval realpath $PWD 2>/dev/null)

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -120,7 +120,14 @@ function wsnameToCurrent () {
   while read -r workspace; do
     if [ -z "$workspace" ]; then continue; fi
     parseWsName "$workspace"
-    if echo "$PWD" | grep -o -q "$rwsdir"; then wsname="$rwsname" && return; fi
+    # compatibility with environnement variable inside .gitconfig:
+    # use combination of `eval` and `realpath` to:
+    # 1. dereference possible environnement variable contained in $rwsdir
+    # 2. match workspaces even across different symlinks
+    rwsdir_rp=$(eval realpath $rwsdir 2>/dev/null)
+    pwd_rp=$(eval realpath $PWD 2>/dev/null)
+    # if pwd and workspace directory match, use this workspace name as current workspace
+    if [[ "$pwd_rp" == "$rwsdir_rp" ]]; then wsname="$rwsname" && return; fi
   done <<< "$(listall)"
   # when here then not in workspace dir
   echo 1>&2 "error: you are not in a workspace directory. your registered workspaces are:" && \

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -127,7 +127,7 @@ function wsnameToCurrent () {
     rwsdir_rp=$(eval realpath $rwsdir 2>/dev/null)
     pwd_rp=$(eval realpath $PWD 2>/dev/null)
     # if pwd and workspace directory match, use this workspace name as current workspace
-    if [[ "$pwd_rp" == "$rwsdir_rp" ]]; then wsname="$rwsname" && return; fi
+    if [[ "$pwd_rp" =~ "$rwsdir_rp" ]]; then wsname="$rwsname" && return; fi
   done <<< "$(listall)"
   # when here then not in workspace dir
   echo 1>&2 "error: you are not in a workspace directory. your registered workspaces are:" && \


### PR DESCRIPTION
# Problem

With the current implementation of `git-bulk` (`df53711` at the time of writing), using environment variables inside the `~/.gitconfig` file to specify a `bulk` workspace works partially.

For example, let's say that `$MYWORKSPACE` is set to `~/myworkspace`.
Let's say we use the following configuration in `~/.gitconfig`:
```bash
[bulkworkspaces]
    myworkspace = $MYWORKSPACE
```
Next, what currently **is working** is the following command, using `status` as a demo command to test `git-bulk`:
```bash
git bulk -w myworkspace status
```
But what is **not working** is the following:
```bash
cd ~/myworkspace && git bulk status
```

However, it is expected to **either** work or not work in the both situations.

# Rationale

I think it would be a good feature to have it working in both situations.
In this way, it would allow to easily use the same workspace name with different paths for different hosts, for example.

# Solution

In the function that test whether our shell `$PWD` is in a workspace or not, I simply dereference variable values if there is any and I use the `realpath` of both `$PWD` and the workspace directory.
In addition to enabling full usage of environnement variable, this allows to match a workspace directory even if there is a mismatch between our `$PWD` and the workspace directory because of a symlink. 