### PR TITLE
Feat: allow git-summary showing full path of repository

### DIFF
--- a/bin/git-summary
+++ b/bin/git-summary
@@ -3,12 +3,16 @@
 
 cd "$(git root)" || { echo "Can't cd to top level directory";exit 1; }
 
+PROJECT_FULL_PATH=
 SUMMARY_BY_LINE=
 DEDUP_BY_EMAIL=
 MERGES_ARG=
 OUTPUT_STYLE=
 for arg in "$@"; do
     case "$arg" in
+        --full-path)
+            PROJECT_FULL_PATH=1
+            ;;
         --line)
             SUMMARY_BY_LINE=1
             ;;
@@ -51,7 +55,12 @@ if [ -n "$SUMMARY_BY_LINE" ]; then
 else
   [ $# -ne 0 ] && commit=$*
 fi
-project=${PWD##*/}
+
+if [[ -n "$PROJECT_FULL_PATH" ]]; then
+  project=${PWD/${HOME}/\~}
+else
+  project=${PWD##*/}
+fi
 
 #
 # get date for the given <commit>

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -349,6 +349,7 @@ _git-standup() {
 }
 
 _git-summary() {
+    _arguments '--full-path[show repository full path]'
     _arguments '--line[summarize with lines rather than commits]'
     _arguments '--dedup-by-email[remove duplicate users by the email address]'
     _arguments '--no-merges[exclude merge commits]'

--- a/man/git-summary.1
+++ b/man/git-summary.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "GIT\-SUMMARY" "1" "June 2023" "" "Git Extras"
+.TH "GIT\-SUMMARY" "1" "February 2025" "" "Git Extras"
 .SH "NAME"
 \fBgit\-summary\fR \- Show repository summary
 .SH "SYNOPSIS"
@@ -37,6 +37,10 @@ $ git summary \-\-dedup\-by\-email
 \-\-no\-merges
 .P
 Exclude merge commits\.
+.P
+\-\-full\-path
+.P
+Show the full path of the repository instead of its directory name\.
 .P
 \-\-line
 .P

--- a/man/git-summary.html
+++ b/man/git-summary.html
@@ -114,6 +114,10 @@ $ git summary --dedup-by-email
 
 <p>Exclude merge commits.</p>
 
+<p>--full-path</p>
+
+<p>Show the full path of the repository instead of its directory name.</p>
+
 <p>--line</p>
 
 <p>Summarize with lines other than commits.
@@ -221,7 +225,7 @@ git-extras / age: 13 years / last active: 7 hours ago / active on 807 days / com
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>June 2023</li>
+    <li class='tc'>February 2025</li>
     <li class='tr'>git-summary(1)</li>
   </ol>
 

--- a/man/git-summary.md
+++ b/man/git-summary.md
@@ -39,6 +39,10 @@ Shows a summary of the repository or a path within it.
 
   Exclude merge commits.
 
+  --full-path
+
+  Show the full path of the repository instead of its directory name.
+
   --line
 
   Summarize with lines other than commits.

--- a/man/index.txt
+++ b/man/index.txt
@@ -12,8 +12,8 @@ git-clear-soft(1) git-clear-soft
 git-clear(1) git-clear
 git-coauthor(1) git-coauthor
 git-commits-since(1) git-commits-since
-git-contrib(1) git-contrib
 git-continue(1) git-continue
+git-contrib(1) git-contrib
 git-count(1) git-count
 git-cp(1) git-cp
 git-create-branch(1) git-create-branch


### PR DESCRIPTION
Add a very simple `--full-path` option to `git-summary` allowing to show the full path of a repository instead of its directory name. This may be useful (or necessary) when you have different repositories with the same name (*e.g.*, same repo on local computer and on a mounted network host or mounted external storage device).