### PR TITLE
feat(git-bulk): add new option to no follow symlinks

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -15,13 +15,12 @@ no_follow_symlinks=false
 # print usage message
 #
 usage() {
-  echo 1>&2 "usage: git bulk [-q|--quiet] [-g] ([-a]|[-w <ws-name>]) <git command>"
+  echo 1>&2 "usage: git bulk [--no-follow-symlinks] [-q|--quiet] [-g] ([-a]|[-w <ws-name>]) <git command>"
   echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory> (--from <URL or file>)"
   echo 1>&2 "       git bulk --removeworkspace <ws-name>"
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
   echo 1>&2 "       git bulk --purge"
   echo 1>&2 "       git bulk --listall"
-  echo 1>&2 "       git bulk --no-follow-symlinks"
 }
 
 cdfail() {

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -155,7 +155,7 @@ function executBulkOp () {
       find_flags+=(-L)
     fi
     # find all git repositories under the workspace on which we want to operate
-    allGitFolders=( $(eval find $find_flags . -name ".git" 2>/dev/null) )
+    readarray allGitFolders < <(find "${find_flags[@]}" . -name ".git" 2>/dev/null)
 
     for line in "${allGitFolders[@]}"; do
       local gitrepodir=${line::${#line}-5} # cut the .git part of find results to have the root git directory of that repository

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -9,6 +9,7 @@ guardedmode=false
 singlemode=false
 allwsmode=false
 quiet=false
+no_follow_symlinks=false
 
 #
 # print usage message
@@ -20,6 +21,7 @@ usage() {
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
   echo 1>&2 "       git bulk --purge"
   echo 1>&2 "       git bulk --listall"
+  echo 1>&2 "       git bulk --no-follow-symlinks"
 }
 
 cdfail() {
@@ -146,7 +148,15 @@ function executBulkOp () {
     local actual=$PWD
     [ "${quiet?}" != "true" ] && echo 1>&2 "Executing bulk operation in workspace ${inverse}$actual${reset}"
 
-    allGitFolders=( $(eval find -L . -name ".git" 2>/dev/null) )
+    # build `find` flags depending on command-line options
+    local find_flags=()
+    if [[ "$no_follow_symlinks" == true ]]; then
+      find_flags+=(-P)
+    else
+      find_flags+=(-L)
+    fi
+    # find all git repositories under the workspace on which we want to operate
+    allGitFolders=( $(eval find $find_flags . -name ".git" 2>/dev/null) )
 
     for line in "${allGitFolders[@]}"; do
       local gitrepodir=${line::${#line}-5} # cut the .git part of find results to have the root git directory of that repository
@@ -172,6 +182,8 @@ while [ "${#}" -ge 1 ] ; do
       butilcommand="${1:2}" && break ;;
     --removeworkspace|--addcurrent|--addworkspace)
       butilcommand="${1:2}" && wsname="$2" && wsdir="$3" && if [ "$4" == "--from" ]; then source="$5"; fi && break ;;
+    --no-follow-symlinks)
+      no_follow_symlinks=true ;;
     -a)
       allwsmode=true ;;
     -g)

--- a/man/git-bulk.1
+++ b/man/git-bulk.1
@@ -1,10 +1,10 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "GIT\-BULK" "1" "September 2024" "" "Git Extras"
+.TH "GIT\-BULK" "1" "February 2025" "" "Git Extras"
 .SH "NAME"
 \fBgit\-bulk\fR \- Run git commands on multiple repositories
 .SH "SYNOPSIS"
-\fBgit\-bulk\fR [\-g] ([\-a]|[\-w
+\fBgit\-bulk\fR [\-g] [\-\-no\-follow\-symlinks] ([\-a]|[\-w
 .br
 \fBgit\-bulk\fR \-\-addworkspace
 .br
@@ -32,6 +32,10 @@ Run a git command on all workspaces and their repositories\.
 \-g
 .P
 Ask the user for confirmation on every execution\.
+.P
+\-\-no\-follow\-symlinks
+.P
+Do not traverse symbolic links under the workspace when searching for git repositories\.
 .P
 \-w <ws\-name>
 .P

--- a/man/git-bulk.html
+++ b/man/git-bulk.html
@@ -77,7 +77,7 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-bulk</code> [-g] ([-a]|[-w <ws-name>]) <git command> </git></ws-name><br>
+<p><code>git-bulk</code> [-g] [--no-follow-symlinks] ([-a]|[-w <ws-name>]) <git command> </git></ws-name><br>
 <code>git-bulk</code> --addworkspace <ws-name> <ws-root-directory> (--from <url or file>) </url></ws-root-directory></ws-name><br>
 <code>git-bulk</code> --removeworkspace &lt;ws-name&gt; <br>
 <code>git-bulk</code> --addcurrent &lt;ws-name&gt; <br>
@@ -104,6 +104,10 @@
 <p>-g</p>
 
 <p>Ask the user for confirmation on every execution.</p>
+
+<p>--no-follow-symlinks</p>
+
+<p>Do not traverse symbolic links under the workspace when searching for git repositories.</p>
 
 <p>-w &lt;ws-name&gt;</p>
 
@@ -196,7 +200,7 @@ $ git bulk --purge
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>September 2024</li>
+    <li class='tc'>February 2025</li>
     <li class='tr'>git-bulk(1)</li>
   </ol>
 

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -3,7 +3,7 @@ git-bulk(1) -- Run git commands on multiple repositories
 
 ## SYNOPSIS
 
-`git-bulk` [-g] ([-a]|[-w &lt;ws-name&gt;]) &lt;git command&gt; <br/>
+`git-bulk` [-g] [--no-follow-symlinks] ([-a]|[-w &lt;ws-name&gt;]) &lt;git command&gt; <br/>
 `git-bulk` --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt; (--from &lt;URL or file&gt;) <br/>
 `git-bulk` --removeworkspace &lt;ws-name&gt; <br/>
 `git-bulk` --addcurrent &lt;ws-name&gt; <br/>
@@ -27,6 +27,10 @@ git bulk adds convenient support for operations that you want to execute on mult
   -g
 
   Ask the user for confirmation on every execution.
+
+  --no-follow-symlinks
+
+  Do not traverse symbolic links under the workspace when searching for git repositories.
 
   -w &lt;ws-name&gt;
 

--- a/man/index.txt
+++ b/man/index.txt
@@ -12,8 +12,8 @@ git-clear-soft(1) git-clear-soft
 git-clear(1) git-clear
 git-coauthor(1) git-coauthor
 git-commits-since(1) git-commits-since
-git-contrib(1) git-contrib
 git-continue(1) git-continue
+git-contrib(1) git-contrib
 git-count(1) git-count
 git-cp(1) git-cp
 git-create-branch(1) git-create-branch


### PR DESCRIPTION
Add a new option `--no-follow-symlinks` for `git-bulk` to not traverse symlinks under the workspace directories when searching for git repositories. This PR does not change the default behavior, it only add the option for the user.
