### PR TITLE
feat(git-bulk): add new option to not follow hidden directories

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -16,13 +16,12 @@ no_follow_hidden=false
 # print usage message
 #
 usage() {
-  echo 1>&2 "usage: git bulk [--no-follow-symlinks] [-q|--quiet] [-g] ([-a]|[-w <ws-name>]) <git command>"
+  echo 1>&2 "usage: git bulk [--no-follow-symlinks] [--no-follow-hidden] [-q|--quiet] [-g] ([-a]|[-w <ws-name>]) <git command>"
   echo 1>&2 "       git bulk --addworkspace <ws-name> <ws-root-directory> (--from <URL or file>)"
   echo 1>&2 "       git bulk --removeworkspace <ws-name>"
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
   echo 1>&2 "       git bulk --purge"
   echo 1>&2 "       git bulk --listall"
-  echo 1>&2 "       git bulk --no-follow-hidden"
 }
 
 cdfail() {

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -10,6 +10,7 @@ singlemode=false
 allwsmode=false
 quiet=false
 no_follow_symlinks=false
+no_follow_hidden=false
 
 #
 # print usage message
@@ -21,6 +22,7 @@ usage() {
   echo 1>&2 "       git bulk --addcurrent <ws-name>"
   echo 1>&2 "       git bulk --purge"
   echo 1>&2 "       git bulk --listall"
+  echo 1>&2 "       git bulk --no-follow-hidden"
 }
 
 cdfail() {
@@ -172,7 +174,10 @@ function executBulkOp () {
       cd "$gitrepodir" || exit 1 # into git repo location
       local curdir=$PWD
       local leadingpath=${curdir#"${actual}"}
-      guardedExecution "$@"
+      # do not execute if we do not want to consider a ".git" directory under a hidden directory
+      if [[ ! ( $no_follow_hidden == true && "$leadingpath" =~ "/." ) ]]; then
+        guardedExecution "$@"
+      fi
       cd "$rwsdir" || exit 1 # back to origin location of last find command
     done
   done
@@ -193,6 +198,8 @@ while [ "${#}" -ge 1 ] ; do
       butilcommand="${1:2}" && wsname="$2" && wsdir="$3" && if [ "$4" == "--from" ]; then source="$5"; fi && break ;;
     --no-follow-symlinks)
       no_follow_symlinks=true ;;
+    --no-follow-hidden)
+      no_follow_hidden=true ;;
     -a)
       allwsmode=true ;;
     -g)

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -174,7 +174,7 @@ function executBulkOp () {
       local curdir=$PWD
       local leadingpath=${curdir#"${actual}"}
       # do not execute if we do not want to consider a ".git" directory under a hidden directory
-      if [ $no_follow_hidden = false ] || ! [ "$leadingpath" =~ "/." ]; then
+      if [ $no_follow_hidden = false ] || ! [[ "$leadingpath" =~ "/." ]]; then
         guardedExecution "$@"
       fi
       cd "$rwsdir" || exit 1 # back to origin location of last find command

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -174,7 +174,7 @@ function executBulkOp () {
       local curdir=$PWD
       local leadingpath=${curdir#"${actual}"}
       # do not execute if we do not want to consider a ".git" directory under a hidden directory
-      if [[ ! ( $no_follow_hidden == true && "$leadingpath" =~ "/." ) ]]; then
+      if [ $no_follow_hidden = false ] || ! [ "$leadingpath" =~ "/." ]; then
         guardedExecution "$@"
       fi
       cd "$rwsdir" || exit 1 # back to origin location of last find command

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -135,6 +135,8 @@ _git-bulk() {
         '-g[Ask the user for confirmation on every execution (guarded mode).]' \
         '-w[Run the git command on the specified workspace.]:workspace-name:__gitex_workspace_names' \
         '-q[Suppress bulk output about current execution (quiet mode).]' \
+        '--no-follow-symlinks[Do not traverse symbolic links when searching for git repositories.]' \
+        '--no-follow-hidden[Do not traverse hidden directories when searching for git repositories.]' \
         '--addworkspace[Register a workspace for bulk operations.]' \
         '--removeworkspace[Remove the specified workspace.]:workspace-name:__gitex_workspace_names' \
         '--addcurrent[Adds the current directory as workspace to git bulk operations]' \

--- a/man/git-bulk.1
+++ b/man/git-bulk.1
@@ -4,7 +4,7 @@
 .SH "NAME"
 \fBgit\-bulk\fR \- Run git commands on multiple repositories
 .SH "SYNOPSIS"
-\fBgit\-bulk\fR [\-g] [\-\-no\-follow\-symlinks] ([\-a]|[\-w
+\fBgit\-bulk\fR [\-g] [\-\-no\-follow\-symlinks] [\-\-no\-follow\-hidden] ([\-a]|[\-w
 .br
 \fBgit\-bulk\fR \-\-addworkspace
 .br
@@ -36,6 +36,10 @@ Ask the user for confirmation on every execution\.
 \-\-no\-follow\-symlinks
 .P
 Do not traverse symbolic links under the workspace when searching for git repositories\.
+.P
+\-\-no\-follow\-hidden
+.P
+Do not traverse hidden (dotted) directories under the workspace when searching for git repositories\.
 .P
 \-w <ws\-name>
 .P

--- a/man/git-bulk.html
+++ b/man/git-bulk.html
@@ -78,7 +78,7 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-bulk</code> [-g] [--no-follow-symlinks] ([-a]|[-w <ws-name>]) <git command> </git></ws-name><br>
+<p><code>git-bulk</code> [-g] [--no-follow-symlinks] [--no-follow-hidden] ([-a]|[-w <ws-name>]) <git command> </git></ws-name><br>
 <code>git-bulk</code> --addworkspace <ws-name> <ws-root-directory> (--from <url or file>) </url></ws-root-directory></ws-name><br>
 <code>git-bulk</code> --removeworkspace &lt;ws-name&gt; <br>
 <code>git-bulk</code> --addcurrent &lt;ws-name&gt; <br>
@@ -109,6 +109,10 @@
 <p>--no-follow-symlinks</p>
 
 <p>Do not traverse symbolic links under the workspace when searching for git repositories.</p>
+
+<p>--no-follow-hidden</p>
+
+<p>Do not traverse hidden (dotted) directories under the workspace when searching for git repositories.</p>
 
 <p>-w &lt;ws-name&gt;</p>
 

--- a/man/git-bulk.md
+++ b/man/git-bulk.md
@@ -3,7 +3,7 @@ git-bulk(1) -- Run git commands on multiple repositories
 
 ## SYNOPSIS
 
-`git-bulk` [-g] [--no-follow-symlinks] ([-a]|[-w &lt;ws-name&gt;]) &lt;git command&gt; <br/>
+`git-bulk` [-g] [--no-follow-symlinks] [--no-follow-hidden] ([-a]|[-w &lt;ws-name&gt;]) &lt;git command&gt; <br/>
 `git-bulk` --addworkspace &lt;ws-name&gt; &lt;ws-root-directory&gt; (--from &lt;URL or file&gt;) <br/>
 `git-bulk` --removeworkspace &lt;ws-name&gt; <br/>
 `git-bulk` --addcurrent &lt;ws-name&gt; <br/>
@@ -31,6 +31,10 @@ git bulk adds convenient support for operations that you want to execute on mult
   --no-follow-symlinks
 
   Do not traverse symbolic links under the workspace when searching for git repositories.
+
+  --no-follow-hidden
+
+  Do not traverse hidden (dotted) directories under the workspace when searching for git repositories.
 
   -w &lt;ws-name&gt;
 


### PR DESCRIPTION
Add a new option `--no-follow-hidden` for `git-bulk` to not traverse hidden directories (containing a dot at the beginning) under the workspace directories when searching for git repositories. This PR does not change the default behavior, it only adds the option for the user.

Note that on the implementation, I did not changed the way `find` is searching for directories. Instead, I checked using a regex before performing the operation if we are under a hidden directory. This was the easiest way I found.
