### PR TITLE
fix(git-bulk): quiet find errors by default

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -146,7 +146,7 @@ function executBulkOp () {
     local actual=$PWD
     [ "${quiet?}" != "true" ] && echo 1>&2 "Executing bulk operation in workspace ${inverse}$actual${reset}"
 
-    allGitFolders=( $(eval find -L . -name ".git") )
+    allGitFolders=( $(eval find -L . -name ".git" 2>/dev/null) )
 
     for line in "${allGitFolders[@]}"; do
       local gitrepodir=${line::${#line}-5} # cut the .git part of find results to have the root git directory of that repository


### PR DESCRIPTION
It may be a bad experience for a user to see a bunch of find errors (*e.g.*, file name too long, no permissions, *etc.*) when using `git-bulk`.  I feel like it is not the job of the tool to report all errors that `find` can throws when searching all files under a hierarchy. Therefore, I quiet the `find` errors by default in this PR. If showing its errors is really on purpose, maybe we could create a flag to do so?