### PR TITLE
fix(git-bulk): fix a bad integer expression

### DIFF
--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -129,7 +129,7 @@ function wsnameToCurrent () {
 
 # helper to check number of arguments.
 function allowedargcount () {
-	if [ "$paramcount" -ne "$1"  ] && [ "$paramcount" -ne "$2" ]; then
+	if [ "$paramcount" -ne "${1:-0}"  ] && [ "$paramcount" -ne "${2:-0}" ]; then
 		echo 1>&2 "error: wrong number of arguments" && usage;
 		exit 1;
 	fi


### PR DESCRIPTION
Fix a logic error inside the `allowedargcount()` function. This function may be called with one or two arguments. However, no default values are assigned to `$1` and `$2` that are used inside a numerical comparison. Therefore, when using a bad number of arguments for the following lines:

```
listall|purge) allowedargcount 1;;
addcurrent|removeworkspace) allowedargcount 2;;
```

Then, we would get the error `[: : integer expression expected`. To fix this, we assign the 0 default value to `$1` and `$2`, such that we trigger the error message destined to the user without any integer error when there is a bad number of argument and that the function is called with only 1 argument instead of 2.

<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
