### PR TITLE
Improvements to Bash completion

### DIFF
--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -1,6 +1,22 @@
 # shellcheck shell=bash
 # bash completion support for git-extras.
 
+_git_authors(){
+  __gitcomp "-l --list --no-email"
+}
+
+_git_browse(){
+  __git_complete_remote_or_refspec
+}
+
+_git_browse_ci(){
+  __git_complete_remote_or_refspec
+}
+
+_git_brv(){
+  __gitcomp "-r --reverse"
+}
+
 _git_changelog(){
   local s_opts=( '-a' '-l' '-t' '-f' '-s' '-n' '-p' '-x' '-h' '?' )
   local l_opts=(
@@ -20,14 +36,6 @@ _git_changelog(){
   merged_opts_str+="$(printf "%s " "${l_opts[@]}")"
 
   __gitcomp "$merged_opts_str"
-}
-
-_git_authors(){
-  __gitcomp "-l --list --no-email"
-}
-
-_git_brv(){
-  __gitcomp "-r --reverse"
 }
 
 _git_coauthor(){
@@ -136,6 +144,10 @@ _git_ignore(){
   esac
 }
 
+_git_info(){
+  __gitcomp "--color -c --no-config"
+}
+
 _git_missing(){
     # Suggest all known refs
     __gitcomp "$(git for-each-ref --format='%(refname:short)')"
@@ -158,15 +170,15 @@ _git_reauthor(){
    __gitcomp "${comp}"
 }
 
-_git_scp(){
-  __git_complete_remote_or_refspec
-}
-
-_git_stamp(){
-  __gitcomp '--replace -r'
+_git_rename_file() {
+  __gitcomp "-h --help"
 }
 
 _git_rscp(){
+  __git_complete_remote_or_refspec
+}
+
+_git_scp(){
   __git_complete_remote_or_refspec
 }
 
@@ -174,22 +186,10 @@ _git_squash(){
   __gitcomp "$(__git_heads)"
 }
 
+_git_stamp(){
+  __gitcomp '--replace -r'
+}
+
 _git_undo(){
    __gitcomp "--hard --soft -h -s"
-}
-
-_git_info(){
-  __gitcomp "--color -c --no-config"
-}
-
-_git_browse(){
-  __git_complete_remote_or_refspec
-}
-
-_git_browse_ci(){
-  __git_complete_remote_or_refspec
-}
-
-_git_rename_file() {
-  __gitcomp "-h --help"
 }

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -186,6 +186,12 @@ _git_rename_remote(){
   fi
 }
 
+_git_rename_tag(){
+  if ((COMP_CWORD == 2 || COMP_CWORD == 3)); then
+    __gitcomp "$(__git_tags)"
+  fi
+}
+
 _git_rscp(){
   __git_complete_remote_or_refspec
 }

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -176,10 +176,6 @@ _git_rename_branch(){
   fi
 }
 
-_git_rename_file() {
-  __gitcomp "-h --help"
-}
-
 _git_rename_remote(){
   if ((COMP_CWORD == 2 || COMP_CWORD == 3)); then
     __gitcomp "$(__git_remotes)"

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -170,6 +170,12 @@ _git_reauthor(){
    __gitcomp "${comp}"
 }
 
+_git_rename_branch(){
+  if ((COMP_CWORD == 2 || COMP_CWORD == 3)); then
+    __gitcomp "$(__git_heads)"
+  fi
+}
+
 _git_rename_file() {
   __gitcomp "-h --help"
 }

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -180,6 +180,12 @@ _git_rename_file() {
   __gitcomp "-h --help"
 }
 
+_git_rename_remote(){
+  if ((COMP_CWORD == 2 || COMP_CWORD == 3)); then
+    __gitcomp "$(__git_remotes)"
+  fi
+}
+
 _git_rscp(){
   __git_complete_remote_or_refspec
 }

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -170,22 +170,22 @@ _git_reauthor(){
    __gitcomp "${comp}"
 }
 
-_git_rename_branch(){
+__git_extras_rename(){
   if ((COMP_CWORD == 2 || COMP_CWORD == 3)); then
-    __gitcomp "$(__git_heads)"
+    __gitcomp "$1"
   fi
+}
+
+_git_rename_branch(){
+  __git_extras_rename "$(__git_heads)"
 }
 
 _git_rename_remote(){
-  if ((COMP_CWORD == 2 || COMP_CWORD == 3)); then
-    __gitcomp "$(__git_remotes)"
-  fi
+  __git_extras_rename "$(__git_remotes)"
 }
 
 _git_rename_tag(){
-  if ((COMP_CWORD == 2 || COMP_CWORD == 3)); then
-    __gitcomp "$(__git_tags)"
-  fi
+  __git_extras_rename "$(__git_tags)"
 }
 
 _git_rscp(){


### PR DESCRIPTION
* Add Bash completion for `rename-branch`, `rename-remote` and `remote-tag` commands.
* Remove Bash completion for `rename-file`, which only included `-h` and `--help` options: I find it more sensible to use existing file paths, instead; also, base `git` completion doesn't include `--help` options.

For convenience, this shows the actual changes after the existing functions were sorted alphabetically: https://github.com/danpaolella/git-extras/compare/6e41685...danpaolella:git-extras:bash-completion.

I'm not using Zsh and fish, but I can give a try at those too, if consistency is required.