### PR TITLE
Fix minor typo in `git rename-branch` man page

### DIFF
--- a/man/git-rename-branch.1
+++ b/man/git-rename-branch.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-RENAME\-BRANCH" "1" "July 2019" "" "Git Extras"
+.TH "GIT\-RENAME\-BRANCH" "1" "September 2025" "" "Git Extras"
 .
 .SH "NAME"
 \fBgit\-rename\-branch\fR \- rename local branch and push to remote
@@ -10,26 +10,19 @@
 \fBgit\-rename\-branch\fR <old\-branch> <new\-branch>
 .
 .SH "DESCRIPTION"
-.
-.nf
-
 Rename local branch and push the new branch to remote
 .
-.fi
-.
 .SH "OPTIONS"
-.
-.nf
-
 <old\-branch>
-
-Old branch whose has to be renamed\. This is an optional parameter\. If no value is supplied then the current branch will be renamed\.
-
-<new\-branch>
-
-New branch name
 .
-.fi
+.P
+Old branch whose has to be renamed\. This is an optional parameter\. If no value is supplied then the current branch will be renamed\.
+.
+.P
+<new\-branch>
+.
+.P
+New branch name
 .
 .SH "EXAMPLES"
 .

--- a/man/git-rename-branch.1
+++ b/man/git-rename-branch.1
@@ -21,11 +21,11 @@ Rename local branch and push the new branch to remote
 .
 .nf
 
-&lt;old\-branch&gt;
+<old\-branch>
 
 Old branch whose has to be renamed\. This is an optional parameter\. If no value is supplied then the current branch will be renamed\.
 
-&lt;new\-branch&gt;
+<new\-branch>
 
 New branch name
 .

--- a/man/git-rename-branch.html
+++ b/man/git-rename-branch.html
@@ -80,19 +80,17 @@
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<pre><code>Rename local branch and push the new branch to remote
-</code></pre>
+<p>  Rename local branch and push the new branch to remote</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<pre><code>&amp;lt;old-branch&amp;gt;
+<p>  &lt;old-branch&gt;</p>
 
-Old branch whose has to be renamed. This is an optional parameter. If no value is supplied then the current branch will be renamed.
+<p>  Old branch whose has to be renamed. This is an optional parameter. If no value is supplied then the current branch will be renamed.</p>
 
-&amp;lt;new-branch&amp;gt;
+<p>  &lt;new-branch&gt;</p>
 
-New branch name
-</code></pre>
+<p>  New branch name</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -103,7 +101,7 @@ $ git rename-branch new-name
 
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Hozefa Jodiawalla &lt;<a href="&#109;&#97;&#105;&#x6c;&#x74;&#111;&#x3a;&#x68;&#x6f;&#122;&#x65;&#102;&#97;&#114;&#117;&#x6c;&#101;&#x73;&#64;&#103;&#109;&#x61;&#x69;&#x6c;&#46;&#99;&#x6f;&#x6d;" data-bare-link="true">&#x68;&#x6f;&#122;&#x65;&#x66;&#x61;&#114;&#117;&#x6c;&#x65;&#x73;&#x40;&#103;&#x6d;&#x61;&#105;&#x6c;&#x2e;&#99;&#x6f;&#109;</a>&gt;</p>
+<p>Written by Hozefa Jodiawalla &lt;<a href="&#109;&#x61;&#x69;&#x6c;&#x74;&#x6f;&#x3a;&#104;&#111;&#x7a;&#x65;&#x66;&#x61;&#114;&#117;&#108;&#x65;&#115;&#x40;&#x67;&#109;&#x61;&#x69;&#108;&#46;&#x63;&#x6f;&#109;" data-bare-link="true">&#x68;&#111;&#x7a;&#x65;&#102;&#97;&#114;&#x75;&#108;&#x65;&#115;&#64;&#103;&#x6d;&#97;&#x69;&#x6c;&#46;&#99;&#111;&#109;</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -116,7 +114,7 @@ $ git rename-branch new-name
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>July 2019</li>
+    <li class='tc'>September 2025</li>
     <li class='tr'>git-rename-branch(1)</li>
   </ol>
 

--- a/man/git-rename-branch.md
+++ b/man/git-rename-branch.md
@@ -7,17 +7,17 @@ git-rename-branch(1) -- rename local branch and push to remote
 
 ## DESCRIPTION
 
-    Rename local branch and push the new branch to remote
+  Rename local branch and push the new branch to remote
 
 ## OPTIONS
 
-    &lt;old-branch&gt;
+  &lt;old-branch&gt;
 
-    Old branch whose has to be renamed. This is an optional parameter. If no value is supplied then the current branch will be renamed.
+  Old branch whose has to be renamed. This is an optional parameter. If no value is supplied then the current branch will be renamed.
 
-    &lt;new-branch&gt;
+  &lt;new-branch&gt;
 
-    New branch name
+  New branch name
 
 ## EXAMPLES
 


### PR DESCRIPTION
Show the option as `<old-branch>` and `<new-branch>` instead of `&lt;old-branch&gt;` and `&lt;new-branch&gt;`.