### PR TITLE
Fix use of `git-whatchanged` to `git-log`

### DIFF
--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -34,10 +34,10 @@ fi
 
 status_opts=(--porcelain --short)
 # %ct: committer date, UNIX timestamp / %at: author date, UNIX timestamp
-whatchanged_opts=(--format='%ct')
+log_opts=(--format='%ct')
 if git status --help 2>&1 | grep -q -- "--no-renames"; then
   status_opts+=(--no-renames)
-  whatchanged_opts+=(--no-renames)
+  log_opts+=(--no-renames)
 fi
 if git status --help 2>&1 | grep -q -- "--untracked-files"; then
   status_opts+=(--untracked-files=no)
@@ -126,6 +126,6 @@ git --no-pager status "${status_opts[@]}" . \
   | cut -c 4- >"${tmpfile}"
 
 # prefix is not stripped:
-git --no-pager whatchanged "${whatchanged_opts[@]}" . \
+git --no-pager log --raw --no-merges "${log_opts[@]}" . \
   | awk "${awk_flags[@]}" "${awk_script}" "${tmpfile}" - \
   | BASH_ENV='' bash "${bash_opts[@]}" -


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->

This PR fixes the issue found in #1210.

Error:

```text
'git whatchanged' is nominated for removal.
If you still use this command, please add an extra
option, '--i-still-use-this', on the command line
and let us know you still use it by sending an e-mail
to <git@vger.kernel.org>.  Thanks.
fatal: refusing to run without --i-still-use-this
```

According to the `git-whatchanged` [manpage](https://git-scm.com/docs/git-whatchanged):

> New users are encouraged to use git-log[1] instead. The whatchanged command is essentially the same as git-log[1] but defaults to showing the raw format diff output and skipping merges.

This changes the `git whatchanged` invocation to the `git log --raw --no-merges` replacement. I tested this on a test repository and the output is the same:

```console
$ git whatchanged
commit 7769eb195aba87248c60ca980e7f79571595118b (branch-b)
Author: Edwin Kofler <edwin@kofler.dev>
Date:   Wed Aug 27 14:00:08 2025 -0700

    b

:000000 100644 0000000 e69de29 A        b

commit dfee73d1cbc201d048fc1accee3aefccab87e489 (branch-a)
Author: Edwin Kofler <edwin@kofler.dev>
Date:   Wed Aug 27 13:59:19 2025 -0700

    a commit

:000000 100644 0000000 e69de29 A        a

commit 5e09db44b2136b6dd1680c771e5d2048baafe9b3
Author: Edwin Kofler <edwin@kofler.dev>
Date:   Wed Aug 27 13:59:07 2025 -0700

    main first commit

:000000 100644 0000000 e69de29 A        main
```

```console
$ git log --raw --no-merges
commit 7769eb195aba87248c60ca980e7f79571595118b (branch-b)
Author: Edwin Kofler <edwin@kofler.dev>
Date:   Wed Aug 27 14:00:08 2025 -0700

    b

:000000 100644 0000000 e69de29 A        b

commit dfee73d1cbc201d048fc1accee3aefccab87e489 (branch-a)
Author: Edwin Kofler <edwin@kofler.dev>
Date:   Wed Aug 27 13:59:19 2025 -0700

    a commit

:000000 100644 0000000 e69de29 A        a

commit 5e09db44b2136b6dd1680c771e5d2048baafe9b3
Author: Edwin Kofler <edwin@kofler.dev>
Date:   Wed Aug 27 13:59:07 2025 -0700

    main first commit

:000000 100644 0000000 e69de29 A        main
```

I also tested by running `git-utimes` and it showed output that looks right with no errors.