### PR TITLE
feat: `delete-branch` multiple unique branch names completions

### DIFF
--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -1,6 +1,13 @@
 # shellcheck shell=bash
 # bash completion support for git-extras.
 
+__gitex_heads_unique() {
+  local branch specified=("${COMP_WORDS[@]:2}")
+  for branch in $(__git_heads); do
+    [[ " ${specified[*]} " == *" $branch "* ]] || printf '%s\n' "$branch"
+  done
+}
+
 _git_authors(){
   __gitcomp "-l --list --no-email"
 }
@@ -84,7 +91,7 @@ __git_cp(){
 }
 
 _git_delete_branch(){
-  __gitcomp "$(__git_heads)"
+  __gitcomp "$(__gitex_heads_unique)"
 }
 
 _git_delete_squashed_branches(){

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -72,6 +72,15 @@ __gitex_branch_names() {
     _wanted branch-names expl branch-name compadd $* - $branch_names
 }
 
+__gitex_branch_names_unique() {
+    local expl
+    declare -a branch_names already_specified
+    branch_names=(${${(f)"$(_call_program branchrefs git for-each-ref --format='"%(refname)"' refs/heads 2>/dev/null)"}#refs/heads/})
+    __gitex_command_successful || return
+    already_specified=(${words[2,-1]})
+    _wanted branch-names expl branch-name compadd -F already_specified $* - $branch_names
+}
+
 __gitex_specific_branch_names() {
     local expl
     declare -a branch_names
@@ -196,8 +205,7 @@ _git-create-branch() {
 }
 
 _git-delete-branch() {
-    _arguments \
-        ':branch-name:__gitex_branch_names'
+    __gitex_branch_names_unique
 }
 
 _git-delete-squashed-branches() {


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->

This PR improves `git delete-branch` bash and zsh completions by making them each accept multiple unique branch names.

The `__gitex_branch_names_unique` is identical to `__gitex_branch_names` (and corresponding in bash) except that:

- The added `-F` flag in zsh and the for loop in bash make it so that if a branch was already specified in the argument list, it doesn't get specified again.
- The `COMPWORDS[@]:2` and `${words[2,-1]}` stuff is there to make it so that the code doesn't include the `delete-branch` argument as one of the already deleted branches, which accounts for the admittedly very unlikely edgecase that `delete-branch` itself is a branch