### PR TITLE
Support passing ref to `git-commits-since`

### DIFF
--- a/bin/git-commits-since
+++ b/bin/git-commits-since
@@ -1,5 +1,36 @@
 #!/usr/bin/env bash
 
-SINCE="last week"
-test $# -ne 0 && SINCE=$*
-git log --pretty='%h: %an - %s' --after="@{$SINCE}"
+REF=""
+SINCE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -r|--ref)
+            if [[ -z "$2" ]]; then
+                echo "error: option $1 requires an argument" >&2
+                exit 1
+            fi
+            REF="$2"
+            shift
+            shift
+            ;;
+        *)
+            # non-flag args accumulation, e.g. "last " + "week" -> "last week"
+            SINCE="${SINCE:+$SINCE }$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "$REF" && -n "$SINCE" ]]; then
+    echo "error: '--ref <ref>' and '<date>' are mutually exclusive" >&2
+    exit 1
+fi
+
+SINCE="${SINCE:-last week}"
+
+if [[ -n "$REF" ]]; then
+    git log --pretty='%h %an - %s' "$REF..HEAD"
+else
+    git log --pretty='%h %an - %s' --after="@{$SINCE}"
+fi

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -82,6 +82,10 @@ _git_contrib(){
   COMPREPLY=($(compgen -W "$all" -- "$cur"))
 }
 
+_git_commits_since(){
+  __gitcomp "-r --ref"
+}
+
 _git_count(){
   __gitcomp "--all"
 }

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -171,6 +171,11 @@ _git-coauthor() {
         ':co-author-email[email address of co-author to add]:__gitex_author_emails'
 }
 
+_git-commits-since() {
+    _arguments \
+        '(-r --ref)'{-r,--ref}'[show commits since ref]'
+}
+
 _git-contrib() {
     _arguments \
         ':author:__gitex_author_names'

--- a/etc/git-extras.fish
+++ b/etc/git-extras.fish
@@ -131,6 +131,8 @@ function __fish_git_extra_coauthor_email
 end
 complete -c git -f -n '__fish_git_using_command coauthor; and __fish_git_arg_number 2' -a '(__fish_git_extra_coauthor_name)'
 complete -c git -f -n '__fish_git_using_command coauthor; and __fish_git_arg_number 3' -a '(__fish_git_extra_coauthor_email)'
+# commits-since
+complete -c git -f -n '__fish_git_using_command commits-since' -s r -l ref -d 'show commits since ref'
 # count
 complete -c git -f -n '__fish_git_using_command count' -l all -d 'detailed commit count'
 # create-branch

--- a/man/git-commits-since.1
+++ b/man/git-commits-since.1
@@ -4,13 +4,20 @@
 .SH "NAME"
 \fBgit\-commits\-since\fR \- Show commit logs since some date
 .SH "SYNOPSIS"
-\fBgit\-commits\-since\fR [<date>]
+.TS
+allbox;
+\fBgit\-commits\-since\fR [\-r	\-\-ref <ref>] [<date>]
+.TE
 .SH "DESCRIPTION"
-List of commits since the given \fIdate\fR\.
+List of commits since the given \fIdate\fR or \fIref\fR\.
 .SH "OPTIONS"
 <date>
 .P
-Show commits more recent than \fIdate\fR\. By default, the command shows the commit logs since "last week"\.
+Show commits more recent than <date>\. By default, the command shows the commit logs since "last week"\.
+.P
+\-r, \-\-ref <ref>
+.P
+Show commits since the given ref (tag, branch, or commit)\. When specified, the command uses \fBref\.\.HEAD\fR instead of date\-based filtering\.
 .SH "EXAMPLES"
 It is really flexible and these are only 3 of the options, go ahead give it a try:
 .IP "" 4
@@ -28,6 +35,13 @@ $ git commits\-since 2 hour ago
 aa084d9 TweeKane \- Add global gitignore to git\-ignore output
 515e94a TJ Holowaychuk \- Merge pull request #128 from nickl\-/git\-extras\-html\-hyperlinks
 5f86b54 TJ Holowaychuk \- Merge pull request #129 from nickl\-/develop
+
+$ git commits\-since \-\-ref 7\.4\.0
+6ed2643 John Bachir \- ability to specify command when hitting enter (#1223)
+b9bd309 John Bachir \- Improve `git\-repl` prompt (#1224)
+6f4cf0c johnpyp \- feat: `delete\-branch` multiple unique branch names completions (#1221)
+\|\.\|\.\|\.
+215382b 罗泽轩 \- Bump version to 7\.5\.0\-dev (#1207)
 .fi
 .IP "" 0
 .SH "AUTHOR"

--- a/man/git-commits-since.html
+++ b/man/git-commits-since.html
@@ -77,17 +77,29 @@
 </p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-commits-since</code> [&lt;date&gt;]</p>
+<table>
+  <tbody>
+    <tr>
+      <td>
+<code>git-commits-since</code> [-r</td>
+      <td>--ref &lt;ref&gt;] [&lt;date&gt;]</td>
+    </tr>
+  </tbody>
+</table>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>List of commits since the given <em>date</em>.</p>
+<p>List of commits since the given <em>date</em> or <em>ref</em>.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <p>&lt;date&gt;</p>
 
-<p>Show commits more recent than <var>date</var>. By default, the command shows the commit logs since "last week".</p>
+<p>Show commits more recent than &lt;date&gt;. By default, the command shows the commit logs since "last week".</p>
+
+<p>-r, --ref &lt;ref&gt;</p>
+
+<p>Show commits since the given ref (tag, branch, or commit). When specified, the command uses <code>ref..HEAD</code> instead of date-based filtering.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -106,6 +118,13 @@ $ git commits-since 2 hour ago
 aa084d9 TweeKane - Add global gitignore to git-ignore output
 515e94a TJ Holowaychuk - Merge pull request #128 from nickl-/git-extras-html-hyperlinks
 5f86b54 TJ Holowaychuk - Merge pull request #129 from nickl-/develop
+
+$ git commits-since --ref 7.4.0
+6ed2643 John Bachir - ability to specify command when hitting enter (#1223)
+b9bd309 John Bachir - Improve `git-repl` prompt (#1224)
+6f4cf0c johnpyp - feat: `delete-branch` multiple unique branch names completions (#1221)
+...
+215382b 罗泽轩 - Bump version to 7.5.0-dev (#1207)
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>

--- a/man/git-commits-since.md
+++ b/man/git-commits-since.md
@@ -3,17 +3,21 @@ git-commits-since(1) -- Show commit logs since some date
 
 ## SYNOPSIS
 
-`git-commits-since` [&lt;date&gt;]
+`git-commits-since` [-r|--ref &lt;ref&gt;] [&lt;date&gt;]
 
 ## DESCRIPTION
 
-  List of commits since the given _date_.
+  List of commits since the given _date_ or _ref_.
 
 ## OPTIONS
 
   &lt;date&gt;
 
-  Show commits more recent than <date>. By default, the command shows the commit logs since "last week".
+  Show commits more recent than &lt;date&gt;. By default, the command shows the commit logs since "last week".
+
+  -r, --ref &lt;ref&gt;
+
+  Show commits since the given ref (tag, branch, or commit). When specified, the command uses `ref..HEAD` instead of date-based filtering.
 
 ## EXAMPLES
 
@@ -33,6 +37,12 @@ git-commits-since(1) -- Show commit logs since some date
     515e94a TJ Holowaychuk - Merge pull request #128 from nickl-/git-extras-html-hyperlinks
     5f86b54 TJ Holowaychuk - Merge pull request #129 from nickl-/develop
 
+    $ git commits-since --ref 7.4.0
+    6ed2643 John Bachir - ability to specify command when hitting enter (#1223)
+    b9bd309 John Bachir - Improve `git-repl` prompt (#1224)
+    6f4cf0c johnpyp - feat: `delete-branch` multiple unique branch names completions (#1221)
+    ...
+    215382b 罗泽轩 - Bump version to 7.5.0-dev (#1207)
 
 ## AUTHOR
 


### PR DESCRIPTION
The commits-since command only considers dates. It's useful to dump a list of commits based on a ref, i.e. a tag, branch, or even another commit. This patch introduces a new optional '--ref|-r' flag that toggles a ref-specific variant of 'git log'.

Docs for the respective module has been updated & regenerated as well.

<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
