### PR TITLE
Fix `git-changelog` to handle whitespace in command arguments 

### DIFF
--- a/bin/git-changelog
+++ b/bin/git-changelog
@@ -9,6 +9,15 @@ GIT_MERGELOG_FORMAT="$(git config changelog.mergeformat)"
 GIT_EDITOR="$(git var GIT_EDITOR)"
 PROGNAME="git-changelog"
 
+git_editor() {
+  if test -z "${GIT_EDITOR:+set}"
+  then
+    GIT_EDITOR="$(git var GIT_EDITOR)" || return $?
+  fi
+
+  eval "$GIT_EDITOR" '"$@"'
+}
+
 _usage() {
 cat << EOF
 usage: $PROGNAME options [file]
@@ -574,7 +583,7 @@ main() {
     rm -f "$tmpfile"
 
     if [[ -n "$GIT_EDITOR" ]]; then
-      $GIT_EDITOR "$changelog" || _exit
+      git_editor "$changelog" || _exit
     else
       less "$changelog" || _exit
     fi


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
