### PR TITLE
feat: add git-delete-gone-branches command

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -18,6 +18,7 @@
  - [`git cp`](#git-cp)
  - [`git create-branch`](#git-create-branch)
  - [`git delete-branch`](#git-delete-branch)
+ - [`git delete-gone-branches`](#git-delete-gone-branches)
  - [`git delete-merged-branches`](#git-delete-merged-branches)
  - [`git delete-squashed-branches`](#git-delete-squashed-branches)
  - [`git delete-submodule`](#git-delete-submodule)
@@ -930,6 +931,21 @@ Delete local and remote tag `name`:
 
 ```bash
 $ git delete-tag 0.0.1
+```
+
+## git delete-gone-branches
+
+Deletes all local branches whose remote-tracking branch has been deleted (i.e. branches shown as `[gone]` in `git branch -vv`). Use `--dry-run` to preview what would be deleted.
+
+```bash
+$ git delete-gone-branches
+Deleted branch feature-123 (was abc1234).
+Deleted branch feature-456 (was def5678).
+
+$ git delete-gone-branches --dry-run
+Would delete the following branches:
+  feature-123
+  feature-456
 ```
 
 ## git delete-merged-branches

--- a/bin/git-delete-gone-branches
+++ b/bin/git-delete-gone-branches
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 dry_run=false
+force=false
+prune=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -10,15 +12,28 @@ while [[ $# -gt 0 ]]; do
       dry_run=true
       shift
       ;;
+    -f|--force)
+      force=true
+      shift
+      ;;
+    -p|--prune)
+      prune=true
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: git delete-gone-branches [-n|--dry-run]"
+      echo "Usage: git delete-gone-branches [-n|--dry-run] [-f|--force] [-p|--prune]"
       exit 1
       ;;
   esac
 done
 
-gone_branches=$(git branch -vv | awk '/: gone\]/{print $1}')
+if [ "$prune" = true ]; then
+  git fetch --prune
+fi
+
+gone_branches=$(git for-each-ref --format \
+  '%(if:equals=[gone])%(upstream:track,nobracket)%(then)%(refname:short)%(end)' refs/heads/ | sed '/^$/d')
 
 if [ -z "$gone_branches" ]; then
   echo "No branches with a gone remote found."
@@ -29,6 +44,17 @@ if [ "$dry_run" = true ]; then
   echo "Would delete the following branches:"
   echo "$gone_branches"
   exit 0
+fi
+
+echo "The following branches will be deleted:"
+echo "$gone_branches"
+
+if [ "$force" = false ]; then
+  read -r -p "Delete these branches? [y/N] " confirm
+  if [[ ! "$confirm" =~ ^[yY]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
 fi
 
 echo "$gone_branches" | xargs git branch -D

--- a/bin/git-delete-gone-branches
+++ b/bin/git-delete-gone-branches
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--dry-run)
+      dry_run=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: git delete-gone-branches [-n|--dry-run]"
+      exit 1
+      ;;
+  esac
+done
+
+gone_branches=$(git branch -vv | awk '/: gone\]/{print $1}')
+
+if [ -z "$gone_branches" ]; then
+  echo "No branches with a gone remote found."
+  exit 0
+fi
+
+if [ "$dry_run" = true ]; then
+  echo "Would delete the following branches:"
+  echo "$gone_branches"
+  exit 0
+fi
+
+echo "$gone_branches" | xargs git branch -D

--- a/bin/git-delete-gone-branches
+++ b/bin/git-delete-gone-branches
@@ -33,7 +33,7 @@ if [ "$prune" = true ]; then
 fi
 
 gone_branches=$(git for-each-ref --format \
-  '%(if:equals=[gone])%(upstream:track,nobracket)%(then)%(refname:short)%(end)' refs/heads/ | sed '/^$/d')
+  '%(if:equals=gone)%(upstream:track,nobracket)%(then)%(refname:short)%(end)' refs/heads/ | sed '/^$/d')
 
 if [ -z "$gone_branches" ]; then
   echo "No branches with a gone remote found."

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -213,6 +213,11 @@ _git-delete-branch() {
     __gitex_branch_names_unique
 }
 
+_git-delete-gone-branches() {
+    _arguments \
+        '(-n --dry-run)'{-n,--dry-run}'[show branches that would be deleted without deleting]'
+}
+
 _git-delete-squashed-branches() {
     _arguments \
         ':branch-name:__gitex_branch_names'
@@ -421,6 +426,7 @@ zstyle ':completion:*:*:git:*' user-commands $existing_user_commands \
     count:'show commit count' \
     create-branch:'create branches' \
     delete-branch:'delete branches' \
+    delete-gone-branches:'delete branches whose remote is gone' \
     delete-merged-branches:'delete merged branches' \
     delete-squashed-branches:'delete squashed branches' \
     delete-submodule:'delete submodules' \

--- a/man/git-delete-gone-branches.1
+++ b/man/git-delete-gone-branches.1
@@ -1,0 +1,54 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "GIT\-DELETE\-GONE\-BRANCHES" "1" "March 2026" "" "Git Extras"
+.
+.SH "NAME"
+\fBgit\-delete\-gone\-branches\fR \- Delete branches whose remote is gone
+.
+.SH "SYNOPSIS"
+\fBgit\-delete\-gone\-branches\fR [\-n|\-\-dry\-run] [\-f|\-\-force] [\-p|\-\-prune]
+.
+.SH "DESCRIPTION"
+Deletes all local branches whose remote\-tracking branch has been deleted\. This commonly happens after a pull request is merged and the remote branch is removed\. By default, lists the branches and prompts for confirmation before deleting\.
+.
+.SH "OPTIONS"
+\-n, \-\-dry\-run
+.
+.P
+Show the branches that would be deleted without actually deleting them\.
+.
+.P
+\-f, \-\-force
+.
+.P
+Skip the confirmation prompt and delete branches immediately\.
+.
+.P
+\-p, \-\-prune
+.
+.P
+Run \fBgit fetch \-\-prune\fR before checking for gone branches, to ensure remote\-tracking refs are up to date\.
+.
+.SH "EXAMPLES"
+.
+.nf
+
+$ git delete\-gone\-branches
+
+$ git delete\-gone\-branches \-\-dry\-run
+
+$ git delete\-gone\-branches \-\-force
+
+$ git delete\-gone\-branches \-\-prune
+.
+.fi
+.
+.SH "AUTHOR"
+Written by Utsav Sabharwal <\fIutsav\.sabharwal@sysdig\.com\fR>
+.
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-delete-gone-branches.1
+++ b/man/git-delete-gone-branches.1
@@ -45,7 +45,7 @@ $ git delete\-gone\-branches \-\-prune
 .fi
 .
 .SH "AUTHOR"
-Written by Utsav Sabharwal <\fIutsav\.sabharwal@sysdig\.com\fR>
+Written by Utsav Sabharwal <\fIhttps://github\.com/codersofthedark\fR>
 .
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>

--- a/man/git-delete-gone-branches.html
+++ b/man/git-delete-gone-branches.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-delete-gone-branches(1) - Delete branches whose remote is gone</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-delete-gone-branches(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-delete-gone-branches(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-delete-gone-branches</code> - <span class="man-whatis">Delete branches whose remote is gone</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-delete-gone-branches</code> [-n|--dry-run] [-f|--force] [-p|--prune]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>  Deletes all local branches whose remote-tracking branch has been deleted.
+  This commonly happens after a pull request is merged and the remote branch
+  is removed. By default, lists the branches and prompts for confirmation
+  before deleting.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -n, --dry-run</p>
+
+<p>  Show the branches that would be deleted without actually deleting them.</p>
+
+<p>  -f, --force</p>
+
+<p>  Skip the confirmation prompt and delete branches immediately.</p>
+
+<p>  -p, --prune</p>
+
+<p>  Run <code>git fetch --prune</code> before checking for gone branches, to ensure
+  remote-tracking refs are up to date.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<pre><code>$ git delete-gone-branches
+
+$ git delete-gone-branches --dry-run
+
+$ git delete-gone-branches --force
+
+$ git delete-gone-branches --prune
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Utsav Sabharwal &lt;<a href="&#x6d;&#97;&#105;&#x6c;&#x74;&#111;&#x3a;&#117;&#116;&#115;&#97;&#x76;&#x2e;&#115;&#x61;&#x62;&#x68;&#x61;&#x72;&#x77;&#x61;&#108;&#64;&#115;&#x79;&#x73;&#x64;&#105;&#x67;&#x2e;&#99;&#111;&#x6d;" data-bare-link="true">&#117;&#116;&#115;&#x61;&#x76;&#x2e;&#x73;&#x61;&#x62;&#104;&#97;&#x72;&#x77;&#97;&#108;&#64;&#x73;&#121;&#115;&#x64;&#105;&#103;&#46;&#x63;&#x6f;&#109;</a>&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>March 2026</li>
+    <li class='tr'>git-delete-gone-branches(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-delete-gone-branches.md
+++ b/man/git-delete-gone-branches.md
@@ -1,0 +1,36 @@
+git-delete-gone-branches(1) -- Delete branches whose remote is gone
+====================================================================
+
+## SYNOPSIS
+
+`git-delete-gone-branches` [-n|--dry-run]
+
+## DESCRIPTION
+
+  Deletes all local branches whose remote-tracking branch has been deleted
+  (i.e. branches marked as `[gone]` in `git branch -vv`). This commonly
+  happens after a pull request is merged and the remote branch is removed.
+
+## OPTIONS
+
+  -n, --dry-run
+
+  Show the branches that would be deleted without actually deleting them.
+
+## EXAMPLES
+
+    $ git delete-gone-branches
+
+    $ git delete-gone-branches --dry-run
+
+## AUTHOR
+
+Written by Utsav Sabharwal &lt;<utsav.sabharwal@sysdig.com>&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;

--- a/man/git-delete-gone-branches.md
+++ b/man/git-delete-gone-branches.md
@@ -39,7 +39,7 @@ git-delete-gone-branches(1) -- Delete branches whose remote is gone
 
 ## AUTHOR
 
-Written by Utsav Sabharwal &lt;<utsav.sabharwal@sysdig.com>&gt;
+Written by Utsav Sabharwal &lt;<https://github.com/codersofthedark>&gt;
 
 ## REPORTING BUGS
 

--- a/man/git-delete-gone-branches.md
+++ b/man/git-delete-gone-branches.md
@@ -3,13 +3,14 @@ git-delete-gone-branches(1) -- Delete branches whose remote is gone
 
 ## SYNOPSIS
 
-`git-delete-gone-branches` [-n|--dry-run]
+`git-delete-gone-branches` [-n|--dry-run] [-f|--force] [-p|--prune]
 
 ## DESCRIPTION
 
-  Deletes all local branches whose remote-tracking branch has been deleted
-  (i.e. branches marked as `[gone]` in `git branch -vv`). This commonly
-  happens after a pull request is merged and the remote branch is removed.
+  Deletes all local branches whose remote-tracking branch has been deleted.
+  This commonly happens after a pull request is merged and the remote branch
+  is removed. By default, lists the branches and prompts for confirmation
+  before deleting.
 
 ## OPTIONS
 
@@ -17,11 +18,24 @@ git-delete-gone-branches(1) -- Delete branches whose remote is gone
 
   Show the branches that would be deleted without actually deleting them.
 
+  -f, --force
+
+  Skip the confirmation prompt and delete branches immediately.
+
+  -p, --prune
+
+  Run `git fetch --prune` before checking for gone branches, to ensure
+  remote-tracking refs are up to date.
+
 ## EXAMPLES
 
     $ git delete-gone-branches
 
     $ git delete-gone-branches --dry-run
+
+    $ git delete-gone-branches --force
+
+    $ git delete-gone-branches --prune
 
 ## AUTHOR
 

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -46,6 +46,7 @@ git-extras(1) -- Awesome GIT utilities
    - **git-cp(1)** Copy a file keeping its history
    - **git-create-branch(1)** Create branches
    - **git-delete-branch(1)** Delete branches
+   - **git-delete-gone-branches(1)** Delete branches whose remote is gone
    - **git-delete-merged-branches(1)** Delete merged branches
    - **git-delete-squashed-branches(1)** Delete branches that were squashed
    - **git-delete-submodule(1)** Delete submodules

--- a/man/index.txt
+++ b/man/index.txt
@@ -18,6 +18,7 @@ git-count(1) git-count
 git-cp(1) git-cp
 git-create-branch(1) git-create-branch
 git-delete-branch(1) git-delete-branch
+git-delete-gone-branches(1) git-delete-gone-branches
 git-delete-merged-branches(1) git-delete-merged-branches
 git-delete-squashed-branches(1) git-delete-squashed-branches
 git-delete-submodule(1) git-delete-submodule


### PR DESCRIPTION
Closes #1220

## What

Adds a new `git delete-gone-branches` command that deletes all local branches whose remote-tracking branch has been deleted (shown as `[gone]` in `git branch -vv`).

## Why

After PRs are merged and remote branches are cleaned up on GitHub/GitLab, local branches are left behind with no remote. There's no existing git-extras command to clean these up — `git delete-merged-branches` handles a different case (merged but remote still exists).

## Usage

```bash
# Delete all gone branches
$ git delete-gone-branches
Deleted branch feature-123 (was abc1234).
Deleted branch feature-456 (was def5678).

# Preview without deleting
$ git delete-gone-branches --dry-run
Would delete the following branches:
  feature-123
  feature-456
```

## Changes

- `bin/git-delete-gone-branches` — the command
- `man/git-delete-gone-branches.md` — man page
- `Commands.md` — added to index and description section
- `etc/git-extras-completion.zsh` — zsh completion with `--dry-run` flag

## Checklist

- [x] Script starts with `#!/usr/bin/env bash`
- [x] Man page written
- [x] Added to `Commands.md`
- [x] Updated `etc/git-extras-completion.zsh`
- [ ] `check_integrity.sh` — requires local install of ronn to generate `.1`/`.html` man files; happy to add if needed