### PR TITLE
feat: add git-delete-gone-branches

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -18,6 +18,7 @@
  - [`git cp`](#git-cp)
  - [`git create-branch`](#git-create-branch)
  - [`git delete-branch`](#git-delete-branch)
+ - [`git delete-gone-branches`](#git-delete-gone-branches)
  - [`git delete-merged-branches`](#git-delete-merged-branches)
  - [`git delete-squashed-branches`](#git-delete-squashed-branches)
  - [`git delete-submodule`](#git-delete-submodule)

--- a/bin/git-delete-gone-branches
+++ b/bin/git-delete-gone-branches
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Check if current directory is inside a git repository
+git rev-parse --show-toplevel > /dev/null 2>&1
+result=$?
+if test $result != 0; then
+    >&2 echo 'Not a git repo!'
+    exit $result
+fi
+
+git branch -vv |
+    grep gone |
+    cut -c2- |
+    grep -v $(git config --get init.defaultBranch) |
+    perl -ane 'print "@F[0]\n"' |
+    xargs -r git branch -D

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -421,6 +421,7 @@ zstyle ':completion:*:*:git:*' user-commands $existing_user_commands \
     count:'show commit count' \
     create-branch:'create branches' \
     delete-branch:'delete branches' \
+    delete-gone-branches:'delete gone branches' \
     delete-merged-branches:'delete merged branches' \
     delete-squashed-branches:'delete squashed branches' \
     delete-submodule:'delete submodules' \

--- a/man/git-delete-gone-branches.1
+++ b/man/git-delete-gone-branches.1
@@ -1,0 +1,19 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-DELETE\-GONE\-BRANCHES" "1" "March 2026" "" "Git Extras"
+.SH "NAME"
+\fBgit\-delete\-gone\-branches\fR \- Delete branches where the remote branch is gone
+.SH "SYNOPSIS"
+\fBgit\-delete\-gone\-branches\fR
+.SH "DESCRIPTION"
+Delete all branches where the remote branch is gone because it was deleted\. This is common when you work with GitHub, you have your personal repository, and use the "Delete" button to delete the branch after it is merged with the main branch\.
+.SH "EXAMPLES"
+.nf
+$ git delete\-gone\-branches
+.fi
+.SH "AUTHOR"
+Written by Mats Kindahl <mats@kindahl\.net>
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-delete-gone-branches.html
+++ b/man/git-delete-gone-branches.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
+  <title>git-delete-gone-branches(1) - Delete branches where the remote branch is gone</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-delete-gone-branches(1)</li>
+    <li class='tc'>Git Extras</li>
+    <li class='tr'>git-delete-gone-branches(1)</li>
+  </ol>
+
+  
+
+<h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-delete-gone-branches</code> - <span class="man-whatis">Delete branches where the remote branch is gone</span>
+</p>
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-delete-gone-branches</code></p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>Delete all branches where the remote branch is gone because it was
+  deleted. This is common when you work with GitHub, you have your
+  personal repository, and use the "Delete" button to delete the
+  branch after it is merged with the main branch.</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<pre><code>$ git delete-gone-branches
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Mats Kindahl &lt;mats@kindahl.net&gt;</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras/issues" data-bare-link="true">https://github.com/tj/git-extras/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>March 2026</li>
+    <li class='tr'>git-delete-gone-branches(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-delete-gone-branches.md
+++ b/man/git-delete-gone-branches.md
@@ -1,0 +1,29 @@
+git-delete-gone-branches(1) -- Delete branches where the remote branch is gone
+================================
+
+## SYNOPSIS
+
+`git-delete-gone-branches`
+
+## DESCRIPTION
+
+  Delete all branches where the remote branch is gone because it was
+  deleted. This is common when you work with GitHub, you have your
+  personal repository, and use the "Delete" button to delete the
+  branch after it is merged with the main branch.
+
+## EXAMPLES
+
+    $ git delete-gone-branches
+
+## AUTHOR
+
+Written by Mats Kindahl &lt;mats@kindahl.net&gt;
+
+## REPORTING BUGS
+
+&lt;<https://github.com/tj/git-extras/issues>&gt;
+
+## SEE ALSO
+
+&lt;<https://github.com/tj/git-extras>&gt;

--- a/man/git-extras.1
+++ b/man/git-extras.1
@@ -1,0 +1,185 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "GIT\-EXTRAS" "1" "March 2026" "" "Git Extras"
+.SH "NAME"
+\fBgit\-extras\fR \- Awesome GIT utilities
+.SH "SYNOPSIS"
+\fBgit\-extras\fR [\-v,\-\-version] [\-h,\-\-help] [update]
+.SH "OPTIONS"
+\-v, \-\-version
+.P
+Show git\-extras version number\.
+.P
+\-h, \-\-help
+.P
+Show this help\. This option can also be used for any of the extras commands\.
+.P
+update
+.P
+Self update\.
+.SH "ENVIRONMENT AND CONFIGURATION VARIABLES"
+\fBgit config \-\-add git\-extras\.default\-branch $BRANCH\fR
+.P
+Change the default branch to \fB$BRANCH\fR\. If \fBgit\-extras\.default\-branch\fR isn't set, \fBinit\.defaultBranch\fR is used instead\. If none of them are set it defaults to \fBmain\fR\.
+.SH "COMMANDS"
+.IP "\[ci]" 4
+\fBgit\-abort(1)\fR Abort current git operation
+.IP "\[ci]" 4
+\fBgit\-alias(1)\fR Define, search and show aliases
+.IP "\[ci]" 4
+\fBgit\-archive\-file(1)\fR Export the current HEAD of the git repository to an archive
+.IP "\[ci]" 4
+\fBgit\-authors(1)\fR Generate authors report
+.IP "\[ci]" 4
+\fBgit\-browse\-ci(1)\fR \fIView the web page for the current repository\fR
+.IP "\[ci]" 4
+\fBgit\-browse(1)\fR \fIView the web page for the current repository\fR
+.IP "\[ci]" 4
+\fBgit\-brv(1)\fR List branches sorted by their last commit date
+.IP "\[ci]" 4
+\fBgit\-bulk(1)\fR Run git commands on multiple repositories
+.IP "\[ci]" 4
+\fBgit\-changelog(1)\fR Generate a changelog report
+.IP "\[ci]" 4
+\fBgit\-clear\-soft(1)\fR Soft clean up a repository
+.IP "\[ci]" 4
+\fBgit\-clear(1)\fR Rigorously clean up a repository
+.IP "\[ci]" 4
+\fBgit\-coauthor(1)\fR Add a co\-author to the last commit
+.IP "\[ci]" 4
+\fBgit\-commits\-since(1)\fR Show commit logs since some date
+.IP "\[ci]" 4
+\fBgit\-continue(1)\fR Continue current git operation
+.IP "\[ci]" 4
+\fBgit\-contrib(1)\fR Show user's contributions
+.IP "\[ci]" 4
+\fBgit\-count(1)\fR Show commit count
+.IP "\[ci]" 4
+\fBgit\-cp(1)\fR Copy a file keeping its history
+.IP "\[ci]" 4
+\fBgit\-create\-branch(1)\fR Create branches
+.IP "\[ci]" 4
+\fBgit\-delete\-branch(1)\fR Delete branches
+.IP "\[ci]" 4
+\fBgit\-delete\-gone\-branches(1)\fR Delete branches where the remote branch is gone
+.IP "\[ci]" 4
+\fBgit\-delete\-merged\-branches(1)\fR Delete merged branches
+.IP "\[ci]" 4
+\fBgit\-delete\-squashed\-branches(1)\fR Delete branches that were squashed
+.IP "\[ci]" 4
+\fBgit\-delete\-submodule(1)\fR Delete submodules
+.IP "\[ci]" 4
+\fBgit\-delete\-tag(1)\fR Delete tags
+.IP "\[ci]" 4
+\fBgit\-delta(1)\fR Lists changed files
+.IP "\[ci]" 4
+\fBgit\-effort(1)\fR Show effort statistics on file(s)
+.IP "\[ci]" 4
+\fBgit\-feature(1)\fR Create/Merge feature branch
+.IP "\[ci]" 4
+\fBgit\-force\-clone(1)\fR overwrite local repositories with clone
+.IP "\[ci]" 4
+\fBgit\-fork(1)\fR Fork a repo on github
+.IP "\[ci]" 4
+\fBgit\-fresh\-branch(1)\fR Create fresh branches
+.IP "\[ci]" 4
+\fBgit\-get(1)\fR Clone a Git repository under a configured directory
+.IP "\[ci]" 4
+\fBgit\-gh\-pages(1)\fR Create the GitHub Pages branch
+.IP "\[ci]" 4
+\fBgit\-graft(1)\fR Merge and destroy a given branch
+.IP "\[ci]" 4
+\fBgit\-guilt(1)\fR calculate change between two revisions
+.IP "\[ci]" 4
+\fBgit\-ignore\-io(1)\fR Get sample gitignore file
+.IP "\[ci]" 4
+\fBgit\-ignore(1)\fR Add \.gitignore patterns
+.IP "\[ci]" 4
+\fBgit\-info(1)\fR Returns information on current repository
+.IP "\[ci]" 4
+\fBgit\-local\-commits(1)\fR List local commits
+.IP "\[ci]" 4
+\fBgit\-lock(1)\fR Lock a file excluded from version control
+.IP "\[ci]" 4
+\fBgit\-locked(1)\fR ls files that have been locked
+.IP "\[ci]" 4
+\fBgit\-magic(1)\fR Automate add/commit/push routines
+.IP "\[ci]" 4
+\fBgit\-merge\-into(1)\fR Merge one branch into another
+.IP "\[ci]" 4
+\fBgit\-merge\-repo(1)\fR Merge two repo histories
+.IP "\[ci]" 4
+\fBgit\-missing(1)\fR Show commits missing from another branch
+.IP "\[ci]" 4
+\fBgit\-mr(1)\fR Checks out a merge request locally
+.IP "\[ci]" 4
+\fBgit\-obliterate(1)\fR rewrite past commits to remove some files
+.IP "\[ci]" 4
+\fBgit\-paste(1)\fR Send patches to pastebin for chat conversations
+.IP "\[ci]" 4
+\fBgit\-pr(1)\fR Checks out a pull request locally
+.IP "\[ci]" 4
+\fBgit\-psykorebase(1)\fR Rebase a branch with a merge commit
+.IP "\[ci]" 4
+\fBgit\-pull\-request(1)\fR Create pull request for GitHub project
+.IP "\[ci]" 4
+\fBgit\-reauthor(1)\fR Rewrite history to change author's identity
+.IP "\[ci]" 4
+\fBgit\-rebase\-patch(1)\fR Rebases a patch
+.IP "\[ci]" 4
+\fBgit\-release(1)\fR Commit, tag and push changes to the repository
+.IP "\[ci]" 4
+\fBgit\-rename\-branch(1)\fR rename local branch and push to remote
+.IP "\[ci]" 4
+\fBgit\-rename\-file(1)\fR Rename a file or directory and ensure Git recognizes the change, regardless of filesystem case\-sensitivity\.
+.IP "\[ci]" 4
+\fBgit\-rename\-remote(1)\fR Rename a remote
+.IP "\[ci]" 4
+\fBgit\-rename\-tag(1)\fR Rename a tag
+.IP "\[ci]" 4
+\fBgit\-repl(1)\fR git read\-eval\-print\-loop
+.IP "\[ci]" 4
+\fBgit\-reset\-file(1)\fR Reset one file
+.IP "\[ci]" 4
+\fBgit\-root(1)\fR show path of root
+.IP "\[ci]" 4
+\fBgit\-scp(1)\fR Copy files to SSH compatible \fBgit\-remote\fR
+.IP "\[ci]" 4
+\fBgit\-sed(1)\fR replace patterns in git\-controlled files
+.IP "\[ci]" 4
+\fBgit\-setup(1)\fR Set up a git repository
+.IP "\[ci]" 4
+\fBgit\-show\-merged\-branches(1)\fR Show merged branches
+.IP "\[ci]" 4
+\fBgit\-show\-tree(1)\fR show branch tree of commit history
+.IP "\[ci]" 4
+\fBgit\-show\-unmerged\-branches(1)\fR Show unmerged branches
+.IP "\[ci]" 4
+\fBgit\-squash(1)\fR squash N last changes up to a ref'ed commit
+.IP "\[ci]" 4
+\fBgit\-stamp(1)\fR Stamp the last commit message
+.IP "\[ci]" 4
+\fBgit\-standup(1)\fR Recall the commit history
+.IP "\[ci]" 4
+\fBgit\-summary(1)\fR Show repository summary
+.IP "\[ci]" 4
+\fBgit\-sync(1)\fR Sync local branch with remote branch
+.IP "\[ci]" 4
+\fBgit\-touch(1)\fR Touch and add file to the index
+.IP "\[ci]" 4
+\fBgit\-undo(1)\fR Remove latest commits
+.IP "\[ci]" 4
+\fBgit\-unlock(1)\fR Unlock a file excluded from version control
+.IP "\[ci]" 4
+\fBgit\-unwip(1)\fR Undo a Work In Progress commit
+.IP "\[ci]" 4
+\fBgit\-utimes(1)\fR Change files modification time to their last commit date
+.IP "\[ci]" 4
+\fBgit\-wip(1)\fR Create a Work In Progress commit
+.IP "" 0
+.SH "AUTHOR"
+Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR>
+.SH "REPORTING BUGS"
+<\fIhttps://github\.com/tj/git\-extras/issues\fR>
+.SH "SEE ALSO"
+<\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-extras.html
+++ b/man/git-extras.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' content='text/html;charset=utf-8'>
-  <meta name='generator' content='Ronn-NG/v0.10.1 (http://github.com/apjanke/ronn-ng/tree/0.10.1)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>git-extras(1) - Awesome GIT utilities</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -143,6 +143,8 @@
   <li>
 <strong><a class="man-ref" href="git-delete-branch.html">git-delete-branch<span class="s">(1)</span></a></strong> Delete branches</li>
   <li>
+<strong><a class="man-ref" href="git-delete-gone-branches.html">git-delete-gone-branches<span class="s">(1)</span></a></strong> Delete branches where the remote branch is gone</li>
+  <li>
 <strong><a class="man-ref" href="git-delete-merged-branches.html">git-delete-merged-branches<span class="s">(1)</span></a></strong> Delete merged branches</li>
   <li>
 <strong><a class="man-ref" href="git-delete-squashed-branches.html">git-delete-squashed-branches<span class="s">(1)</span></a></strong> Delete branches that were squashed</li>
@@ -273,7 +275,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>February 2026</li>
+    <li class='tc'>March 2026</li>
     <li class='tr'>git-extras(1)</li>
   </ol>
 

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -46,6 +46,7 @@ git-extras(1) -- Awesome GIT utilities
    - **git-cp(1)** Copy a file keeping its history
    - **git-create-branch(1)** Create branches
    - **git-delete-branch(1)** Delete branches
+   - **git-delete-gone-branches(1)** Delete branches where the remote branch is gone
    - **git-delete-merged-branches(1)** Delete merged branches
    - **git-delete-squashed-branches(1)** Delete branches that were squashed
    - **git-delete-submodule(1)** Delete submodules

--- a/man/index.txt
+++ b/man/index.txt
@@ -18,6 +18,7 @@ git-count(1) git-count
 git-cp(1) git-cp
 git-create-branch(1) git-create-branch
 git-delete-branch(1) git-delete-branch
+git-delete-gone-branches(1) git-delete-gone-branches
 git-delete-merged-branches(1) git-delete-merged-branches
 git-delete-squashed-branches(1) git-delete-squashed-branches
 git-delete-submodule(1) git-delete-submodule


### PR DESCRIPTION
When using GitHub and using the "Delete" button after merging a branch into a upstreams repository, the remote branch is gone but the local branch stays.

This command removes all "gone" branches that are still checked out.

I have tested this on macOs and Linux, but nothing else.

<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
