### PR TITLE
refactor(abort): common `gitdir`

### DIFF
--- a/bin/git-abort
+++ b/bin/git-abort
@@ -4,7 +4,6 @@ set -euo pipefail
 
 # git rev-parse emits an error if not in a git repo so only need to bail out
 gitdir="$(git rev-parse --git-dir)" || exit
-readonly gitdir
 
 discover_op() {
   local op

--- a/bin/git-abort
+++ b/bin/git-abort
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
+# git rev-parse emits an error if not in a git repo so only need to bail out
+gitdir="$(git rev-parse --git-dir)" || exit
+readonly gitdir
+
 discover_op() {
-  local gitdir
-  # git rev-parse emits an error if not in a git repo so only need to bail out
-  gitdir="$(git rev-parse --git-dir)" || exit
   local op
   for op in cherry_pick merge rebase revert ; do
       if [ -f "${gitdir}/${op^^}_HEAD" ]; then
@@ -22,7 +23,6 @@ validate_op() {
   fi
   if [[ "$(echo "$op" | wc -l)" -gt 1 ]]; then
     echo "Multiple active operations found:" >&2
-    gitdir="$(git rev-parse --git-dir)" || exit
     for o in $op; do
       echo "  - $o: HEAD: $(cat "${gitdir}/${o}_HEAD")" >&2
     done


### PR DESCRIPTION
This promotes `gitdir` to a global (shared within script) `readonly`, to:
- improve perf
- dedupe ("DRY")
- ensure consistent value by avoiding data-races