### PR TITLE
feat(git-utimes): add ability to update directory timestamp

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -1624,6 +1624,8 @@ $ git browse-ci upstream
 
 Change files modification time to their last commit date. Does not touch files that are in the working tree or index.
 
+To also update the timestamps for directories, use the `--touch-dirs` or `-d` flag.
+
 The `--newer` flag preserves the original modification time of files that were committed from the local repo, by only touching files that are newer than their last commit date.
 
 ```bash

--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -16,20 +16,18 @@ log_opts=(
 op=eq
 
 for arg in "$@"; do
-    case "$arg" in
-        --newer)
-            op=le
-            ;;
-        --touch-dirs | -d)
-            log_opts+=(--dirstat=files,0)
-            ;;
-        *)
-            >&2 echo "unknown argument $arg found"
-            exit 1
-            ;;
-    esac
-
-    shift
+  case "$arg" in
+    --newer)
+      op=le
+      ;;
+    --touch-dirs | -d)
+      log_opts+=(--dirstat=files,0)
+      ;;
+    *)
+      >&2 echo "unknown argument $arg found"
+      exit 1
+      ;;
+  esac
 done
 
 # BSD systems

--- a/bin/git-utimes
+++ b/bin/git-utimes
@@ -7,12 +7,30 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-if [[ "${1:-}" == "--newer" ]]; then
-  op=le
-  shift
-else
-  op=eq
-fi
+# %ct: committer date, UNIX timestamp / %at: author date, UNIX timestamp
+# --diff-filter=d: exclude deleted files
+log_opts=(
+  --format='%ct'
+  --diff-filter=d
+)
+op=eq
+
+for arg in "$@"; do
+    case "$arg" in
+        --newer)
+            op=le
+            ;;
+        --touch-dirs | -d)
+            log_opts+=(--dirstat=files,0)
+            ;;
+        *)
+            >&2 echo "unknown argument $arg found"
+            exit 1
+            ;;
+    esac
+
+    shift
+done
 
 # BSD systems
 if date -j &>/dev/null; then
@@ -33,8 +51,6 @@ if bash --help 2>&1 | grep -q -- '--norc'; then
 fi
 
 status_opts=(--porcelain --short)
-# %ct: committer date, UNIX timestamp / %at: author date, UNIX timestamp
-log_opts=(--format='%ct')
 if git status --help 2>&1 | grep -q -- "--no-renames"; then
   status_opts+=(--no-renames)
   log_opts+=(--no-renames)
@@ -91,13 +107,17 @@ FILENAME==tmpfile {
 }
 # skip blank lines
 !/^$/ {
-  # skip deletes
-  if (substr($1, length($1), 1) ~ /D/) {
-    next
-  }
   if (NF == 1) {
-    ct=$1
-    next
+    # dirstat line
+    if ($1 ~ /^.+% .+\/$/) {
+      # remove percentage before path
+      gsub(/^.+% /, "", $1)
+      $2 = $1
+    # timestamp line
+    } else {
+      ct=$1
+      next
+    }
   }
   $2 = substr($2, strip, length($2)- strip + 1)
   if ($2 in seen) {

--- a/man/git-utimes.1
+++ b/man/git-utimes.1
@@ -1,6 +1,6 @@
-.\" generated with Ronn-NG/v0.9.1
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "GIT\-UTIMES" "1" "May 2022" "" "Git Extras"
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "GIT\-UTIMES" "1" "January 1980" "" "Git Extras"
 .SH "NAME"
 \fBgit\-utimes\fR \- Change files modification time to their last commit date
 .SH "SYNOPSIS"
@@ -11,6 +11,10 @@ Change files modification time to their last commit date\. Does not touch files 
 \-\-newer
 .P
 Preserves the original modification time of files that were committed from the local repo, by only touching files that are newer than their last commit date\.
+.P
+\-\-touch\-dirs or \-d
+.P
+Also update the modification time of directories to the latest commit date of any file within them\. This can be useful for build systems that rely on directory timestamps\.
 .SH "EXAMPLES"
 Update all files' modification time to their last commit date, except those in working tree or index:
 .IP "" 4
@@ -23,6 +27,13 @@ As above, but preserve original modification time of files that were committed f
 .IP "" 4
 .nf
 $ git utimes \-\-newer
+.fi
+.IP "" 0
+.P
+Update all files' and directories' modification time to their last commit date, except those in working tree or index:
+.IP "" 4
+.nf
+$ git utimes \-\-touch\-dirs
 .fi
 .IP "" 0
 .SH "AUTHOR"

--- a/man/git-utimes.1
+++ b/man/git-utimes.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1
-.TH "GIT\-UTIMES" "1" "January 1980" "" "Git Extras"
+.TH "GIT\-UTIMES" "1" "April 2026" "" "Git Extras"
 .SH "NAME"
 \fBgit\-utimes\fR \- Change files modification time to their last commit date
 .SH "SYNOPSIS"

--- a/man/git-utimes.html
+++ b/man/git-utimes.html
@@ -124,7 +124,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>January 1980</li>
+    <li class='tc'>April 2026</li>
     <li class='tr'>git-utimes(1)</li>
   </ol>
 

--- a/man/git-utimes.html
+++ b/man/git-utimes.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' content='text/html;charset=utf8'>
-  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf-8'>
+  <meta name='generator' content='Ronn-NG/v0.10.1 (http://github.com/apjanke/ronn-ng/tree/0.10.1)'>
   <title>git-utimes(1) - Change files modification time to their last commit date</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -89,6 +89,10 @@
 
 <p>Preserves the original modification time of files that were committed from the local repo, by only touching files that are newer than their last commit date.</p>
 
+<p>--touch-dirs or -d</p>
+
+<p>Also update the modification time of directories to the latest commit date of any file within them. This can be useful for build systems that rely on directory timestamps.</p>
+
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
 <p>Update all files' modification time to their last commit date, except those in working tree or index:</p>
@@ -99,6 +103,11 @@
 <p>As above, but preserve original modification time of files that were committed from local repo:</p>
 
 <pre><code>$ git utimes --newer
+</code></pre>
+
+<p>Update all files' and directories' modification time to their last commit date, except those in working tree or index:</p>
+
+<pre><code>$ git utimes --touch-dirs
 </code></pre>
 
 <h2 id="AUTHOR">AUTHOR</h2>
@@ -115,7 +124,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>May 2022</li>
+    <li class='tc'>January 1980</li>
     <li class='tr'>git-utimes(1)</li>
   </ol>
 

--- a/man/git-utimes.md
+++ b/man/git-utimes.md
@@ -14,6 +14,10 @@ git-utimes(1) -- Change files modification time to their last commit date
   --newer
 
   Preserves the original modification time of files that were committed from the local repo, by only touching files that are newer than their last commit date.
+  
+  --touch-dirs or -d
+  
+  Also update the modification time of directories to the latest commit date of any file within them. This can be useful for build systems that rely on directory timestamps.
 
 ## EXAMPLES
 
@@ -24,6 +28,10 @@ Update all files' modification time to their last commit date, except those in w
 As above, but preserve original modification time of files that were committed from local repo:
 
     $ git utimes --newer
+    
+Update all files' and directories' modification time to their last commit date, except those in working tree or index:
+
+    $ git utimes --touch-dirs
 
 ## AUTHOR
 


### PR DESCRIPTION
New flag `--touch-dirs` or `-d` allows to update directory timestamp when using `git utimes` command.

Refs: #1246

I haven't done much with awk till now. Only tested under linux with git `2.53.0`.

<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->
