### PR TITLE
chore: `get-regexp` is deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ install: check
 	@# chmod from rw-------(default) to rwxrwxr-x, so that users can exec the scripts
 	@chmod 775 $(TEMPFILE)
 	$(eval EXISTED_ALIASES := $(shell \
-		git config --get-regexp 'alias\..*' | awk '{print "git-" substr($$1, 7)}'))
+		git config get --all --show-names --regexp 'alias\..*' | awk '{print "git-" substr($$1, 7)}'))
 	@$(foreach COMMAND, $(COMMANDS), \
 		should_install='yes'; \
 		if [ ! -z "$(filter $(COMMAND), $(EXISTED_ALIASES))" ] && [ "$$SKIP_CONFLICT_CHECK" != yes ]; then \

--- a/bin/git-alias
+++ b/bin/git-alias
@@ -22,16 +22,16 @@ fi
 case $# in
   0)
       if [[ -z "$options" ]]; then
-        git config --get-regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort
+        git config get --all --show-names --regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort
       else
-        git config "$options" --get-regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort
+        git config get "$options" --all --show-names --regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort
       fi
       ;;
   1)
       if [[ -z "$options" ]]; then
-        git config --get-regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort | grep -e "$1"
+        git config get --all --show-names --regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort | grep -e "$1"
       else
-        git config "$options" --get-regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort | grep -e "$1"
+        git config get "$options" --all --show-names --regexp 'alias.*' | sed 's/^alias\.//' | sed 's/[ ]/ = /' | sort | grep -e "$1"
       fi
       ;;
   2)

--- a/bin/git-bulk
+++ b/bin/git-bulk
@@ -68,7 +68,7 @@ removeworkspace() { checkWSName && git config --global --unset bulkworkspaces."$
 purge() { git config --global --remove-section bulkworkspaces; }
 
 # list all current workspace locations defined
-listall() { git config --global --get-regexp bulkworkspaces; }
+listall() { git config get --global --all --show-names --regexp bulkworkspaces; }
 
 # guarded execution of a git command in one specific repository
 guardedExecution () {
@@ -92,7 +92,7 @@ checkGitCommand () {
   if git help -a | grep -o -q "\b${corecommand}\b"; then
     echo 1>&2 "Core command \"$corecommand\" accepted."
   else
-    if git config --get-regexp alias | grep -o -q "\.${corecommand} "; then
+    if git config get --all --show-names --regexp alias | grep -o -q "\.${corecommand} "; then
       echo 1>&2 "Alias ${corecommand} accepted."
     else
       usage && echo 1>&2 "error: unknown GIT command: $corecommand" && exit 1


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->

According to [the docs](https://git-scm.com/docs/git-config#Documentation/git-config.txt---get-regexpname-regexp), `config --get-regexp` is deprecated in favor of `config get --all --show-names --regexp`, so I replaced all the occurrences I've found