### PR TITLE
perf(git-locked): replace `sed` by `cut`

### DIFF
--- a/bin/git-locked
+++ b/bin/git-locked
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-git ls-files -v | grep ^S | sed -e 's|S ||'
+git ls-files -v | grep ^S | cut -c3-


### PR DESCRIPTION
<!--

Note

* Mark the PR as draft until it's ready to be reviewed.
* Please update the documentation to reflect the changes made in the PR.
* If the command is covered by tests under ./tests, please add/update tests for any changes unless you have a good reason. 
* Make a new commit to resolve conversations instead of `push -f`.
* To resolve merge conflicts, merge from the `main` branch instead of rebasing over `main`.
* Please wait for the reviewer to mark a conversation as resolved.

-->

This is a micro-optimization. I did it on my own, but I asked Copilot if it could be improved, it suggested these (not tested):
```sh
git ls-files -v | sed -n '/^S /s///p'
git ls-files -v | awk '/^S /{print substr($0,3)}'
```
