### PR TITLE
Added edit/remove functionality to git-ignore

### DIFF
--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -126,7 +126,7 @@ _usage() {
 remove_patterns() {
   local args
   local tmpfile
-  args="${@:3}"
+  args="${*:3}"
   tmpfile="$(get_tmp_file)"
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -124,16 +124,16 @@ _usage() {
 }
 
 remove_patterns() {
-  local args
+  declare -a args
   local tmpfile
-  args="${*:3}"
+  args=( "${@:3}" )
   tmpfile="$(get_tmp_file)"
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
     echo "Removing patterns from $1 gitignore ($2)..."
     while read -r line; do
       local drop=
-      for pattern in $args; do
+      for pattern in "${args[@]}"; do
         test "$pattern" = "$line" && drop="yes"
       done
       if [ -z "$drop" ]; then

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -2,6 +2,7 @@
 
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 
+
 show_contents() {
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
@@ -27,6 +28,17 @@ cd_to_git_root() {
   if result=$(git rev-parse --show-toplevel 2>/dev/null); then
     cd "$result" || exit
   fi
+}
+
+get_tmp_file() {
+  local tmpfile=
+  if ! git rev-parse --git-dir &>/dev/null || [ -z "$GIT_DIR" ]; then
+    tmpfile="$(mktemp -q "${TMPDIR:-/tmp}"/git-extras-ignore.XXXXXX 2>/dev/null)"
+  else
+    cd_to_git_root --warn &>/dev/null
+    tmpfile="$(mktemp -q "$GIT_DIR"/git-extras-ignore.XXXXXX 2>/dev/null)"
+  fi
+  echo "${tmpfile:-$(mktemp -q)}"
 }
 
 global_ignore() {
@@ -94,6 +106,54 @@ add_patterns() {
   done
 }
 
+# TODO: create a file if does not exist??
+edit_file() {
+  local file="${2/#~/$HOME}"
+  if [ -f "$file" ]; then
+    echo "Editing $1 gitignore ($2)..." && $(git var GIT_EDITOR) "$file"
+    echo "Done."
+  else
+    echo "There is no $1 .gitignore yet." >&2
+    exit 1
+  fi
+}
+
+_usage() {
+  # TODO
+  echo "Under construction."
+}
+
+remove_patterns() {
+  local args
+  local tmpfile
+  args="${@:3}"
+  tmpfile="$(get_tmp_file)"
+  local file="${2/#~/$HOME}"
+  if [ -f "$file" ]; then
+    echo "Removing patterns from $1 gitignore ($2)..."
+    while read -r line; do
+      local drop=
+      for pattern in $args; do
+        test "$pattern" = "$line" && drop="yes"
+      done
+      if [ -z "$drop" ]; then
+        echo "$line" >> "$tmpfile"
+      else
+        echo "Removed $line pattern."
+      fi
+    done < "$file"
+    mv "$tmpfile" "$file" # tmp file created in get_tmp_file 'deleted'
+    echo "Done."
+  else
+    echo "There is no $1 .gitignore yet"
+    exit 1
+  fi
+}
+
+
+# can have only 1 action and 1 level, if conflicting flags are passed
+# latter ones overwrite former
+# sanity of args not tested (e.g. there should be no args if -e is supplied)
 if test $# -eq 0; then
    show_global
    echo "---------------------------------"
@@ -101,22 +161,102 @@ if test $# -eq 0; then
    echo "---------------------------------"
    show_private
 else
-  case "$1" in
-    -l|--local)
-      test $# -gt 1 && add_local "${@:2}" && echo
-      show_local
-      ;;
-    -g|--global)
-      test $# -gt 1 && add_global "${@:2}" && echo
-      show_global
-      ;;
-    -p|--private)
-      test $# -gt 1 && add_private "${@:2}" && echo
-      show_private
-      ;;
-    *)
-      add_local "$@"
-      ;;
-  esac
-fi
+  # parse flags and args
+  level="none"
+  action="none"
+  declare -a args
+  while [ "$1" != "" ]; do
+    case "$1" in
+      -h|--help)
+        _usage
+        exit 0
+        ;;
+      -l|--local)
+        level="local"
+        ;;
+      -g|--global)
+        level="global"
+        ;;
+      -p|--private)
+        level="private"
+        ;;
+      -e|--edit)
+        action="edit"
+        ;;
+      -r|--remove)
+        action="remove"
+        ;;
+      --)
+        shift
+        args+=("$@")
+        break
+        ;;
+      *)
+        args+=("$1")
+        ;;
+    esac
+    shift
+  done
+  # compatible with previous version
+  if [ "$action" = "none" ]; then
+    case "$level" in
+      local)
+        test ${#args[@]} -ne 0 && add_local "${args[@]}" && echo
+        show_local
+        ;;
+      global)
+        test ${#args[@]} -ne 0 && add_global "${args[@]}" && echo
+        show_global
+        ;;
+      private)
+        test ${#args[@]} -ne 0 && add_private "${args[@]}" && echo
+        show_private
+        ;;
+      none)
+        add_local "${args[@]}"
+        # maybe show_local here too?
+        ;;
+    esac
+    exit 0
+  # open file in editor
+  elif [ "$action" = "edit" ]; then
+    case "$level" in
+      local|none)
+        cd_to_git_root --warn
+        edit_file 'local' .gitignore
+        ;;
+      global)
+        global_gitignore="$(global_ignore)"
+        edit_file global "$global_gitignore"
+        ;;
+      private)
+        cd_to_git_root --error
+        test -d "${GIT_DIR}/info" || mkdir -p "${GIT_DIR}/info"
+        edit_file private "${GIT_DIR}/info/exclude"
+        ;;
+    esac
+    exit 0
+  # remove entries
+  else
+    if [ ${#args[@]} -eq 0 ]; then
+      echo "Nothing to remove."
+      exit 0
+    fi
+    case "$level" in
+      local|none)
+        cd_to_git_root --warn
+        remove_patterns 'local' .gitignore "${args[@]}"
+        ;;
+      global)
+        global_gitignore="$(global_ignore)"
+        remove_patterns global "$global_gitignore" "${args[@]}"
+        ;;
+      private)
+        cd_to_git_root --error
+        remove_patterns private "${GIT_DIR}/info/exclude" "${args[@]}"
+        ;;
+    esac
+    exit 0
 
+  fi
+fi

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -30,17 +30,6 @@ cd_to_git_root() {
   fi
 }
 
-get_tmp_file() {
-  local tmpfile=
-  if ! git rev-parse --git-dir &>/dev/null || [ -z "$GIT_DIR" ]; then
-    tmpfile="$(mktemp -q "${TMPDIR:-/tmp}"/git-extras-ignore.XXXXXX 2>/dev/null)"
-  else
-    cd_to_git_root --warn &>/dev/null
-    tmpfile="$(mktemp -q "$GIT_DIR"/git-extras-ignore.XXXXXX 2>/dev/null)"
-  fi
-  echo "${tmpfile:-$(mktemp -q)}"
-}
-
 global_ignore() {
   if ! git config --global core.excludesFile 2>/dev/null; then
     if [ -f "$HOME/.gitignore" ]; then
@@ -110,7 +99,7 @@ add_patterns() {
 edit_file() {
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
-    echo "Editing $1 gitignore ($2)..." && $(git var GIT_EDITOR) "$file"
+    echo "Editing $1 gitignore ($2)..." && eval "$(git var GIT_EDITOR) $file"
     echo "Done."
   else
     echo "There is no $1 .gitignore yet." >&2
@@ -127,22 +116,23 @@ remove_patterns() {
   declare -a args
   local tmpfile
   args=( "${@:3}" )
-  tmpfile="$(get_tmp_file)"
+  tmpfile="$(mktemp -q "${TMPDIR:-/tmp}"/git-extras-ignore.XXXXXX 2>/dev/null)"
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
     echo "Removing patterns from $1 gitignore ($2)..."
-    while read -r line; do
+    while IFS= read -r line || [ -n "$line" ]; do
       local drop=
       for pattern in "${args[@]}"; do
         test "$pattern" = "$line" && drop="yes"
       done
       if [ -z "$drop" ]; then
-        echo "$line" >> "$tmpfile"
+        printf '%s\n' "$line" >> "$tmpfile"
       else
         echo "Removed $line pattern."
       fi
     done < "$file"
-    mv "$tmpfile" "$file" # tmp file created in get_tmp_file 'deleted'
+    cat "$tmpfile" > "$file"
+    rm "$tmpfile"
     echo "Done."
   else
     echo "There is no $1 .gitignore yet"
@@ -165,7 +155,7 @@ else
   level="none"
   action="none"
   declare -a args
-  while [ "$1" != "" ]; do
+  while [ $# -gt 0 ]; do
     case "$1" in
       -h|--help)
         _usage

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -2,6 +2,25 @@
 
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 
+# awk script that takes 2 input files. The first one is newline deilmeted
+# string of patterns to look for, second one is the file to remove them from.
+# outfile has to be passed with -v upon call and is the file result is
+# written to.
+read -r -d '' AWK_SCRIPT <<'EOF'
+# process the first "file" (newline split argument list)
+NR==FNR { a[b++]=$0; next; }
+# process file
+{
+   found=0;
+   for (i=0; i != b; i++) {
+      if (a[i] == $0) { found=1; }
+   }
+   if (found == 1) { print "... removing '"$0"'"; }
+   else { print $0 > outfile }
+}
+EOF
+
+
 
 show_contents() {
   local file="${2/#~/$HOME}"
@@ -99,7 +118,7 @@ add_patterns() {
 edit_file() {
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
-    echo "Editing $1 gitignore ($2)..." && eval "$(git var GIT_EDITOR) $file"
+    echo "Editing $1 gitignore: ($2)" && eval "$(git var GIT_EDITOR) $file"
     echo "Done."
   else
     echo "There is no $1 .gitignore yet." >&2
@@ -119,21 +138,11 @@ remove_patterns() {
   tmpfile="$(mktemp -q "${TMPDIR:-/tmp}"/git-extras-ignore.XXXXXX 2>/dev/null)"
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
-    echo "Removing patterns from $1 gitignore ($2)..."
-    while IFS= read -r line || [ -n "$line" ]; do
-      local drop=
-      for pattern in "${args[@]}"; do
-        test "$pattern" = "$line" && drop="yes"
-      done
-      if [ -z "$drop" ]; then
-        printf '%s\n' "$line" >> "$tmpfile"
-      else
-        echo "Removed $line pattern."
-      fi
-    done < "$file"
+    echo "Removing patterns from $1 gitignore: $2"
+    awk -v outfile="$tmpfile" "${AWK_SCRIPT}"\
+       <(printf '%s\n' "${args[@]}") "$file"
     cat "$tmpfile" > "$file"
     rm "$tmpfile"
-    echo "Done."
   else
     echo "There is no $1 .gitignore yet"
     exit 1
@@ -213,16 +222,16 @@ else
     case "$level" in
       local|none)
         cd_to_git_root --warn
-        edit_file 'local' .gitignore
+        edit_file 'local' .gitignore && echo
         ;;
       global)
         global_gitignore="$(global_ignore)"
-        edit_file global "$global_gitignore"
+        edit_file global "$global_gitignore" && echo
         ;;
       private)
         cd_to_git_root --error
         test -d "${GIT_DIR}/info" || mkdir -p "${GIT_DIR}/info"
-        edit_file private "${GIT_DIR}/info/exclude"
+        edit_file private "${GIT_DIR}/info/exclude" && echo
         ;;
     esac
     exit 0
@@ -235,15 +244,15 @@ else
     case "$level" in
       local|none)
         cd_to_git_root --warn
-        remove_patterns 'local' .gitignore "${args[@]}"
+        remove_patterns 'local' .gitignore "${args[@]}" && echo
         ;;
       global)
         global_gitignore="$(global_ignore)"
-        remove_patterns global "$global_gitignore" "${args[@]}"
+        remove_patterns global "$global_gitignore" "${args[@]}" && echo
         ;;
       private)
         cd_to_git_root --error
-        remove_patterns private "${GIT_DIR}/info/exclude" "${args[@]}"
+        remove_patterns private "${GIT_DIR}/info/exclude" "${args[@]}" && echo
         ;;
     esac
     exit 0

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -135,9 +135,9 @@ remove_patterns() {
   declare -a args
   local tmpfile
   args=( "${@:3}" )
-  tmpfile="$(mktemp -q "${TMPDIR:-/tmp}"/git-extras-ignore.XXXXXX 2>/dev/null)"
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
+    tmpfile="$(mktemp -q "${TMPDIR:-/tmp}"/git-extras-ignore.XXXXXX 2>/dev/null)"
     echo "Removing patterns from $1 gitignore: $2"
     awk -v outfile="$tmpfile" "${AWK_SCRIPT}"\
        <(printf '%s\n' "${args[@]}") "$file"
@@ -245,14 +245,17 @@ else
       local|none)
         cd_to_git_root --warn
         remove_patterns 'local' .gitignore "${args[@]}" && echo
+        show_local
         ;;
       global)
         global_gitignore="$(global_ignore)"
         remove_patterns global "$global_gitignore" "${args[@]}" && echo
+        show_global
         ;;
       private)
         cd_to_git_root --error
         remove_patterns private "${GIT_DIR}/info/exclude" "${args[@]}" && echo
+        show_private
         ;;
     esac
     exit 0

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -114,7 +114,6 @@ add_patterns() {
   done
 }
 
-# TODO: create a file if does not exist??
 edit_file() {
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
@@ -127,8 +126,30 @@ edit_file() {
 }
 
 _usage() {
-  # TODO
-  echo "Under construction."
+  cat << EOF
+Usage: git ignore [OPTON]... [PATTERN]...
+Modify or display local global or private gitignore files.
+
+OPTIONs set context (local, global, private) and action (display, add,
+remove, edit). In case of collision, last flag overwrites preceding ones.
+Defaults are: local context, action is display (see man git ignore for
+more details).
+Context examples:
+local:   .../repo/.gitignore
+private: .../repo/.git/info/exclude
+global:  \$HOME/.gitignore
+
+PATTERNs are the gitignore patterns as specified in git documentation.
+
+Options:
+  -l, --local      Set context to local gitignore
+  -g, --global     Set context to global gitignore
+  -p, --private    Set context to private gitignore
+  -e, --edit       Set action to edit
+  -r, --remove     Set action to remove
+  -h, --help       Print this message
+  --               End of options delimeter
+EOF
 }
 
 remove_patterns() {

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -127,7 +127,7 @@ edit_file() {
 
 _usage() {
   cat << EOF
-Usage: git ignore [OPTON]... [PATTERN]...
+Usage: git ignore [OPTION]... [PATTERN]...
 Modify or display local global or private gitignore files.
 
 OPTIONs set context (local, global, private) and action (display, add,
@@ -148,7 +148,7 @@ Options:
   -e, --edit       Set action to edit
   -r, --remove     Set action to remove
   -h, --help       Print this message
-  --               End of options delimeter
+  --               End of options delimiter
 EOF
 }
 

--- a/bin/git-ignore
+++ b/bin/git-ignore
@@ -117,7 +117,7 @@ add_patterns() {
 edit_file() {
   local file="${2/#~/$HOME}"
   if [ -f "$file" ]; then
-    echo "Editing $1 gitignore: ($2)" && eval "$(git var GIT_EDITOR) $file"
+    echo "Editing $1 gitignore: ($2)" && eval "$(git var GIT_EDITOR) $(printf '%q' "$file")"
     echo "Done."
   else
     echo "There is no $1 .gitignore yet." >&2

--- a/etc/bash_completion.sh
+++ b/etc/bash_completion.sh
@@ -145,11 +145,11 @@ _git_graft(){
 _git_ignore(){
   case "$cur" in
   --*)
-    __gitcomp "--global --local --private"
+    __gitcomp "--global --local --private --edit --remove"
     return
     ;;
   -*)
-    __gitcomp "--global --local --private -g -l -p"
+    __gitcomp "--global --local --private --edit --remove -g -l -p -e -r"
     return
     ;;
   esac

--- a/etc/git-extras-completion.zsh
+++ b/etc/git-extras-completion.zsh
@@ -317,9 +317,11 @@ _git-guilt() {
 
 _git-ignore() {
     _arguments -C \
-        '(--local -l)'{--local,-l}'[show local gitignore]' \
-        '(--global -g)'{--global,-g}'[show global gitignore]' \
-        '(--private -p)'{--private,-p}'[show repo gitignore]' \
+        '(--local -l)'{--local,-l}'[set context to local gitignore]' \
+        '(--global -g)'{--global,-g}'[set context to global gitignore]' \
+        '(--private -p)'{--private,-p}'[set context to private gitignore]' \
+        '(--edit -e)'{--edit,-e}'[set action to edit]' \
+        '(--remove -r)'{--remove,-r}'[set action to remove]' \
         '*:filename:_files'
 }
 
@@ -443,7 +445,7 @@ zstyle ':completion:*:*:git:*' user-commands $existing_user_commands \
     graft:'merge and destroy a given branch' \
     guilt:'calculate change between two revisions' \
     ignore-io:'get sample gitignore file' \
-    ignore:'add .gitignore patterns' \
+    ignore:'Modify or display .gitignore files' \
     info:'returns information on current repository' \
     local-commits:'list local commits' \
     lock:'lock a file excluded from version control' \

--- a/etc/git-extras.fish
+++ b/etc/git-extras.fish
@@ -32,7 +32,7 @@ set __fish_git_extras_commands \
     "graft:Merge and destroy a given branch" \
     "guilt:calculate change between two revisions" \
     "ignore-io:Get sample gitignore file" \
-    "ignore:Add .gitignore patterns" \
+    "ignore:Modify or display .gitignore files" \
     "info:Returns information on current repository" \
     "local-commits:List local commits" \
     "lock:Lock a file excluded from version control" \
@@ -162,9 +162,11 @@ complete -c git -f -n '__fish_git_using_command guilt' -s e -l email -d 'display
 complete -c git -f -n '__fish_git_using_command guilt' -s d -l debug -d 'output debug information'
 complete -c git -f -n '__fish_git_using_command guilt' -s h -d 'output usage information'
 # ignore
-complete -c git -f -n '__fish_git_using_command ignore' -s l -l local -d 'show local gitignore'
-complete -c git -f -n '__fish_git_using_command ignore' -s g -l global -d 'show global gitignore'
-complete -c git -f -n '__fish_git_using_command ignore' -s p -l private -d 'show repo gitignore'
+complete -c git -f -n '__fish_git_using_command ignore' -s l -l local -d 'set context to local gitignore'
+complete -c git -f -n '__fish_git_using_command ignore' -s g -l global -d 'set context to global gitignore'
+complete -c git -f -n '__fish_git_using_command ignore' -s p -l private -d 'set context to private gitignore'
+complete -c git -f -n '__fish_git_using_command ignore' -s e -l edit -d 'set action to edit'
+complete -c git -f -n '__fish_git_using_command ignore' -s r -l remove -d 'set action to remove'
 # ignore-io
 function __fish_git_extra_get_ignore_io_types
     # we will first remove every tab spaces, and then append `\t` at the end to remove the default description

--- a/man/git-extras.md
+++ b/man/git-extras.md
@@ -62,7 +62,7 @@ git-extras(1) -- Awesome GIT utilities
    - **git-graft(1)** Merge and destroy a given branch
    - **git-guilt(1)** calculate change between two revisions
    - **git-ignore-io(1)** Get sample gitignore file
-   - **git-ignore(1)** Add .gitignore patterns
+   - **git-ignore(1)** Modify or display .gitignore files
    - **git-info(1)** Returns information on current repository
    - **git-local-commits(1)** List local commits
    - **git-lock(1)** Lock a file excluded from version control

--- a/man/git-ignore.1
+++ b/man/git-ignore.1
@@ -1,77 +1,84 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "GIT\-IGNORE" "1" "April 2018" "" "Git Extras"
-.
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "GIT\-IGNORE" "1" "June 2026" "" "Git Extras"
 .SH "NAME"
-\fBgit\-ignore\fR \- Add \.gitignore patterns
-.
+\fBgit\-ignore\fR \- Modify or display \.gitignore files
 .SH "SYNOPSIS"
-\fBgit\-ignore\fR [<context>] [<pattern> [<pattern>]\.\.\.]
-.
+\fBgit\-ignore\fR [<context>] [<action>] [\-\-] [<pattern> [<pattern>]\|\.\|\.\|\.]
 .SH "DESCRIPTION"
-Adds the given _pattern_s to a \.gitignore file if it doesn\'t already exist\.
-.
+Modifies or shows \.gitignore of selected \fIcontext\fR\.
+.P
+Possible actions are: addition of new \fIpattern\fRs, removal of existing \fIpattern\fRs from gitignore files, opening these files in text editor or simply displaying their contents in current terminal (for details see flags/usage)\.
+.P
+Contexts are global (e\.g\. $HOME/\.gitignore or $HOME/\.local/\.git/\.gitignore), private (e\.g\. \|\.\|\.\|\./project/\.git/info/exclude) and local (e\.g\. \|\.\|\.\|\./project/\.gitignore)
+.P
+Adding only happens for \fIpattern\fRs that don't already exist in the file; removing \fIpattern\fRs that are not present does not do anything; editing fails if the file is not yet present\.
+.P
+At most 1 \fIcontext\fR and 1 \fIaction\fR matter for the program, the ones selected are the latest encountered in the flag list\.
+.P
+Default behavior:
+.IP "\(bu" 4
+If no flags or arguments are passed, prints gitignores of all 3 \fIcontext\fRs\.
+.IP "\(bu" 4
+Passing arguments with no \fIaction\fR implies addition of \fIpattern\fRs to gitignore\.
+.IP "\(bu" 4
+If an \fIaction\fR is chosen, but not \fIcontext\fR, \fIaction\fR is performed on local gitignore\.
+.IP "\(bu" 4
+If \fIcontext\fR is chosen but not action (not even implied), gitignore of chosen \fIcontext\fR is printed\.
+.IP "" 0
 .SH "OPTIONS"
 <context>
-.
 .P
 \-l, \-\-local
-.
 .P
 Sets the context to the \.gitignore file in the current working directory\. (default)
-.
 .P
 \-g, \-\-global
-.
 .P
 Sets the context to the global gitignore file for the current user\.
-.
 .P
 \-p, \-\-private
-.
 .P
 Sets the context to the private exclude file for the repository (\fB\.git/info/exclude\fR)\.
-.
+.P
+<action>
+.P
+\-e, \-\-edit
+.P
+Sets action to edit\. This will open gitignore in a text editor (editor selection is the same as for git commit)\. If no \fIcontext\fR is provided local is assumed\. Any \fIpattern\fR; provided in additional arguments is silently omitted\.
+.P
+\-r, \-\-remove
+.P
+Sets action to remove\. This will look for \fIpattern\fRs in gitignore of selected \fIcontext\fR and remove if finds them\. If no \fIpattern\fR is provided does nothing\. All characters in \fIpattern\fR are treated literally, no interpretation of metacharacters is performed as would be, for example, for a regex pattern\.
 .P
 <pattern>
-.
 .P
 A space delimited list of patterns to append to the file in context\.
-.
+.P
+\-\-
+.P
+End of options delimeter\. Everything to the right of it is treated as positional arguments or more precisely a \fIpattern\fR\.
 .SS "PATTERN FORMAT"
 Pattern format as described in the git manual
-.
 .IP "\(bu" 4
 A blank line matches no files, so it can serve as a separator for readability\. To append a blank line use empty quotes ""\.
-.
 .IP "\(bu" 4
 A line starting with # serves as a comment\. For example, "# This is a comment"
-.
 .IP "\(bu" 4
-An optional prefix ! which negates the pattern; any matching file excluded by a previous pattern will become included again\. If a negated pattern matches, this will override lower precedence patterns sources\. To use an exclamation ! as command line argument it is best placed between single quotes \'\'\. For example, \'!src\'
-.
+An optional prefix ! which negates the pattern; any matching file excluded by a previous pattern will become included again\. If a negated pattern matches, this will override lower precedence patterns sources\. To use an exclamation ! as command line argument it is best placed between single quotes ''\. For example, '!src'
 .IP "\(bu" 4
 If the pattern ends with a slash, it is removed for the purpose of the following description, but it would only find a match with a directory\. In other words, foo/ will match a directory foo and paths underneath it, but will not match a regular file or a symbolic link foo (this is consistent with the way how pathspec works in general in git)\.
-.
 .IP "\(bu" 4
 If the pattern does not contain a slash /, git treats it as a shell glob pattern and checks for a match against the pathname relative to the location of the \.gitignore file (relative to the top level of the work tree if not from a \.gitignore file)\.
-.
 .IP "\(bu" 4
 Otherwise, git treats the pattern as a shell glob suitable for consumption by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the pattern will not match a / in the pathname\. For example, "Documentation/*\.html" matches "Documentation/git\.html" but not "Documentation/ppc/ppc\.html" or "tools/perf/Documentation/perf\.html"\.
-.
 .IP "\(bu" 4
 A leading slash matches the beginning of the pathname\. For example, "/*\.c" matches "cat\-file\.c" but not "mozilla\-sha1/sha1\.c"\.
-.
 .IP "" 0
-.
 .SH "EXAMPLES"
-All arguments are optional so calling git\-ignore alone will display first the global then the local gitignore files:
-.
+All arguments are optional so calling git\-ignore alone will display global, local and private gitignore files in order:
 .IP "" 4
-.
 .nf
-
 $ git ignore
 Global gitignore: /home/alice/\.gitignore
 # Numerous always\-ignore extensions
@@ -86,92 +93,101 @@ Global gitignore: /home/alice/\.gitignore
 *\.sass\-cache
 
 # OS or Editor folders
-\.DS_Store
-\.Trashes
-\._*
+\&\.DS_Store
+\&\.Trashes
+\&\._*
 Thumbs\.db
 \-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
 Local gitignore: \.gitignore
-\.cache
-\.project
-\.settings
-\.tmproj
+\&\.cache
+\&\.project
+\&\.settings
+\&\.tmproj
 nbproject
-.
+\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-
+Private gitignore: \.git/info/exclude
+notes\.txt
+test\.sh
+\&\.env\.local
+config\.json
 .fi
-.
 .IP "" 0
-.
 .P
-If you only want to see the global context use the \-\-global argument (for local use \-\-local):
-.
+If you only want to see the global context use the \-\-global argument (for local use \-\-local, for private use \-\-private):
 .IP "" 4
-.
 .nf
-
 $ git ignore
 Global gitignore: /home/alice/\.gitignore
-\.DS_Store
-\.Trashes
-\._*
+\&\.DS_Store
+\&\.Trashes
+\&\._*
 Thumbs\.db
-.
 .fi
-.
 .IP "" 0
-.
 .P
 To quickly append a new pattern to the default/local context simply:
-.
 .IP "" 4
-.
 .nf
-
 $ git ignore *\.log
 Adding pattern(s) to: \.gitignore
-\.\.\. adding \'*\.log\'
-.
+\|\.\|\.\|\. adding '*\.log'
 .fi
-.
 .IP "" 0
-.
 .P
-You can now configure any patterns without ever using an editor, with a context and pattern arguments: The resulting configuration is also returned for your convenience\.
-.
+You can now configure any patterns without ever using an editor (or use a shortcut to open file in editor when needed), with a context and pattern arguments: The resulting configuration is also returned for your convenience\.
 .IP "" 4
-.
 .nf
-
-$ git ignore \-\-local "" "# Temporary files" *\.tmp "*\.log" tmp/*  "" "# Files I\'d like to keep" \'!work\'  ""
+$ git ignore \-\-local "" "# Temporary files" *\.tmp "*\.log" tmp/*  "" "# Files I'd like to keep" '!work'  ""
 Adding pattern(s) to: \.gitignore
-\.\.\. adding \'\'
-\.\.\. adding \'# Temporary files\'
-\.\.\. adding \'index\.tmp\'
-\.\.\. adding \'*\.log\'
-\.\.\. adding \'tmp/*\'
-\.\.\. adding \'\'
-\.\.\. adding \'# Files I\'d like to keep\'
-\.\.\. adding \'!work\'
-\.\.\. adding \'\'
+\|\.\|\.\|\. adding ''
+\|\.\|\.\|\. adding '# Temporary files'
+\|\.\|\.\|\. adding '*\.tmp'
+\|\.\|\.\|\. adding '*\.log'
+\|\.\|\.\|\. adding 'tmp/*'
+\|\.\|\.\|\. adding ''
+\|\.\|\.\|\. adding '# Files I'd like to keep'
+\|\.\|\.\|\. adding '!work'
+\|\.\|\.\|\. adding ''
 
 Local gitignore: \.gitignore
 
 # Temporary files
-index\.tmp
+*\.tmp
 *\.log
+tmp/*
 
-# Files I\'d like to keep
+# Files I'd like to keep
 !work
-.
 .fi
-.
 .IP "" 0
-.
+.P
+Removing patterns works in a similar way\. Select context and pass patterns to be removed from the gitignore file\.
+.IP "" 4
+.nf
+$ git ignore \-l \-r "*\.log"
+Removing patterns from local gitignore: \.gitignore
+\|\.\|\.\|\. removing '*\.log'
+
+Local gitignore: \.gitignore
+
+# Temporary files
+*\.tmp
+tmp/*
+
+# Files I'd like to keep
+!work
+.fi
+.IP "" 0
+.P
+If you want to open gitignore in an editor and do changes manually pass \-e flag:
+.IP "" 4
+.nf
+$ git ignore \-p \-e
+.fi
+.IP "" 0
 .SH "AUTHOR"
-Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR> and Tema Bolshakov <\fItweekane@gmail\.com\fR> and Nick Lombard <\fIgithub@jigsoft\.co\.za\fR>
-.
+Written by Tj Holowaychuk <\fItj@vision\-media\.ca\fR> and Tema Bolshakov <\fItweekane@gmail\.com\fR> and Nick Lombard <\fIgithub@jigsoft\.co\.za\fR&gt and Kirill Dergachev <\fIkdergachev1062@gmail\.com\fR>
 .SH "REPORTING BUGS"
 <\fIhttps://github\.com/tj/git\-extras/issues\fR>
-.
 .SH "SEE ALSO"
 <\fIhttps://github\.com/tj/git\-extras\fR>

--- a/man/git-ignore.1
+++ b/man/git-ignore.1
@@ -58,6 +58,10 @@ A space delimited list of patterns to append to the file in context\.
 \-\-
 .P
 End of options delimeter\. Everything to the right of it is treated as positional arguments or more precisely a \fIpattern\fR\.
+.P
+\-h, \-\-help
+.P
+Print a brief usage summary\.
 .SS "PATTERN FORMAT"
 Pattern format as described in the git manual
 .IP "\(bu" 4

--- a/man/git-ignore.html
+++ b/man/git-ignore.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
-  <title>git-ignore(1) - Add .gitignore patterns</title>
+  <meta http-equiv='content-type' content='text/html;charset=utf-8'>
+  <meta name='generator' content='Ronn-NG/v0.10.1 (http://github.com/apjanke/ronn-ng/tree/0.10.1)'>
+  <title>git-ignore(1) - Modify or display .gitignore files</title>
   <style type='text/css' media='all'>
   /* style: man */
   body#manpage {margin:0}
@@ -69,57 +69,110 @@
     <li class='tr'>git-ignore(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
-<p class="man-name">
-  <code>git-ignore</code> - <span class="man-whatis">Add .gitignore patterns</span>
-</p>
+  
 
+<h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-ignore</code> - <span class="man-whatis">Modify or display .gitignore files</span>
+</p>
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p><code>git-ignore</code> [&lt;context&gt;] [&lt;pattern&gt; [&lt;pattern&gt;]...]</p>
+<p><code>git-ignore</code> [&lt;context&gt;] [&lt;action&gt;] [--] [&lt;pattern&gt; [&lt;pattern&gt;]...]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p>Adds the given _pattern_s to a .gitignore file if it doesn't already exist.</p>
+<p>Modifies or shows .gitignore of selected <em>context</em>.</p>
+
+<p>Possible actions are: addition of new <em>pattern</em>s, removal of existing <em>pattern</em>s from gitignore files, opening these files in text editor or simply displaying their contents in current terminal (for details see flags/usage).</p>
+
+<p>Contexts are global (e.g. $HOME/.gitignore or $HOME/.local/.git/.gitignore), private (e.g. .../project/.git/info/exclude) and local (e.g. .../project/.gitignore)</p>
+
+<p>Adding only happens for <em>pattern</em>s that don't already exist in the file; removing <em>pattern</em>s that are not present does not do anything; editing fails if the file is not yet present.</p>
+
+<p>At most 1 <em>context</em> and 1 <em>action</em> matter for the program, the ones selected are the latest encountered in the flag list.</p>
+
+<p>Default behavior:</p>
+
+<ul>
+  <li>
+    <p>If no flags or arguments are passed, prints gitignores of all 3 <em>context</em>s.</p>
+  </li>
+  <li>
+    <p>Passing arguments with no <em>action</em> implies addition of <em>pattern</em>s to gitignore.</p>
+  </li>
+  <li>
+    <p>If an <em>action</em> is chosen, but not <em>context</em>, <em>action</em> is performed on local gitignore.</p>
+  </li>
+  <li>
+    <p>If <em>context</em> is chosen but not action (not even implied), gitignore of chosen <em>context</em> is printed.</p>
+  </li>
+</ul>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>  &lt;context&gt;</p>
+<p>&lt;context&gt;</p>
 
-<p>  -l, --local</p>
+<p>-l, --local</p>
 
-<p>  Sets the context to the .gitignore file in the current working directory. (default)</p>
+<p>Sets the context to the .gitignore file in the current working directory. (default)</p>
 
-<p>  -g, --global</p>
+<p>-g, --global</p>
 
-<p>  Sets the context to the global gitignore file for the current user.</p>
+<p>Sets the context to the global gitignore file for the current user.</p>
 
-<p>  -p, --private</p>
+<p>-p, --private</p>
 
-<p>  Sets the context to the private exclude file for the repository (<code>.git/info/exclude</code>).</p>
+<p>Sets the context to the private exclude file for the repository (<code>.git/info/exclude</code>).</p>
 
-<p>  &lt;pattern&gt;</p>
+<p>&lt;action&gt;</p>
 
-<p>  A space delimited list of patterns to append to the file in context.</p>
+<p>-e, --edit</p>
+
+<p>Sets action to edit. This will open gitignore in a text editor (editor selection is the same as for git commit). If no <em>context</em> is provided local is assumed. Any <em>pattern</em>; provided in additional arguments is silently omitted.</p>
+
+<p>-r, --remove</p>
+
+<p>Sets action to remove. This will look for <em>pattern</em>s in gitignore of selected <em>context</em> and remove if finds them. If no <em>pattern</em> is provided does nothing. All characters in <em>pattern</em> are treated literally, no interpretation of metacharacters is performed as would be, for example, for a regex pattern.</p>
+
+<p>&lt;pattern&gt;</p>
+
+<p>A space delimited list of patterns to append to the file in context.</p>
+
+<p>--</p>
+
+<p>End of options delimeter. Everything to the right of it is treated as positional arguments or more precisely a <em>pattern</em>.</p>
 
 <h3 id="PATTERN-FORMAT">PATTERN FORMAT</h3>
 
 <p>Pattern format as described in the git manual</p>
 
 <ul>
-<li><p>A blank line matches no files, so it can serve as a separator for readability. To append a blank line use empty quotes "".</p></li>
-<li><p>A line starting with # serves as a comment. For example, "# This is a comment"</p></li>
-<li><p>An optional prefix ! which negates the pattern; any matching file excluded by a previous pattern will become included again. If a negated pattern matches, this will override lower precedence patterns sources. To use an exclamation ! as command line argument it is best placed between single quotes ''. For example, '!src'</p></li>
-<li><p>If the pattern ends with a slash, it is removed for the purpose of the following description, but it would only find a match with a directory. In other words, foo/ will match a directory foo and paths underneath it, but will not match a regular file or a symbolic link foo (this is consistent with the way how pathspec works in general in git).</p></li>
-<li><p>If the pattern does not contain a slash /, git treats it as a shell glob pattern and checks for a match against the pathname relative to the location of the .gitignore file (relative to the top level of the work tree if not from a .gitignore file).</p></li>
-<li><p>Otherwise, git treats the pattern as a shell glob suitable for consumption by <span class="man-ref">fnmatch<span class="s">(3)</span></span> with the FNM_PATHNAME flag: wildcards in the pattern will not match a / in the pathname. For example, "Documentation/*.html" matches "Documentation/git.html" but not "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".</p></li>
-<li><p>A leading slash matches the beginning of the pathname. For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".</p></li>
+  <li>
+    <p>A blank line matches no files, so it can serve as a separator for readability. To append a blank line use empty quotes "".</p>
+  </li>
+  <li>
+    <p>A line starting with # serves as a comment. For example, "# This is a comment"</p>
+  </li>
+  <li>
+    <p>An optional prefix ! which negates the pattern; any matching file excluded by a previous pattern will become included again. If a negated pattern matches, this will override lower precedence patterns sources. To use an exclamation ! as command line argument it is best placed between single quotes ''. For example, '!src'</p>
+  </li>
+  <li>
+    <p>If the pattern ends with a slash, it is removed for the purpose of the following description, but it would only find a match with a directory. In other words, foo/ will match a directory foo and paths underneath it, but will not match a regular file or a symbolic link foo (this is consistent with the way how pathspec works in general in git).</p>
+  </li>
+  <li>
+    <p>If the pattern does not contain a slash /, git treats it as a shell glob pattern and checks for a match against the pathname relative to the location of the .gitignore file (relative to the top level of the work tree if not from a .gitignore file).</p>
+  </li>
+  <li>
+    <p>Otherwise, git treats the pattern as a shell glob suitable for consumption by <span class="man-ref">fnmatch<span class="s">(3)</span></span> with the FNM_PATHNAME flag: wildcards in the pattern will not match a / in the pathname. For example, "Documentation/*.html" matches "Documentation/git.html" but not "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".</p>
+  </li>
+  <li>
+    <p>A leading slash matches the beginning of the pathname. For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".</p>
+  </li>
 </ul>
-
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
-<p>  All arguments are optional so calling git-ignore alone will display first the global then the local gitignore files:</p>
+<p>All arguments are optional so calling git-ignore alone will display global, local and private gitignore files in order:</p>
 
 <pre><code>$ git ignore
 Global gitignore: /home/alice/.gitignore
@@ -146,9 +199,15 @@ Local gitignore: .gitignore
 .settings
 .tmproj
 nbproject
+---------------------------------
+Private gitignore: .git/info/exclude
+notes.txt
+test.sh
+.env.local
+config.json
 </code></pre>
 
-<p>If you only want to see the global context use the --global argument (for local use --local):</p>
+<p>If you only want to see the global context use the --global argument (for local use --local, for private use --private):</p>
 
 <pre><code>$ git ignore
 Global gitignore: /home/alice/.gitignore
@@ -165,14 +224,14 @@ Adding pattern(s) to: .gitignore
 ... adding '*.log'
 </code></pre>
 
-<p>You can now configure any patterns without ever using an editor, with a context and pattern arguments:
+<p>You can now configure any patterns without ever using an editor (or use a shortcut to open file in editor when needed), with a context and pattern arguments:
 The resulting configuration is also returned for your convenience.</p>
 
 <pre><code>$ git ignore --local "" "# Temporary files" *.tmp "*.log" tmp/*  "" "# Files I'd like to keep" '!work'  ""
 Adding pattern(s) to: .gitignore
 ... adding ''
 ... adding '# Temporary files'
-... adding 'index.tmp'
+... adding '*.tmp'
 ... adding '*.log'
 ... adding 'tmp/*'
 ... adding ''
@@ -183,17 +242,39 @@ Adding pattern(s) to: .gitignore
 Local gitignore: .gitignore
 
 # Temporary files
-index.tmp
+*.tmp
 *.log
+tmp/*
 
 # Files I'd like to keep
 !work
 </code></pre>
 
+<p>Removing patterns works in a similar way. Select context and pass patterns to be removed from the gitignore file.</p>
+
+<pre><code>$ git ignore -l -r "*.log"
+Removing patterns from local gitignore: .gitignore
+... removing '*.log'
+
+Local gitignore: .gitignore
+
+# Temporary files
+*.tmp
+tmp/*
+
+# Files I'd like to keep
+!work
+</code></pre>
+
+<p>If you want to open gitignore in an editor and do changes manually pass -e flag:</p>
+
+<pre><code>$ git ignore -p -e
+</code></pre>
+
 <h2 id="AUTHOR">AUTHOR</h2>
 
-<p>Written by Tj Holowaychuk &lt;<a href="&#x6d;&#97;&#105;&#108;&#x74;&#111;&#58;&#116;&#x6a;&#x40;&#x76;&#105;&#115;&#105;&#111;&#110;&#x2d;&#x6d;&#x65;&#100;&#x69;&#97;&#46;&#x63;&#x61;" data-bare-link="true">&#116;&#106;&#x40;&#118;&#x69;&#x73;&#x69;&#x6f;&#110;&#45;&#109;&#101;&#100;&#105;&#97;&#x2e;&#99;&#97;</a>&gt; and Tema Bolshakov &lt;<a href="&#x6d;&#97;&#105;&#x6c;&#116;&#x6f;&#58;&#116;&#x77;&#101;&#101;&#107;&#x61;&#x6e;&#101;&#x40;&#x67;&#x6d;&#97;&#x69;&#108;&#46;&#x63;&#111;&#x6d;" data-bare-link="true">&#x74;&#119;&#x65;&#x65;&#107;&#x61;&#110;&#x65;&#x40;&#103;&#x6d;&#97;&#105;&#x6c;&#x2e;&#x63;&#x6f;&#x6d;</a>&gt;
-and Nick Lombard &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#58;&#x67;&#105;&#116;&#104;&#117;&#x62;&#x40;&#x6a;&#105;&#103;&#x73;&#x6f;&#x66;&#116;&#46;&#x63;&#x6f;&#x2e;&#x7a;&#97;" data-bare-link="true">&#103;&#105;&#116;&#104;&#x75;&#98;&#x40;&#106;&#105;&#103;&#115;&#x6f;&#102;&#x74;&#x2e;&#x63;&#111;&#x2e;&#122;&#x61;</a>&gt;</p>
+<p>Written by Tj Holowaychuk &lt;<a href="mailto:tj@vision-media.ca" data-bare-link="true">tj@vision-media.ca</a>&gt; and Tema Bolshakov &lt;<a href="mailto:tweekane@gmail.com" data-bare-link="true">tweekane@gmail.com</a>&gt;
+and Nick Lombard &lt;<a href="mailto:github@jigsoft.co.za" data-bare-link="true">github@jigsoft.co.za</a>&amp;gt and Kirill Dergachev &lt;<a href="mailto:kdergachev1062@gmail.com" data-bare-link="true">kdergachev1062@gmail.com</a>&gt;</p>
 
 <h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
 
@@ -203,10 +284,9 @@ and Nick Lombard &lt;<a href="&#109;&#97;&#x69;&#x6c;&#116;&#111;&#58;&#x67;&#10
 
 <p>&lt;<a href="https://github.com/tj/git-extras" data-bare-link="true">https://github.com/tj/git-extras</a>&gt;</p>
 
-
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>April 2018</li>
+    <li class='tc'>June 2026</li>
     <li class='tr'>git-ignore(1)</li>
   </ol>
 

--- a/man/git-ignore.html
+++ b/man/git-ignore.html
@@ -142,6 +142,10 @@
 
 <p>End of options delimeter. Everything to the right of it is treated as positional arguments or more precisely a <em>pattern</em>.</p>
 
+<p>-h, --help</p>
+
+<p>Print a brief usage summary.</p>
+
 <h3 id="PATTERN-FORMAT">PATTERN FORMAT</h3>
 
 <p>Pattern format as described in the git manual</p>

--- a/man/git-ignore.md
+++ b/man/git-ignore.md
@@ -61,6 +61,10 @@ Default behavior:
 
   End of options delimeter. Everything to the right of it is treated as positional arguments or more precisely a *pattern*.
 
+  -h, --help
+
+  Print a brief usage summary.
+
 ### PATTERN FORMAT
 
 Pattern format as described in the git manual

--- a/man/git-ignore.md
+++ b/man/git-ignore.md
@@ -1,13 +1,31 @@
-git-ignore(1) -- Add .gitignore patterns
+git-ignore(1) -- Modify or display .gitignore files
 ========================================
 
 ## SYNOPSIS
 
-`git-ignore` [&lt;context&gt;] [&lt;pattern&gt; [&lt;pattern&gt;]...]
+`git-ignore` [&lt;context&gt;] [&lt;action&gt;] [--] [&lt;pattern&gt; [&lt;pattern&gt;]...]
 
 ## DESCRIPTION
 
-Adds the given _pattern_s to a .gitignore file if it doesn't already exist.
+Modifies or shows .gitignore of selected *context*.
+
+Possible actions are: addition of new *pattern*s, removal of existing *pattern*s from gitignore files, opening these files in text editor or simply displaying their contents in current terminal (for details see flags/usage).
+
+Contexts are global (e.g. $HOME/.gitignore or $HOME/.local/.git/.gitignore), private (e.g. .../project/.git/info/exclude) and local (e.g. .../project/.gitignore)
+
+Adding only happens for *pattern*s that don't already exist in the file; removing *pattern*s that are not present does not do anything; editing fails if the file is not yet present.
+
+At most 1 *context* and 1 *action* matter for the program, the ones selected are the latest encountered in the flag list.
+
+Default behavior:
+
+* If no flags or arguments are passed, prints gitignores of all 3 *context*s.
+
+* Passing arguments with no *action* implies addition of *pattern*s to gitignore.
+
+* If an *action* is chosen, but not *context*, *action* is performed on local gitignore.
+
+* If *context* is chosen but not action (not even implied), gitignore of chosen *context* is printed.
 
 ## OPTIONS
 
@@ -25,9 +43,23 @@ Adds the given _pattern_s to a .gitignore file if it doesn't already exist.
 
   Sets the context to the private exclude file for the repository (`.git/info/exclude`).
 
+  &lt;action&gt;
+
+  -e, --edit
+
+  Sets action to edit. This will open gitignore in a text editor (editor selection is the same as for git commit). If no *context* is provided local is assumed. Any *pattern*; provided in additional arguments is silently omitted.
+
+  -r, --remove
+
+  Sets action to remove. This will look for *pattern*s in gitignore of selected *context* and remove if finds them. If no *pattern* is provided does nothing. All characters in *pattern* are treated literally, no interpretation of metacharacters is performed as would be, for example, for a regex pattern.
+
   &lt;pattern&gt;
 
   A space delimited list of patterns to append to the file in context.
+
+  --
+
+  End of options delimeter. Everything to the right of it is treated as positional arguments or more precisely a *pattern*.
 
 ### PATTERN FORMAT
 
@@ -43,14 +75,14 @@ Pattern format as described in the git manual
 
  * If the pattern does not contain a slash /, git treats it as a shell glob pattern and checks for a match against the pathname relative to the location of the .gitignore file (relative to the top level of the work tree if not from a .gitignore file).
 
- * Otherwise, git treats the pattern as a shell glob suitable for consumption by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the pattern will not match a / in the pathname. For example, "Documentation/*.html" matches "Documentation/git.html" but not "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".
+ * Otherwise, git treats the pattern as a shell glob suitable for consumption by fnmatch(3) with the FNM\_PATHNAME flag: wildcards in the pattern will not match a / in the pathname. For example, "Documentation/\*.html" matches "Documentation/git.html" but not "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".
 
- * A leading slash matches the beginning of the pathname. For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
+ * A leading slash matches the beginning of the pathname. For example, "/\*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
 
 
 ## EXAMPLES
 
-  All arguments are optional so calling git-ignore alone will display first the global then the local gitignore files:
+  All arguments are optional so calling git-ignore alone will display global, local and private gitignore files in order:
 
     $ git ignore
     Global gitignore: /home/alice/.gitignore
@@ -77,8 +109,14 @@ Pattern format as described in the git manual
     .settings
     .tmproj
     nbproject
+    ---------------------------------
+    Private gitignore: .git/info/exclude
+    notes.txt
+    test.sh
+    .env.local
+    config.json
 
-If you only want to see the global context use the --global argument (for local use --local):
+If you only want to see the global context use the --global argument (for local use --local, for private use --private):
 
     $ git ignore
     Global gitignore: /home/alice/.gitignore
@@ -93,34 +131,55 @@ To quickly append a new pattern to the default/local context simply:
     Adding pattern(s) to: .gitignore
     ... adding '*.log'
 
-You can now configure any patterns without ever using an editor, with a context and pattern arguments:
+You can now configure any patterns without ever using an editor (or use a shortcut to open file in editor when needed), with a context and pattern arguments:
 The resulting configuration is also returned for your convenience.
 
     $ git ignore --local "" "# Temporary files" *.tmp "*.log" tmp/*  "" "# Files I'd like to keep" '!work'  ""
     Adding pattern(s) to: .gitignore
     ... adding ''
     ... adding '# Temporary files'
-    ... adding 'index.tmp'
+    ... adding '*.tmp'
     ... adding '*.log'
     ... adding 'tmp/*'
     ... adding ''
     ... adding '# Files I'd like to keep'
     ... adding '!work'
     ... adding ''
-
+    
     Local gitignore: .gitignore
-
+    
     # Temporary files
-    index.tmp
+    *.tmp
     *.log
+    tmp/*
 
     # Files I'd like to keep
     !work
 
+Removing patterns works in a similar way. Select context and pass patterns to be removed from the gitignore file.
+
+    $ git ignore -l -r "*.log"
+    Removing patterns from local gitignore: .gitignore
+    ... removing '*.log'
+
+    Local gitignore: .gitignore
+
+    # Temporary files
+    *.tmp
+    tmp/*
+    
+    # Files I'd like to keep
+    !work
+
+If you want to open gitignore in an editor and do changes manually pass -e flag:
+
+    $ git ignore -p -e
+
+
 ## AUTHOR
 
 Written by Tj Holowaychuk &lt;<tj@vision-media.ca>&gt; and Tema Bolshakov &lt;<tweekane@gmail.com>&gt;
-and Nick Lombard &lt;<github@jigsoft.co.za>&gt;
+and Nick Lombard &lt;<github@jigsoft.co.za>&gt and Kirill Dergachev &lt;<kdergachev1062@gmail.com>&gt;
 
 ## REPORTING BUGS
 

--- a/man/git-ignore.md
+++ b/man/git-ignore.md
@@ -59,7 +59,7 @@ Default behavior:
 
   --
 
-  End of options delimeter. Everything to the right of it is treated as positional arguments or more precisely a *pattern*.
+  End of options delimiter. Everything to the right of it is treated as positional arguments or more precisely a *pattern*.
 
   -h, --help
 


### PR DESCRIPTION
PR for issue #1257

These commits introduce flags -r/--remove and -e/--edit to git-ignore to allow removing patterns the same way they can be added and for opening ignore files in a text editor. Some other minor changes like '--' flag-argument separator introduced. New version is mostly backwards-compatible with old one.

Some quirks/things to consider:
- Flags for actions/locations override each other and the last is the actual one.
- Temporary file creation for remove (found that filling tmp file with double loop over lines and patterns is the best way to remove a list of patterns while not interpreting patterns as regex or any other type of special symbols, maybe there is a better way)
- Should edit action create a file if one does not exist?
- Unnecessary arguments are not checked for and just omitted

Submitting this as a draft, and if everything's OK/after changes are made will modify documentation accordingly (same for output with -h/--help flags).