### PR TITLE
fix: support Windows ARM64 (clangarm64) in install.cmd

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -39,13 +39,25 @@ goto :defaultpath
 rem remove the last slash
 SET bindir=%bindir:~0,-1%
 for %%G in ("%bindir%") do set installdir=%%~dpG
-set PREFIX=%installdir%mingw64
+if exist "%installdir%mingw64" (
+    set PREFIX=%installdir%mingw64
+) else if exist "%installdir%clangarm64" (
+    set PREFIX=%installdir%clangarm64
+) else (
+    set PREFIX=%installdir%mingw64
+)
 goto :foundprefix
 
 :defaultpath
 :: default for Git for Windows 2.x
 if exist "%ProgramFiles%\Git" (
-    set PREFIX=%ProgramFiles%\Git\mingw64
+    if exist "%ProgramFiles%\Git\mingw64" (
+        set PREFIX=%ProgramFiles%\Git\mingw64
+    ) else if exist "%ProgramFiles%\Git\clangarm64" (
+        set PREFIX=%ProgramFiles%\Git\clangarm64
+    ) else (
+        set PREFIX=%ProgramFiles%\Git\mingw64
+    )
 )
 
 :foundprefix
@@ -55,6 +67,8 @@ IF NOT "%~1"=="" (
     REM just supplying the git dir is enough...
     if exist "%~1\mingw64" (
         set PREFIX=%~1\mingw64
+    ) else if exist "%~1\clangarm64" (
+        set PREFIX=%~1\clangarm64
     ) else (
         echo Using git install path "%~1" as PREFIX, please make sure it's really a
         echo path to the mingw64 directory...
@@ -72,12 +86,14 @@ set GIT_INSTALL_DIR=!GIT_INSTALL_DIR:"=!
 IF %GIT_INSTALL_DIR:~-1%==\ SET GIT_INSTALL_DIR=%GIT_INSTALL_DIR:~0,-1%
 
 if not exist "%GIT_INSTALL_DIR%\mingw64" (
-    echo No mingw64 folder found in %GIT_INSTALL_DIR%.
-    echo.
-    echo Please supply a proper "Git for Windows 2.x" install path:
-    echo "install.cmd c:\[git-install-path]"
-    set ERROR=1
-    goto :exit
+    if not exist "%GIT_INSTALL_DIR%\clangarm64" (
+        echo No mingw64 or clangarm64 folder found in %GIT_INSTALL_DIR%.
+        echo.
+        echo Please supply a proper "Git for Windows 2.x" install path:
+        echo "install.cmd c:\[git-install-path]"
+        set ERROR=1
+        goto :exit
+    )
 )
 
 echo Installing to %PREFIX%

--- a/install.cmd
+++ b/install.cmd
@@ -71,7 +71,7 @@ IF NOT "%~1"=="" (
         set PREFIX=%~1\clangarm64
     ) else (
         echo Using git install path "%~1" as PREFIX, please make sure it's really a
-        echo path to the mingw64 directory...
+        echo path to the mingw64 or clangarm64 directory...
         echo.
         SET PREFIX=%~1
     )

--- a/install.cmd
+++ b/install.cmd
@@ -132,7 +132,7 @@ FOR /R "%GITEXTRAS%\bin" %%i in (*.*) DO (
     TYPE "%GITEXTRAS%\helper\reset-env" >> "%PREFIX%\bin\%%~ni"
     TYPE "%GITEXTRAS%\helper\git-extra-utility" >> "%PREFIX%\bin\%%~ni"
     TYPE "%GITEXTRAS%\helper\is-git-repo" >> "%PREFIX%\bin\%%~ni"
-    
+
     REM Added /E option for installation fix on Windows 10.0.17134 and higher
     MORE /E +2 "%GITEXTRAS%\bin\%%~ni" >> "%PREFIX%\bin\%%~ni"
 )
@@ -143,7 +143,7 @@ FOR %%i in (%COMMANDS_WITHOUT_REPO%) DO (
     ECHO #^^!/usr/bin/env bash > "%PREFIX%\bin\%%i"
     TYPE "%GITEXTRAS%\helper\reset-env" >> "%PREFIX%\bin\%%i"
     TYPE "%GITEXTRAS%\helper\git-extra-utility" >> "%PREFIX%\bin\%%i"
-    
+
     REM Added /E option for installation fix on Windows 10.0.17134 and higher
     MORE /E +2 "%GITEXTRAS%\bin\%%i" >> "%PREFIX%\bin\%%i"
 )

--- a/install.cmd
+++ b/install.cmd
@@ -39,16 +39,21 @@ goto :defaultpath
 rem remove the last slash
 SET bindir=%bindir:~0,-1%
 for %%G in ("%bindir%") do set installdir=%%~dpG
-if exist "%installdir%mingw64" (
-    set PREFIX=%installdir%mingw64
-) else if exist "%installdir%clangarm64" (
-    set PREFIX=%installdir%clangarm64
-) else if exist "%installdir%..\mingw64" (
-    set PREFIX=%installdir%..\mingw64
-) else if exist "%installdir%..\clangarm64" (
-    set PREFIX=%installdir%..\clangarm64
+rem strip a trailing slash so we can inspect the leaf directory name
+if "%installdir:~-1%"=="\" set installdir=%installdir:~0,-1%
+rem git.exe found under <GitRoot>\mingw64\bin or <GitRoot>\clangarm64\bin
+rem means installdir already is the architecture directory itself
+for %%G in ("%installdir%") do set archdir=%%~nxG
+if /I "%archdir%"=="mingw64" (
+    set PREFIX=%installdir%
+) else if /I "%archdir%"=="clangarm64" (
+    set PREFIX=%installdir%
+) else if exist "%installdir%\mingw64" (
+    set PREFIX=%installdir%\mingw64
+) else if exist "%installdir%\clangarm64" (
+    set PREFIX=%installdir%\clangarm64
 ) else (
-    set PREFIX=%installdir%mingw64
+    set PREFIX=%installdir%\mingw64
 )
 goto :foundprefix
 

--- a/install.cmd
+++ b/install.cmd
@@ -43,6 +43,10 @@ if exist "%installdir%mingw64" (
     set PREFIX=%installdir%mingw64
 ) else if exist "%installdir%clangarm64" (
     set PREFIX=%installdir%clangarm64
+) else if exist "%installdir%..\mingw64" (
+    set PREFIX=%installdir%..\mingw64
+) else if exist "%installdir%..\clangarm64" (
+    set PREFIX=%installdir%..\clangarm64
 ) else (
     set PREFIX=%installdir%mingw64
 )


### PR DESCRIPTION
## Problem

Git for Windows on ARM64 uses a `clangarm64` directory instead of `mingw64`. Running `install.cmd` on an ARM64 Windows machine fails with:

> No mingw64 folder found in C:\Program Files\Git.

## Solution

Updated `install.cmd` to auto-detect `clangarm64` when `mingw64` is not present. The changes cover all four places where the script resolves the target directory:

1. **Auto-detection from PATH** — resolves the correct architecture directory regardless of where `git.exe` sits in PATH. It inspects the leaf directory name of the resolved install dir: if `git.exe` is found under `<GitRoot>\mingw64\bin` or `<GitRoot>\clangarm64\bin`, that architecture directory is used directly; otherwise the script looks for a `mingw64` or `clangarm64` subdirectory. This avoids the previously-possible non-existent `...\mingw64\mingw64` / `...\clangarm64\clangarm64` paths.
2. **Default path fallback** — same auto-detection for `%ProgramFiles%\Git`
3. **User-supplied path** — recognizes `clangarm64` in user-provided install paths
4. **Validation check** — accepts either `mingw64` or `clangarm64`

When both directories exist, `mingw64` is preferred to preserve existing behavior on x86/x64 systems.

## Testing

Tested on Windows 11 ARM64 with Git for Windows 2.54.0 (`clangarm64` layout). The installer now correctly detects and installs to `C:\Program Files\Git\clangarm64` without requiring the user to manually supply the path.

Additionally verified that PATH auto-detection resolves the correct `PREFIX` for all four common layouts, with no duplicated or `..` path segments:

- `<GitRoot>\cmd\git.exe` (x64) → `<GitRoot>\mingw64`
- `<GitRoot>\mingw64\bin\git.exe` → `<GitRoot>\mingw64`
- `<GitRoot>\cmd\git.exe` (ARM64) → `<GitRoot>\clangarm64`
- `<GitRoot>\clangarm64\bin\git.exe` → `<GitRoot>\clangarm64`