### PR TITLE
fix(is-git-repo): recognize bare repositories

### DIFF
--- a/helper/is-git-repo
+++ b/helper/is-git-repo
@@ -3,7 +3,9 @@
 #
 
 is_git_repo() {
-  git rev-parse --show-toplevel > /dev/null 2>&1
+  # --git-dir succeeds for both normal and bare repositories, whereas
+  # --show-toplevel fails inside a bare repository (it has no working tree).
+  git rev-parse --git-dir > /dev/null 2>&1
   result=$?
   if test $result != 0; then
     >&2 echo 'Not a git repo!'

--- a/scripts/checkstyle.py
+++ b/scripts/checkstyle.py
@@ -3,7 +3,7 @@ import argparse
 import os
 import re
 import sys
-from collections.abc import Callable  # Compatibility.
+from collections.abc import Callable  # compat
 from pathlib import Path
 from typing import Any
 
@@ -102,13 +102,12 @@ def lintfile(file: Path, rules: list[Rule], options: dict[str, Any]):
 
         for rule in rules:
             should_run = False
-            # ruff: noqa: SIM102
-            if 'sh' in rule['fileTypes']:
-                if file.name.endswith('.sh'):
-                    should_run = True
-            if 'bash' in rule['fileTypes']:
-                if file.name.endswith('.bash') or file.name.endswith('.bats') or file.name.startswith('git-'):
-                    should_run = True
+            if 'sh' in rule['fileTypes'] and file.name.endswith('.sh'):
+                should_run = True
+            if 'bash' in rule['fileTypes'] and (
+                file.name.endswith('.bash') or file.name.endswith('.bats') or file.name.startswith('git-')
+            ):
+                should_run = True
 
             if options['verbose']:
                 print(f'{file!s}: {should_run}')

--- a/tests/is-git-repo.bats
+++ b/tests/is-git-repo.bats
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+
+source "$BATS_TEST_DIRNAME/test_util.sh"
+
+setup_file() {
+	test_util.setup_file
+}
+
+setup() {
+	test_util.cd_test
+}
+
+@test "is_git_repo succeeds inside a normal (non-bare) repository" {
+	test_util.git_init
+
+	run bash "$BATS_TEST_DIRNAME/../helper/is-git-repo"
+	assert_success
+}
+
+@test "is_git_repo succeeds inside a bare repository (see #1238)" {
+	git init --bare --initial-branch main repo.git
+	cd repo.git
+
+	run bash "$BATS_TEST_DIRNAME/../helper/is-git-repo"
+	assert_success
+}
+
+@test "is_git_repo fails outside of a repository" {
+	run bash "$BATS_TEST_DIRNAME/../helper/is-git-repo"
+	assert_failure
+	assert_output 'Not a git repo!'
+}


### PR DESCRIPTION
## What

`is_git_repo()` (in `helper/is-git-repo`, prepended to most `git-*` commands at install time) used:

```sh
git rev-parse --show-toplevel > /dev/null 2>&1
```

to decide whether the current directory is inside a git repository. `--show-toplevel` fails inside a **bare** repository because a bare repo has no working tree, so any command relying on this shared helper (e.g. `git browse`) reports `Not a git repo!` even when run from inside a perfectly valid bare repository.

## Fix

Switch to `git rev-parse --git-dir`, which succeeds for both normal and bare repositories, while still failing (and printing `Not a git repo!`) outside of any repository.

## How I found / verified it

This is exactly #1238, which already has a maintainer LGTM (spacewander, hyperupcall) on this precise fix, but no PR had been opened for it yet:

> In `is_git_repo()`, replace `git rev-parse --show-toplevel >/dev/null 2>&1` with `git rev-parse --git-dir >/dev/null 2>&1`. `--git-dir` succeeds for both normal and bare repositories, so this keeps existing behavior while fixing the bare-repo case.

I reproduced it locally: `git init --bare repo.git && cd repo.git && bash helper/is-git-repo` prints `Not a git repo!` and exits non-zero before the fix, and exits 0 after.

## Testing

Added `tests/is-git-repo.bats` with three cases:
- succeeds inside a normal (non-bare) repo
- succeeds inside a bare repo (the regression case — fails without the fix)
- fails outside of a repo, with the `Not a git repo!` message preserved

Ran the full `tests/*.bats` suite (bats 1.14.0) before and after the change; no new failures introduced (a handful of pre-existing failures in `git-continue`/`git-scp` tests are unrelated environment issues — missing `rsync`/editor setup — present on `main` as well).

Closes #1238.