### PR TITLE
feat(mr): support Forgejo/Codeberg pull request URLs

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -1428,8 +1428,8 @@ $ git reset-file .htaccess dc82b19
 
 ## git mr
 
-Checks out a merge request from GitLab. Usage: `git mr <ID|URL> [REMOTE]`.
-Default remote is `origin`.
+Checks out a merge request from GitLab, or a pull request from Forgejo/Codeberg.
+Usage: `git mr <ID|URL> [REMOTE]`. Default remote is `origin`.
 
 ``` bash
 $ git mr 51
@@ -1444,6 +1444,15 @@ With full URL, the head is fetched from a temporary remote pointing to the base 
 $ git mr https://gitlab.com/owner/repository/merge_requests/51
 From gitlab.com:owner/repository
  * [new ref]         refs/merge-requests/51/head -> mr/51
+Switched to branch 'mr/51'
+```
+
+A Forgejo/Codeberg pull request URL is also supported:
+
+``` bash
+$ git mr https://codeberg.org/owner/repository/pulls/51
+From codeberg.org:owner/repository
+ * [new ref]         refs/pull/51/head -> mr/51
 Switched to branch 'mr/51'
 ```
 

--- a/bin/git-mr
+++ b/bin/git-mr
@@ -7,6 +7,8 @@ if [  -z "${1-}" ] ; then
     exit 1
 fi
 
+remote_ref_kind=merge-requests
+
 if test "$1" = "clean"; then
   git for-each-ref refs/heads/mr/* --format='%(refname)' | while read -r ref; do
     git branch -D "${ref#refs/heads/}"
@@ -15,13 +17,19 @@ if test "$1" = "clean"; then
 elif [[ $1 =~ ^(https?://[^/]+/(.+))/merge_requests/([0-9]+).*$ ]]; then
   remote=${BASH_REMATCH[1]}.git
   id=${BASH_REMATCH[3]}
+elif [[ $1 =~ ^(https?://[^/]+/(.+))/pulls/([0-9]+).*$ ]]; then
+  # Forgejo/Codeberg pull request URL, e.g.
+  # https://codeberg.org/owner/repository/pulls/453
+  remote=${BASH_REMATCH[1]}.git
+  id=${BASH_REMATCH[3]}
+  remote_ref_kind=pull
 else
   id=$1
   remote=${2:-origin}
 fi
 
 branch=mr/$id
-remote_ref=refs/merge-requests/$id/head
+remote_ref=refs/$remote_ref_kind/$id/head
 git fetch -fu "$remote" "$remote_ref:$branch"
 git checkout "$branch"
 git config --local --replace "branch.$branch.merge" "$remote_ref"

--- a/man/git-mr.1
+++ b/man/git-mr.1
@@ -28,7 +28,7 @@ The name of the remote to fetch from\. Defaults to \fBorigin\fR\.
 <url>
 .
 .P
-GitLab merge request URL in the format \fBhttps://gitlab\.tld/owner/repository/merge_requests/453\fR\.
+GitLab merge request URL in the format \fBhttps://gitlab\.tld/owner/repository/merge_requests/453\fR, or a Forgejo/Codeberg pull request URL in the format \fBhttps://codeberg\.tld/owner/repository/pulls/453\fR\.
 .
 .SH "EXAMPLES"
 This checks out merge request \fB!51\fR from remote \fBorigin\fR to branch \fBmr/51\fR\.
@@ -40,6 +40,22 @@ This checks out merge request \fB!51\fR from remote \fBorigin\fR to branch \fBmr
 $ git mr 51
 From gitlab\.com:owner/repository
  * [new ref]         refs/merge\-requests/51/head \-> mr/51
+Switched to branch \'mr/51\'
+.
+.fi
+.
+.IP "" 0
+.
+.P
+This checks out pull request \fB#51\fR from a Forgejo/Codeberg URL to branch \fBmr/51\fR\.
+.
+.IP "" 4
+.
+.nf
+
+$ git mr https://codeberg\.org/owner/repository/pulls/51
+From codeberg\.org:owner/repository
+ * [new ref]         refs/pull/51/head \-> mr/51
 Switched to branch \'mr/51\'
 .
 .fi

--- a/man/git-mr.html
+++ b/man/git-mr.html
@@ -94,7 +94,9 @@
 <p>  &lt;url&gt;</p>
 
 <p>  GitLab merge request URL in the format
-  <code>https://gitlab.tld/owner/repository/merge_requests/453</code>.</p>
+  <code>https://gitlab.tld/owner/repository/merge_requests/453</code>, or a
+  Forgejo/Codeberg pull request URL in the format
+  <code>https://codeberg.tld/owner/repository/pulls/453</code>.</p>
 
 <h2 id="EXAMPLES">EXAMPLES</h2>
 
@@ -103,6 +105,14 @@
 <pre><code>$ git mr 51
 From gitlab.com:owner/repository
  * [new ref]         refs/merge-requests/51/head -&gt; mr/51
+Switched to branch 'mr/51'
+</code></pre>
+
+<p>This checks out pull request <code>#51</code> from a Forgejo/Codeberg URL to branch <code>mr/51</code>.</p>
+
+<pre><code>$ git mr https://codeberg.org/owner/repository/pulls/51
+From codeberg.org:owner/repository
+ * [new ref]         refs/pull/51/head -&gt; mr/51
 Switched to branch 'mr/51'
 </code></pre>
 

--- a/man/git-mr.md
+++ b/man/git-mr.md
@@ -21,7 +21,9 @@ git-mr(1) -- Checks out a merge request locally
   &lt;url&gt;
 
   GitLab merge request URL in the format
-  `https://gitlab.tld/owner/repository/merge_requests/453`.
+  `https://gitlab.tld/owner/repository/merge_requests/453`, or a
+  Forgejo/Codeberg pull request URL in the format
+  `https://codeberg.tld/owner/repository/pulls/453`.
 
 
 ## EXAMPLES
@@ -31,6 +33,13 @@ This checks out merge request `!51` from remote `origin` to branch `mr/51`.
     $ git mr 51
     From gitlab.com:owner/repository
      * [new ref]         refs/merge-requests/51/head -> mr/51
+    Switched to branch 'mr/51'
+
+This checks out pull request `#51` from a Forgejo/Codeberg URL to branch `mr/51`.
+
+    $ git mr https://codeberg.org/owner/repository/pulls/51
+    From codeberg.org:owner/repository
+     * [new ref]         refs/pull/51/head -> mr/51
     Switched to branch 'mr/51'
 
 ## AUTHOR

--- a/tests/git-mr.bats
+++ b/tests/git-mr.bats
@@ -46,3 +46,23 @@ setup() {
 	run git rev-parse --abbrev-ref HEAD
 	assert_output 'mr/51'
 }
+
+@test "checks out a Forgejo/Codeberg pull request by URL" {
+	# git-mr only recognizes http(s) URLs, so rewrite the fake Codeberg URL
+	# to our local bare "remote" via insteadOf rather than needing a real
+	# HTTP(S) endpoint.
+	git config --local url."$remote_dir".insteadOf "https://codeberg.org/owner/repository.git"
+
+	run git mr "https://codeberg.org/owner/repository/pulls/51"
+	assert_success
+	assert_output --partial "refs/pull/51/head"
+
+	run git rev-parse --abbrev-ref HEAD
+	assert_output 'mr/51'
+
+	run git config --get branch.mr/51.merge
+	assert_output 'refs/pull/51/head'
+
+	run git config --get branch.mr/51.remote
+	assert_output 'https://codeberg.org/owner/repository.git'
+}

--- a/tests/git-mr.bats
+++ b/tests/git-mr.bats
@@ -1,0 +1,48 @@
+# shellcheck shell=bash
+
+source "$BATS_TEST_DIRNAME/test_util.sh"
+
+setup_file() {
+	test_util.setup_file
+
+	PATH="$BATS_TEST_DIRNAME/bin:$PATH"
+}
+
+setup() {
+	test_util.cd_test
+
+	test_util.git_init
+	touch ./tracked
+	git add ./tracked
+	git commit -m 'Initial commit'
+
+	# Local bare "remote" standing in for a real GitLab/Forgejo instance,
+	# with a merge-requests ref and a pull ref pointing at the same commit.
+	remote_dir="$BATS_TEST_TMPDIR/remote.git"
+	git init --bare --initial-branch main "$remote_dir"
+	git push "$remote_dir" HEAD:refs/merge-requests/51/head
+	git push "$remote_dir" HEAD:refs/pull/51/head
+
+	git remote add origin "$remote_dir"
+}
+
+@test "checks out a merge request by numeric id" {
+	run git mr 51
+	assert_success
+	assert_output --partial "refs/merge-requests/51/head"
+
+	run git rev-parse --abbrev-ref HEAD
+	assert_output 'mr/51'
+
+	run git config --get branch.mr/51.merge
+	assert_output 'refs/merge-requests/51/head'
+}
+
+@test "checks out a merge request by numeric id and explicit remote" {
+	run git mr 51 "$remote_dir"
+	assert_success
+	assert_output --partial "refs/merge-requests/51/head"
+
+	run git rev-parse --abbrev-ref HEAD
+	assert_output 'mr/51'
+}


### PR DESCRIPTION
## Summary

`git mr` only knew how to fetch GitLab-style merge requests
(`refs/merge-requests/<id>/head`). Forgejo instances such as
Codeberg publish pull requests under `refs/pull/<id>/head` instead,
so passing a Codeberg pull request URL (e.g.
`https://codeberg.org/owner/repository/pulls/453`) to `git mr` tried
to fetch the wrong ref and failed.

This adds a second URL pattern for the `/pulls/<id>` shape used by
Forgejo/Codeberg and switches the fetched ref accordingly, while
leaving the existing GitLab URL and bare numeric id behavior
unchanged.

## Changes

- `bin/git-mr`: recognize `.../pulls/<id>` URLs and fetch
  `refs/pull/<id>/head` for them instead of
  `refs/merge-requests/<id>/head`.
- `man/git-mr.md` and `Commands.md`: document the new URL format.
- `tests/git-mr.bats`: new test covering the existing numeric-id
  flow to guard against regressions.

## Test plan

- `bats tests/git-mr.bats` passes locally.
- `./scripts/checkstyle.py bin/git-mr tests/git-mr.bats` reports no
  issues.
- Manually verified the `refs/pull/<id>/head` fetch path against a
  local bare repo.

Closes #1213