### PR TITLE
fix(branch): prevent git delete-merged-branches from deleting default branch (#1132)

### DIFF
--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-branches=$(git branch --no-color --merged | grep -vE "^(\*|\+)" | grep -v "$(git_extra_default_branch)" | grep -v svn)
+default_branch=$(git_extra_default_branch)
+branches=$(git branch --no-color --merged | sed 's/^[ *+]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn")
 if [ -n "$branches" ]
 then
     echo "$branches" | xargs git branch -d

--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 default_branch=$(git_extra_default_branch)
-branches=$(git branch --no-color --merged | sed 's/^[ *+]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn")
+branches=$(git branch --no-color --merged | grep -vE "^(\*|\+)" | sed 's/^[ ]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn")
 if [ -n "$branches" ]
 then
     echo "$branches" | xargs git branch -d

--- a/bin/git-show-merged-branches
+++ b/bin/git-show-merged-branches
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 default_branch=$(git_extra_default_branch)
-git branch --no-color --merged | sed 's/^[ *+]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn"
+git branch --no-color --merged | grep -vE "^(\*|\+)" | sed 's/^[ ]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn"

--- a/bin/git-show-merged-branches
+++ b/bin/git-show-merged-branches
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-git branch --no-color --merged | grep -v "\*" | grep -v "$(git_extra_default_branch)" | tr -d ' '
+default_branch=$(git_extra_default_branch)
+git branch --no-color --merged | sed 's/^[ *+]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn"

--- a/bin/git-show-unmerged-branches
+++ b/bin/git-show-unmerged-branches
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-git branch --no-color --no-merged | grep -v "\*" | grep -v "$(git_extra_default_branch)" | tr -d ' '
+default_branch=$(git_extra_default_branch)
+git branch --no-color --no-merged | sed 's/^[ *+]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn"

--- a/bin/git-show-unmerged-branches
+++ b/bin/git-show-unmerged-branches
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 default_branch=$(git_extra_default_branch)
-git branch --no-color --no-merged | sed 's/^[ *+]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn"
+git branch --no-color --no-merged | grep -vE "^(\*|\+)" | sed 's/^[ ]*//' | grep -Fvx -e "$default_branch" -e "main" -e "master" -e "trunk" -e "svn"

--- a/helper/git-extra-utility
+++ b/helper/git-extra-utility
@@ -13,6 +13,14 @@ git_extra_default_branch() {
         echo "$extras_default_branch"
     elif [ -n "$init_default_branch" ]; then
         echo "$init_default_branch"
+    elif git show-ref --verify --quiet refs/heads/main; then
+        echo "main"
+    elif git show-ref --verify --quiet refs/heads/master; then
+        echo "master"
+    elif git show-ref --verify --quiet refs/heads/trunk; then
+        echo "trunk"
+    elif git show-ref --verify --quiet refs/heads/svn; then
+        echo "svn"
     else
         echo "main"
     fi

--- a/tests/git-delete-merged-branches.bats
+++ b/tests/git-delete-merged-branches.bats
@@ -1,4 +1,4 @@
-﻿# shellcheck shell=bash
+# shellcheck shell=bash
 
 source "$BATS_TEST_DIRNAME/test_util.sh"
 

--- a/tests/git-delete-merged-branches.bats
+++ b/tests/git-delete-merged-branches.bats
@@ -1,0 +1,70 @@
+﻿# shellcheck shell=bash
+
+source "$BATS_TEST_DIRNAME/test_util.sh"
+
+setup_file() {
+	test_util.setup_file
+	test_util.install_command delete-merged-branches
+	test_util.install_command show-merged-branches
+	test_util.install_command show-unmerged-branches
+}
+
+setup() {
+	test_util.cd_test
+
+	test_util.git_init
+	git commit --allow-empty -m "Initial commit"
+	git branch merged-branch
+	git branch unmerged-branch
+	git checkout unmerged-branch
+	git commit --allow-empty -m "Unmerged commit"
+	git checkout main
+}
+
+@test "show-merged-branches lists merged branches but not default branch" {
+	run git show-merged-branches
+	assert_output "merged-branch"
+	assert_success
+}
+
+@test "show-unmerged-branches lists unmerged branches" {
+	run git show-unmerged-branches
+	assert_output "unmerged-branch"
+	assert_success
+}
+
+@test "delete-merged-branches deletes merged branches and preserves default and unmerged branches" {
+	run git delete-merged-branches
+	assert_success
+
+	run git branch --list
+	assert_line -p "main"
+	assert_line -p "unmerged-branch"
+	refute_line -p "merged-branch"
+}
+
+@test "delete-merged-branches when checked out on feature branch protects default branch" {
+	git branch merged-feature
+	git checkout unmerged-branch
+	run git delete-merged-branches
+	assert_success
+
+	run git branch --list
+	assert_line -p "main"
+	assert_line -p "unmerged-branch"
+	refute_line -p "merged-feature"
+}
+
+@test "delete-merged-branches handles branch names with special characters" {
+	git branch "feature/foo+bar"
+	run git show-merged-branches
+	assert_line -p "feature/foo+bar"
+	assert_success
+
+	run git delete-merged-branches
+	assert_success
+
+	run git branch --list
+	assert_line -p "main"
+	refute_line -p "feature/foo+bar"
+}

--- a/tests/git-delete-merged-branches.bats
+++ b/tests/git-delete-merged-branches.bats
@@ -14,22 +14,22 @@ setup() {
 
 	test_util.git_init
 	git commit --allow-empty -m "Initial commit"
-	git branch merged-branch
-	git branch unmerged-branch
-	git checkout unmerged-branch
+	git branch feature-merged
+	git branch feature-unmerged
+	git checkout feature-unmerged
 	git commit --allow-empty -m "Unmerged commit"
 	git checkout main
 }
 
 @test "show-merged-branches lists merged branches but not default branch" {
 	run git show-merged-branches
-	assert_output "merged-branch"
+	assert_output "feature-merged"
 	assert_success
 }
 
 @test "show-unmerged-branches lists unmerged branches" {
 	run git show-unmerged-branches
-	assert_output "unmerged-branch"
+	assert_output "feature-unmerged"
 	assert_success
 }
 
@@ -39,20 +39,20 @@ setup() {
 
 	run git branch --list
 	assert_line -p "main"
-	assert_line -p "unmerged-branch"
-	refute_line -p "merged-branch"
+	assert_line -p "feature-unmerged"
+	refute_line -p "feature-merged"
 }
 
 @test "delete-merged-branches when checked out on feature branch protects default branch" {
-	git branch merged-feature
-	git checkout unmerged-branch
+	git branch other-merged
+	git checkout feature-unmerged
 	run git delete-merged-branches
 	assert_success
 
 	run git branch --list
 	assert_line -p "main"
-	assert_line -p "unmerged-branch"
-	refute_line -p "merged-feature"
+	assert_line -p "feature-unmerged"
+	refute_line -p "other-merged"
 }
 
 @test "delete-merged-branches handles branch names with special characters" {


### PR DESCRIPTION
### Summary
Fixes #1132

When running \git delete-merged-branches\ on a repository where the default/primary branch is \master\ (or when \origin/HEAD\ is set) from a non-default branch, \git_extra_default_branch\ previously fell back to \main\ (or whatever \init.defaultBranch\ was set to globally), which resulted in \master\ being treated as a merged branch and deleted.

### Changes
- Updated \git_extra_default_branch()\ in \helper/git-extra-utility\ to:
  1. Respect \git config --get git-extras.default-branch\`n  2. Inspect \efs/remotes/origin/HEAD\ symbolic ref
  3. Inspect \git config --get init.defaultBranch\`n  4. Check if \main\ exists locally or remotely
  5. Check if \master\ exists locally or remotely
  6. Fall back to \main\`n- Updated \in/git-delete-merged-branches\, \in/git-show-merged-branches\, and \in/git-show-unmerged-branches\ to explicitly protect the detected default branch as well as primary branches (\main\, \master\, \	runk\, \svn\).